### PR TITLE
Lib archive

### DIFF
--- a/software/mk/Makefile.builddefs
+++ b/software/mk/Makefile.builddefs
@@ -19,11 +19,13 @@ endif
 RISCV_GCC     ?= $(RISCV_BIN_DIR)/riscv32-unknown-elf-gcc
 RISCV_ELF2HEX ?= LD_LIBRARY_PATH=$(RISCV_BIN_DIR)/../lib $(RISCV_BIN_DIR)/elf2hex
 RISCV_OBJCOPY ?= $(RISCV_BIN_DIR)/riscv32-unknown-elf-objcopy
+RISCV_AR      ?= $(RISCV_BIN_DIR)/riscv32-unknown-elf-ar
 
 BSG_ROM_GEN = $(BSG_IP_CORES_DIR)/bsg_mem/bsg_ascii_to_rom.py
 HEX2BIN     = $(BSG_MANYCORE_DIR)/software/py/hex2binascii.py
 
 VPATH += $(BSG_MANYCORE_DIR)/software/bsg_manycore_lib
+VPATH += $(BSG_MANYCORE_DIR)/software/spmd/common
 
 # flags
 OPT_LEVEL ?= -O2
@@ -80,10 +82,19 @@ else
 	$(RISCV_GCC) $(RISCV_GCC_OPTS) $(OPT_LEVEL) $(spmd_defs) -c $(INCS) $< -o $@ |& tee $*.comp.log
 endif
 
-
 %.o: %.S
 	$(RISCV_GCC) $(RISCV_GCC_OPTS) $(OPT_LEVEL) $(spmd_defs) -D__ASSEMBLY__=1 \
 		-c $(INCS) $< -o $@
+
+
+# Manycore C library archiving rule
+BSG_MANYCORE_LIB_OBJS+= bsg_set_tile_x_y.o
+BSG_MANYCORE_LIB_OBJS+= bsg_printf.o
+BSG_MANYCORE_LIB      = bsg_manycore_lib.a
+
+$(BSG_MANYCORE_LIB): $(BSG_MANYCORE_LIB_OBJS)
+	$(RISCV_AR) rcs $@ $^
+
 
 # <bytes per row> <rows>
 %.hex: %.riscv

--- a/software/mk/Makefile.tail_rules
+++ b/software/mk/Makefile.tail_rules
@@ -15,7 +15,7 @@ cov_report:
 	cat coverage/modlist.txt
 
 clean:
-	-rm -rf *.o *.jou *.log *.pelog *.pb bsg_manycore_io_complex_rom.v *.riscv *.wdb *.bin *.hex
+	-rm -rf *.o *.a *.jou *.log *.pelog *.pb bsg_manycore_io_complex_rom.v *.riscv *.wdb *.bin *.hex
 	-rm -rf xsim.dir *.mem
 	-rm -rf ./simv csrc simv.daidir ucli.key DVEfiles *.vpd *.vdb coverage* constfile.txt
 	-rm -rf build/ *.bc*

--- a/software/spmd/Makefile
+++ b/software/spmd/Makefile
@@ -1,3 +1,5 @@
+.DEFAULT_GOAL := all
+
 include ./Makefile.regress.list
 include ./Makefile.include
 

--- a/software/spmd/Makefile.include
+++ b/software/spmd/Makefile.include
@@ -1,3 +1,5 @@
+.DEFAULT_GOAL = all
+
 find-dir-with = $(shell /usr/bin/perl -e 'chomp($$_ = `pwd`); while ($$_ ne "" && ! -e "$$_/$(1)") { m:(.*)/[^/]+/??:; $$_ = $$1; } print;')
 
 ifndef BSG_MANYCORE_DIR

--- a/software/spmd/bsg_remote_congestion/Makefile
+++ b/software/spmd/bsg_remote_congestion/Makefile
@@ -1,3 +1,4 @@
+.DEFAULT_GOAL = all
 
 override bsg_tiles_X = 4 
 override bsg_tiles_Y = 8 
@@ -5,13 +6,13 @@ MASTER_X   ?= 2
 MASTER_Y   ?= 2
 
 RISCV_GCC_EXTRA_OPTS ?= -O2 -funroll-loops -DMASTER_X=$(MASTER_X) -DMASTER_Y=$(MASTER_Y)
-OBJECT_FILES=main.o bsg_set_tile_x_y.o
+OBJECT_FILES=main.o
 include ../Makefile.include
 
 all: main.run
 
-main.riscv:  $(OBJECT_FILES) $(SPMD_COMMON_OBJECTS) ../common/crt.o
-	$(RISCV_LINK) $(OBJECT_FILES) -o $@ $(RISCV_LINK_OPTS)
+main.riscv:  $(OBJECT_FILES) $(SPMD_COMMON_OBJECTS) $(BSG_MANYCORE_LIB) crt.o
+	$(RISCV_LINK) $(OBJECT_FILES) -L. -l:$(BSG_MANYCORE_LIB) -o $@ $(RISCV_LINK_OPTS)
 
 
 main.o: Makefile

--- a/software/spmd/hello/Makefile
+++ b/software/spmd/hello/Makefile
@@ -31,7 +31,7 @@ all: main.run
 # for a quick debug of processor or program running on it.
 proc_exe_logs: X0_Y0.pelog X1_Y0.pelog
 
-OBJECT_FILES=main.o bsg_set_tile_x_y.o bsg_printf.o
+OBJECT_FILES=main.o
 
 include ../Makefile.include
 
@@ -41,8 +41,8 @@ include ../Makefile.include
 #     be vanilla core 
 BSG_FPU_OP=0
 
-main.riscv: $(OBJECT_FILES) $(SPMD_COMMON_OBJECTS) ../common/crt.o
-	$(RISCV_LINK) $(OBJECT_FILES) $(SPMD_COMMON_OBJECTS) -o $@ $(RISCV_LINK_OPTS)
+main.riscv: $(OBJECT_FILES) $(SPMD_COMMON_OBJECTS) $(BSG_MANYCORE_LIB) crt.o
+	$(RISCV_LINK) $(OBJECT_FILES) $(SPMD_COMMON_OBJECTS) -L. -l:$(BSG_MANYCORE_LIB) -o $@ $(RISCV_LINK_OPTS)
 
 
 main.o: Makefile


### PR DESCRIPTION
Makefile rule to archive bsg_manycore_lib for static linking.

One complication: the `.a` target added in `Makefile.buidldefs` was begin considered as the default target, instead of `all` in the Makefile including it. Hence, I figured it's a good practice to add `.DEFAULT_GOAL = <default target>` as the first line of any Makefile including other Makefiles. But since existing Makefiles didn't do that, I added `.DEFAULT_GOAL = all` in `Makefile.include`. And, regression passed without any issues.