### PR TITLE
Regfile x0

### DIFF
--- a/software/spmd/.gitignore
+++ b/software/spmd/.gitignore
@@ -1,2 +1,5 @@
 main_dmem.mem
 main_dram.mem
+*.a
+coremark-top
+coremark/coremark

--- a/software/spmd/Makefile.regress.list
+++ b/software/spmd/Makefile.regress.list
@@ -74,5 +74,6 @@ test_case_list+=bsg_mutex
 test_case_list+=bsg_barrier
 test_case_list+=bsg_transpose
 test_case_list+=regfile_x0_test
+test_case_list+=fib
 test_case_list+=striped_hello
 test_case_list+=coremark

--- a/software/spmd/Makefile.regress.list
+++ b/software/spmd/Makefile.regress.list
@@ -73,5 +73,6 @@ test_case_list+=bsg_tile_group_barrier
 test_case_list+=bsg_mutex
 test_case_list+=bsg_barrier
 test_case_list+=bsg_transpose
+test_case_list+=regfile_x0_test
 test_case_list+=striped_hello
 test_case_list+=coremark

--- a/software/spmd/coremark/Makefile
+++ b/software/spmd/coremark/Makefile
@@ -7,8 +7,8 @@ MANYCORE_PORT_SRC=$(BSG_MANYCORE_DIR)/software/spmd/coremark/
 MANYCORE_PORT_DST=$(COREMARK_TOP)/manycore
 
 all:
-	ln -s $(COREMARK_SRC) $(COREMARK_TOP)
-	ln -s $(MANYCORE_PORT_SRC) $(MANYCORE_PORT_DST)
+	ln -sf $(COREMARK_SRC) $(COREMARK_TOP)
+	ln -sf $(MANYCORE_PORT_SRC) $(MANYCORE_PORT_DST)
 	make coremark.run PORT_DIR=manycore ITERATIONS=1 -C $(COREMARK_TOP)
 clean:
 	make clean PORT_DIR=manycore -C $(COREMARK_TOP)

--- a/software/spmd/fib/Makefile
+++ b/software/spmd/fib/Makefile
@@ -1,0 +1,50 @@
+#########################################################
+# Network Configutaion
+# If not configured, Will use default Values
+#	bsg_global_X ?= $(bsg_tiles_X)
+#	bsg_global_Y ?= $(bsg_tiles_Y)+1
+bsg_global_X = 4
+bsg_global_Y = 4
+
+#########################################################
+#Tile group configuration
+# If not configured, Will use default Values
+#	bsg_tiles_org_X ?= 0
+#	bsg_tiles_org_Y ?= 1
+bsg_tiles_org_X =1
+bsg_tiles_org_Y =1
+
+# If not configured, Will use default Values
+#	bsg_tiles_X ?= 2
+#	bsg_tiles_Y ?= 2
+bsg_tiles_X = 2
+bsg_tiles_Y = 2
+
+
+all: main.run
+
+# Rule to write processor execution logs. To be used after the
+# verilog simulation.
+#
+# Redirects verilog standard output starting with "X<x_cord>_Y<y_cord>.pelog" 
+# to a unique log file for each coordinate in the manycore. This can be useful 
+# for a quick debug of processor or program running on it.
+proc_exe_logs: X0_Y0.pelog X1_Y0.pelog
+
+OBJECT_FILES=main.o
+
+include ../Makefile.include
+
+#########################################################
+#            FPU OPTION
+#     The number of horizon node must be two and must 
+#     be vanilla core 
+BSG_FPU_OP=0
+
+main.riscv: $(OBJECT_FILES) $(SPMD_COMMON_OBJECTS) $(BSG_MANYCORE_LIB) crt.o
+	$(RISCV_LINK) $(OBJECT_FILES) $(SPMD_COMMON_OBJECTS) -L. -l:$(BSG_MANYCORE_LIB) -o $@ $(RISCV_LINK_OPTS)
+
+
+main.o: Makefile
+
+include ../../mk/Makefile.tail_rules

--- a/software/spmd/fib/main.c
+++ b/software/spmd/fib/main.c
@@ -1,0 +1,60 @@
+/**
+ *  main.c
+ *  
+ *  fib 
+ *
+ *  calculates the sum of first N fibonacci sequence recursively.
+ *
+ *  fib[0] = 0
+ *  fib[1] = 1
+ *  fib[n] = fib[n-1] + fib[n-2]
+ *
+ */
+
+#include "bsg_manycore.h"
+#include "bsg_set_tile_x_y.h"
+
+#define N 15
+#define ANSWER 986
+
+int my_fib[N];
+
+int fib(int n)
+{
+  if (n == 0)
+  {
+    return 0;
+  }
+  else if (n == 1)
+  {
+    return 1;
+  }
+  else
+  {
+    return fib(n-1) + fib(n-2);
+  }
+}
+
+int main()
+{
+
+  bsg_set_tile_x_y();
+  int sum;
+  sum = 0;
+
+  if ((__bsg_x == 0) && (__bsg_y == 0)) {
+
+    for (int i = 0; i < N; i++)
+    {
+      my_fib[i] = fib(i);
+      bsg_printf("fib[%d] = %d\r\n", i, my_fib[i]);
+      sum += my_fib[i];
+    }
+
+    bsg_finish();
+  }
+
+  bsg_wait_while(1);
+
+}
+

--- a/software/spmd/regfile_x0_test/Makefile
+++ b/software/spmd/regfile_x0_test/Makefile
@@ -1,0 +1,29 @@
+bsg_tiles_X= 4
+bsg_tiles_Y= 4 
+
+all: main.run
+
+# Rule to write processor execution logs. To be used after the
+# verilog simulation.
+#
+# Redirects verilog standard output starting with "X<x_cord>_Y<y_cord>.pelog" 
+# to a unique log file for each coordinate in the manycore. This can be useful 
+# for a quick debug of processor or program running on it.
+proc_exe_logs: X0_Y0.pelog X1_Y0.pelog X0_Y1.pelog X1_Y1.pelog
+
+include ../Makefile.include
+
+RISCV_LINK_OPTS =  -march=rv32ima -nostdlib -nostartfiles 
+
+main.riscv:  main.o 
+	$(RISCV_GCC) -T $(BSG_MANYCORE_DIR)/software/spmd/common/asm.ld  $< -o $@ $(RISCV_LINK_OPTS)
+
+
+clean:
+	-rm -rf *.o *.jou *.log *.pb bsg_manycore_io_complex_rom.v *.riscv *.wdb *.bin *.hex *.vec
+	-rm -rf xsim.dir *.mem
+	-rm -rf ./simv csrc simv.daidir ucli.key DVEfiles *.vpd
+
+
+include ../../mk/Makefile.tail_rules
+

--- a/software/spmd/regfile_x0_test/main.S
+++ b/software/spmd/regfile_x0_test/main.S
@@ -1,0 +1,156 @@
+#include "bsg_manycore_arch.h"
+#include "bsg_manycore_asm.h"
+
+.text
+
+start:
+  addi t1, x0, 1
+  addi t2, x0, 1
+  add t3, x0, x0
+  add t3, t3, t1
+  add t3, t3, t2
+  add t3, t3, t1
+  add t3, t3, t2
+  add t3, t3, t1
+  add t3, t3, t2
+  add t3, t3, t1
+  add t3, t3, t2
+  add x0, t3, t3
+  add x0, t3, t3
+  add t3, t3, t1
+  add x0, t3, t3
+  add x0, t3, t3
+  add t3, t3, t2
+  add x0, t3, t3
+  add x0, t3, t3
+  add t3, t3, t1
+  add t3, t3, t2
+  add x0, t3, t3
+  add x0, t3, t3
+  add t3, t3, t2
+  add t3, t3, t2
+  add x0, t3, t3
+  add x0, t3, t3
+  add x0, t3, t3
+  add x0, t3, t3
+  add t3, t3, t2
+  add x0, t3, t3
+  add x0, t3, t3
+  add x0, t3, t3
+  add x0, t3, t3
+  add x0, t3, t3
+  add x0, t3, t3
+  add t3, t3, t2
+  add x0, t3, t3
+  add x0, t3, t3
+
+  add t3, t3, t2
+  add x0, t3, t3
+
+  add t3, t3, t2
+  add x0, t3, t3
+  add x0, t3, t3
+
+  add t3, t3, t2
+  add x0, t3, t3
+  add x0, t3, t3
+  add x0, t3, t3
+
+  add t3, t3, t2
+  add x0, t3, t3
+  add x0, t3, t3
+  add x0, t3, t3
+  add x0, t3, t3
+
+  add t3, t3, t2
+  add x0, t3, t3
+  add x0, t3, t3
+  add x0, t3, t3
+  add x0, t3, t3
+  add x0, t3, t3
+
+  add t3, t3, t2
+  add t3, t3, t2
+  add x0, t3, t3
+
+  add t3, t3, t2
+  add t3, t3, t2
+  add x0, t3, t3
+  add x0, t3, t3
+
+  add t3, t3, x0
+  add x0, t3, t3
+  add t3, t3, x0
+  add t3, x0, t3
+  add t3, t3, x0
+  add x0, t3, t3
+  add t3, x0, t3
+  add t3, t3, x0
+  add t3, x0, t3
+  add x0, t3, t3
+  add t3, t3, x0
+  add t3, t3, x0
+  add t3, x0, t3
+  add x0, t3, t3
+  add t3, t3, x0
+  add t3, x0, t3
+  add t3, x0, t3
+  add t3, t3, x0
+  add x0, t3, t3
+  add x0, t3, t3
+  add t3, t3, x0
+  add t3, x0, t3
+  add t3, t3, x0
+  add t3, x0, t3
+  add t3, x0, t3
+  add t3, t3, x0
+  add x0, t3, t3
+  add t3, x0, t3
+  add t3, x0, t3
+  add t3, t3, x0
+  add x0, t3, t3
+  add t3, x0, t3
+  add t3, x0, t3
+  add t3, t3, x0
+  add x0, t3, t3
+  add t3, x0, t3
+  add t3, x0, t3
+  add t3, t3, x0
+  add x0, t3, t3
+  add x0, t3, t3
+  add t3, t3, x0
+  add t3, x0, t3
+  add t3, x0, t3
+  add t3, x0, t3
+ 
+  add t3, t3, t1 
+  add t3, x0, t3
+  add t3, x0, t3
+  add t3, t3, x0
+  add x0, t3, t3
+  add t3, x0, t3
+  add t3, x0, t3
+  add t3, t3, x0
+  add x0, t3, t3
+  add x0, t3, t3
+  add t3, t3, x0
+  add t3, t3, t1 
+  add t3, x0, t3
+  add t3, x0, t3
+  add t3, t3, x0
+  add x0, t3, t3
+  add x0, t3, t3
+  add t3, t3, x0
+  add t3, t3, t1 
+  add t3, x0, t3
+  add t3, x0, t3
+  add t3, t3, x0
+
+  addi t4, x0, 28
+  bne t3, t4, fail
+
+pass:
+  bsg_asm_finish(IO_X_INDEX, 0)
+
+fail:
+  bsg_asm_fail(IO_X_INDEX, -1)

--- a/v/vanilla_bean/definitions.vh
+++ b/v/vanilla_bean/definitions.vh
@@ -147,7 +147,7 @@ typedef struct packed
     logic is_branch_op;     // Op is a branch operation
     logic is_jump_op;       // Op is a jump operation
     logic op_reads_rf1;     // OP reads from first port of register file
-    logic op_reads_rf2;     // OP reads from first port of register file
+    logic op_reads_rf2;     // OP reads from second port of register file
     logic op_is_auipc;
 
     //for M extension;

--- a/v/vanilla_bean/hobbit.v
+++ b/v/vanilla_bean/hobbit.v
@@ -1,60 +1,63 @@
+/**
+ *  Vanilla-Bean Core
+ *
+ *  5 stage pipeline implementation of the vanilla core ISA.
+ */
+
 `include "parameters.vh"
 `include "definitions.vh"
 
 `ifdef bsg_FPU
 `include "float_definitions.vh"
 `endif
-//`include "bsg_defines.v"
 
-/**
- *  Vanilla-Bean Core
- *
- *  5 stage pipeline implementation of the vanilla core ISA.
- */
-module hobbit #(parameter 
-                          icache_tag_width_p         = -1, 
-                          icache_addr_width_p        = -1,
-                          gw_ID_p                    = -1,
-                          ring_ID_p                  = -1,
-                          x_cord_width_p             = -1,
-                          y_cord_width_p             = -1,
-                          debug_p                    = 0 ,
-                          pc_width_lp                = icache_tag_width_p + icache_addr_width_p, 
-                          icache_format_width_lp     = `icache_format_width( icache_tag_width_p ),
-                          //As all instructions will be resident in DRAM, we
-                          //need to pad the higher parts of the pc so it
-                          //points to DRAM.
-                          pc_high_padding_width_lp   = RV32_reg_data_width_gp - pc_width_lp -2 ,
-                          pc_high_padding_lp         = {pc_high_padding_width_lp{1'b0}} ,
-                          //used to direct the icache miss address to dram.
-                          dram_addr_mapping_lp       = 32'h8000_0000,
+module hobbit
+  #(parameter icache_tag_width_p = "inv" 
+    , parameter icache_addr_width_p = "inv"
+    , parameter gw_ID_p = "inv"
+    , parameter ring_ID_p = "inv"
+    , parameter x_cord_width_p = "inv"
+    , parameter y_cord_width_p = "inv"
 
-                          remote_addr_prefix_mask_lp = 32'hc000_0000,
-                          remote_addr_mapping_lp     = 32'h4000_0000
-               )(
-                input                             clk_i
-               ,input                             reset_i
+    , parameter debug_p = 0
+    , parameter trace_p = 0
 
-`ifdef bsg_FPU
-               ,fpi_alu_inter.alu_side            fpi_inter
-`endif
-               ,input  ring_packet_s              net_packet_i
+    , localparam pc_width_lp = (icache_tag_width_p + icache_addr_width_p)
+    , localparam icache_format_width_lp = `icache_format_width(icache_tag_width_p)
 
-               ,input  mem_out_s                  from_mem_i
-               ,output mem_in_s                   to_mem_o
-               ,input  logic                      reservation_i
-               ,output logic                      reserve_1_o
+    // As all instructions will be resident in DRAM, we
+    // need to pad the higher parts of the pc so it
+    // points to DRAM.
+    , localparam pc_high_padding_width_lp = (RV32_reg_data_width_gp-pc_width_lp-2)
+    , localparam pc_high_padding_lp = {pc_high_padding_width_lp{1'b0}}
+  
+    // used to direct the icache miss address to dram.
+    , localparam dram_addr_mapping_lp = 32'h8000_0000
 
-               ,input  [x_cord_width_p-1:0]       my_x_i
-               ,input  [y_cord_width_p-1:0]       my_y_i
+    , localparam remote_addr_prefix_mask_lp = 32'hc000_0000
+    , localparam remote_addr_mapping_lp = 32'h4000_0000
+  )
+  (
+    input clk_i
+    , input reset_i
 
-               ,input                             outstanding_stores_i
-               );
+    `ifdef bsg_FPU
+    , fpi_alu_inter.alu_side fpi_inter
+    `endif
 
+    , input ring_packet_s net_packet_i
 
-//localparam trace_lp = 1'b1;
-localparam trace_lp = 1'b0;
-localparam debug_lp = 1'b0;
+    , input mem_out_s from_mem_i
+    , output mem_in_s to_mem_o
+
+    , input logic reservation_i
+    , output logic reserve_1_o
+
+    , input [x_cord_width_p-1:0] my_x_i
+    , input [y_cord_width_p-1:0] my_y_i
+
+    , input outstanding_stores_i
+  );
 
 // position in recoded instruction memory of prediction bit
 // for branches. normally this would be bit 31 in RISCV ISA (branch ofs sign bit)
@@ -485,31 +488,35 @@ begin
   end
 end
 
-// Register file chip enable signal
-// FPU depend stall will not affect register file write back
-// MEM load depend stall will not affect register file write back
-// assign rf_cen = (~ stall ) | (net_reg_write_cmd);
-//   assign rf_cen= ~(stall | depend_stall );
-//  assign rf_cen=  ~stall ;
-assign rf_cen = 1'b1;
+  // Register file chip enable signal
+  // FPU depend stall will not affect register file write back
+  // MEM load depend stall will not affect register file write back
+  // assign rf_cen = (~ stall ) | (net_reg_write_cmd);
+  //   assign rf_cen= ~(stall | depend_stall );
+  //  assign rf_cen=  ~stall ;
+  assign rf_cen = 1'b1;
 
-// Instantiate the general purpose register file
-// This register file is write through, which means when read/write
-// The same address, the read gets the newly written value.
-rf_2r1w_sync_wrapper #( .width_p                (RV32_reg_data_width_gp)
-                       ,.els_p                  (32)
-                      ) rf_0
-  ( .clk_i     (clk_i)
-   ,.reset_i   (reset_i)
-   ,.w_v_i     (rf_wen)
-   ,.w_addr_i  (rf_wa)
-   ,.w_data_i  (rf_wd)
-   ,.r0_v_i    (rf_cen)
-   ,.r0_addr_i (rf_rs1_addr)
-   ,.r0_data_o (rf_rs1_val)
-   ,.r1_v_i    (rf_cen)
-   ,.r1_addr_i (rf_rs2_addr)
-   ,.r1_data_o (rf_rs2_val)
+  // Instantiate the general purpose register file
+  // This register file is write through, which means when read/write
+  // The same address, the read gets the newly written value.
+  rf_2r1w_sync_wrapper #(
+    .width_p(RV32_reg_data_width_gp)
+    ,.els_p(32)
+  ) rf_0 (
+    .clk_i(clk_i)
+    ,.reset_i(reset_i)
+
+    ,.w_v_i(rf_wen)
+    ,.w_addr_i(rf_wa)
+    ,.w_data_i(rf_wd)
+
+    ,.r0_v_i(rf_cen)
+    ,.r0_addr_i(rf_rs1_addr)
+    ,.r0_data_o(rf_rs1_val)
+
+    ,.r1_v_i(rf_cen)
+    ,.r1_addr_i(rf_rs2_addr)
+    ,.r1_data_o(rf_rs2_val)
   );
 
 
@@ -870,16 +877,13 @@ wire id_wb_rs2_forward = id.decode.op_reads_rf2 & ( id.instruction.rs2 == wb.rd_
                        & wb.op_writes_rf
                        & (| id.instruction.rs2); //should not forward r0
 
-wire [RV32_reg_data_width_gp-1:0]  rf_rs1_index0_fix = (~|id.instruction.rs1) ?
-                                        RV32_reg_data_width_gp'(0) : rf_rs1_val;
+wire [RV32_reg_data_width_gp-1:0] rs1_to_exe = id_wb_rs1_forward
+  ? wb.rf_data
+  : rf_rs1_val;
 
-wire [RV32_reg_data_width_gp-1:0]  rf_rs2_index0_fix = (~|id.instruction.rs2) ?
-                                        RV32_reg_data_width_gp'(0) : rf_rs2_val;
-
-wire [RV32_reg_data_width_gp-1:0] rs1_to_exe    = id_wb_rs1_forward ?
-                                        wb.rf_data : rf_rs1_index0_fix;
-wire [RV32_reg_data_width_gp-1:0] rs2_to_exe    = id_wb_rs2_forward ?
-                                        wb.rf_data : rf_rs2_index0_fix;
+wire [RV32_reg_data_width_gp-1:0] rs2_to_exe = id_wb_rs2_forward
+  ? wb.rf_data
+  : rf_rs2_val;
 
 // Pre-Compute the forwarding control signal for ALU in EXE
 // RS register forwarding
@@ -1202,7 +1206,7 @@ always@( negedge clk_i ) begin
         end
 end
 
-if (trace_lp)
+if (trace_p)
   always_ff @(negedge clk_i)
     begin
        if (~(debug_wb.squashed  & (debug_wb.PC_r == 0)))
@@ -1227,7 +1231,7 @@ if (trace_lp)
 // file handle for processor execution log
 integer pelog;
 
-if(debug_p | debug_lp) begin
+if (debug_p) begin
   initial begin
     // open the file and clear it
     pelog = $fopen("pe.log", "w");

--- a/v/vanilla_bean/rf_2r1w_sync_wrapper.v
+++ b/v/vanilla_bean/rf_2r1w_sync_wrapper.v
@@ -3,126 +3,158 @@
 // 11/02/2016, shawnless.xie@gmail.com
 //====================================================================
 
-//This module instantiate a 2r1w sync memory file and add a bypass
-//register. When there is a write and read and the same time, it output
-//the newly written value, which is "write through"
+// This module instantiate a 2r1w sync memory file and add a bypass
+// register. When there is a write and read and the same time, it output
+// the newly written value, which is "write through"
 
-module rf_2r1w_sync_wrapper  #(parameter width_p=-1
-                           , parameter els_p=-1
-                           , parameter addr_width_lp=`BSG_SAFE_CLOG2(els_p)
-                           , parameter harden_p=0
-                           )
-   (  input clk_i
+module rf_2r1w_sync_wrapper
+  #(parameter width_p = "inv"
+    , parameter els_p = "inv"
+
+    , localparam addr_width_lp = `BSG_SAFE_CLOG2(els_p)
+  )
+  ( 
+    input clk_i
     , input reset_i
 
-    , input                     w_v_i
+    , input w_v_i
     , input [addr_width_lp-1:0] w_addr_i
-    , input [width_p-1:0]       w_data_i
+    , input [width_p-1:0] w_data_i
 
-    , input                      r0_v_i
-    , input [addr_width_lp-1:0]  r0_addr_i
+    , input r0_v_i
+    , input [addr_width_lp-1:0] r0_addr_i
     , output logic [width_p-1:0] r0_data_o
 
-    , input                      r1_v_i
-    , input [addr_width_lp-1:0]  r1_addr_i
+    , input r1_v_i
+    , input [addr_width_lp-1:0] r1_addr_i
     , output logic [width_p-1:0] r1_data_o
-    );
+  );
 
-    wire r0_rw_same_addr = w_v_i & r0_v_i & ( w_addr_i == r0_addr_i);
-    wire r1_rw_same_addr = w_v_i & r1_v_i & ( w_addr_i == r1_addr_i);
+  // if we are reading and writing to the same register, we want to read the
+  // value being written and prevent reading from rf_mem..
+  // if we are reading or writing x0, then we don't want to do anything.
 
-    wire r0_wrapper_v    = r0_rw_same_addr ? 1'b0 : r0_v_i;
-    wire r1_wrapper_v    = r1_rw_same_addr ? 1'b0 : r1_v_i;
+  logic r0_rw_same_addr;
+  logic r1_rw_same_addr;
+  logic r0_v_li;
+  logic r1_v_li;
+  logic w_v_li;
+  logic [width_p-1:0] r0_data_lo;
+  logic [width_p-1:0] r1_data_lo;
 
-    wire [width_p-1:0] r0_mem_data, r1_mem_data;
+  assign r0_rw_same_addr = w_v_i & r0_v_i & (w_addr_i == r0_addr_i);
+  assign r1_rw_same_addr = w_v_i & r1_v_i & (w_addr_i == r1_addr_i);
 
-    bsg_mem_2r1w_sync #( .width_p       ( width_p       )
-                        ,.els_p         ( els_p         )
-                        ,.addr_width_lp ( addr_width_lp )
-                        ,.harden_p      ( harden_p      )
+  assign r0_v_li = r0_rw_same_addr
+    ? 1'b0
+    : r0_v_i & (r0_addr_i != '0);
 
-                        ,.read_write_same_addr_p( 1'b1  )
-                        ) rf_mem
-        ( .clk_i
-         ,.reset_i
+  assign r1_v_li = r1_rw_same_addr
+    ? 1'b0
+    : r1_v_i & (r1_addr_i != '0);
 
-         ,.w_v_i
-         ,.w_addr_i
-         ,.w_data_i
+  assign w_v_li = w_v_i & (w_addr_i != '0);
 
-         ,.r0_v_i      ( r0_wrapper_v  )
-         ,.r0_addr_i   ( r0_addr_i     )
-         ,.r0_data_o   ( r0_mem_data   )
+  bsg_mem_2r1w_sync #(
+    .width_p(width_p)
+    ,.els_p(els_p)
+    ,.addr_width_lp(addr_width_lp)
+    ,.read_write_same_addr_p(1'b1)
+  ) rf_mem (
+    .clk_i(clk_i)
+    ,.reset_i(reset_i)
 
-         ,.r1_v_i      ( r1_wrapper_v  )
-         ,.r1_addr_i   ( r1_addr_i     )
-         ,.r1_data_o   ( r1_mem_data   )
-        );
+    ,.w_v_i(w_v_li)
+    ,.w_addr_i(w_addr_i)
+    ,.w_data_i(w_data_i)
 
-    logic                   r0_rw_same_addr_r,  r1_rw_same_addr_r;
-    always_ff@(posedge clk_i)
-    begin
-        if( reset_i )  begin
-            r0_rw_same_addr_r  <= 1'b0;
-            r1_rw_same_addr_r  <= 1'b0;
-        end else begin
-            r0_rw_same_addr_r  <= r0_rw_same_addr;
-            r1_rw_same_addr_r  <= r1_rw_same_addr;
-        end
+    ,.r0_v_i(r0_v_li)
+    ,.r0_addr_i(r0_addr_i)
+    ,.r0_data_o(r0_data_lo)
+
+    ,.r1_v_i(r1_v_li)
+    ,.r1_addr_i(r1_addr_i)
+    ,.r1_data_o(r1_data_lo)
+  );
+
+  // we want to remember which registers we read last time, and we want to
+  // hold the last read value until the new location is read, or the new value is
+  // written to that location.
+
+  logic [width_p-1:0] w_data_r, w_data_n;
+  logic [width_p-1:0] r0_data_r, r0_data_n;
+  logic [width_p-1:0] r1_data_r, r1_data_n;
+  logic [addr_width_lp-1:0] r0_addr_r, r0_addr_n;
+  logic [addr_width_lp-1:0] r1_addr_r, r1_addr_n;
+  logic r0_rw_same_addr_r;
+  logic r1_rw_same_addr_r;
+  logic r0_v_r;
+  logic r1_v_r;
+
+  logic [width_p-1:0] r0_safe_data;
+  logic [width_p-1:0] r1_safe_data;
+
+  // combinational logic
+  //
+  assign r0_safe_data = r0_rw_same_addr_r
+    ? w_data_r
+    : r0_data_lo;
+
+  assign r1_safe_data = r1_rw_same_addr_r
+    ? w_data_r
+    : r1_data_lo;
+
+  assign r0_addr_n = r0_v_i
+      ? r0_addr_i
+      : r0_addr_r;
+
+  assign r1_addr_n = r1_v_i
+      ? r1_addr_i
+      : r1_addr_r;
+
+  assign r0_data_n = (w_v_i & (r0_addr_r == w_addr_i))
+    ? (w_addr_i == '0 ? '0 : w_data_i)
+    : (r0_v_r ? r0_safe_data : r0_data_r);
+
+  assign r1_data_n = (w_v_i & (r1_addr_r == w_addr_i))
+    ? (w_addr_i == '0 ? '0 : w_data_i)
+    : (r1_v_r ? r1_safe_data : r1_data_r);
+   
+  assign w_data_n = (r0_rw_same_addr | r1_rw_same_addr)
+    ? w_data_i
+    : w_data_r;
+
+  assign r0_data_o = (r0_addr_r == '0)
+    ? '0
+    : (r0_v_r ? r0_safe_data : r0_data_r);
+
+  assign r1_data_o = (r1_addr_r == '0)
+    ? '0
+    : (r1_v_r ? r1_safe_data : r1_data_r);
+
+  // sequential logic
+  //
+  always_ff @ (posedge clk_i) begin
+    if (reset_i) begin
+      r0_rw_same_addr_r <= 1'b0;
+      r1_rw_same_addr_r <= 1'b0;
+      r0_v_r <= 1'b0;
+      r1_v_r <= 1'b0;
+      //r0_addr_r <= '0;
+      //r1_addr_r <= '0;
     end
-
-
-    //record the latest written data
-    logic [width_p-1:0]      w_data_r;
-    always_ff@(posedge clk_i)
-    begin
-        if( reset_i )   w_data_r <= 'b0;
-        else if( w_v_i) w_data_r <= w_data_i;
+    else begin
+      r0_rw_same_addr_r <= r0_rw_same_addr;
+      r1_rw_same_addr_r <= r1_rw_same_addr;
+      r0_v_r <= r0_v_i;
+      r1_v_r <= r1_v_i;
+      w_data_r <= w_data_n;
+      r0_data_r <= r0_data_n;
+      r1_data_r <= r1_data_n;
+      r0_addr_r <= r0_addr_n;
+      r1_addr_r <= r1_addr_n;
     end
-
-    //get the safe data
-    wire [width_p-1:0]  r0_data_safe = r0_rw_same_addr_r ? w_data_r : r0_mem_data;
-    wire [width_p-1:0]  r1_data_safe = r1_rw_same_addr_r ? w_data_r : r1_mem_data;
-
-    //save the output if the pipleline is stalled.
-    logic [width_p-1:0]         r0_data_r, r1_data_r;
-    logic [addr_width_lp-1:0]   r0_addr_r, r1_addr_r;
-    logic r0_v_r, r1_v_r;
-
-
-    always_ff@( posedge clk_i ) begin
-        r0_addr_r   <=  r0_addr_i;
-        r1_addr_r   <=  r1_addr_i;
-    end
-
-    wire update_hold_reg0 = r0_v_r &&  w_v_i && (r0_addr_r == w_addr_i ) ;
-    wire update_hold_reg1 = r1_v_r &&  w_v_i && (r1_addr_r == w_addr_i ) ;
-
-    always_ff@( posedge clk_i ) begin
-        r0_data_r   <=  update_hold_reg0 ? w_data_i : r0_data_o;
-        r1_data_r   <=  update_hold_reg1 ? w_data_i : r1_data_o;
-    end
-
-    always_ff@( posedge clk_i) begin
-        r0_v_r <= r0_v_i;
-        r1_v_r <= r1_v_i;
-    end
-
-    //assign the output
-    assign  r0_data_o   = r0_v_r ? r0_data_safe : r0_data_r;
-    assign  r1_data_o   = r1_v_r ? r1_data_safe : r1_data_r;
-
-    ///////////////////////////////////////
-    // synopsys translate_off
-    if(0) begin
-        always_ff@ ( negedge clk_i ) begin
-            if ( r0_rw_same_addr )
-                $display("port0 read with the same address with write: addr=%08x, value=%08x\n",r0_addr_i, w_data_i);
-            if ( r1_rw_same_addr )
-                $display("port1 read with the same address with write: addr=%08x, value=%08x\n",r1_addr_i, w_data_i);
-        end
-    end
-    // synopsys translate_on
+  end
 
 endmodule
 

--- a/v/vanilla_bean/rf_2r1w_sync_wrapper.v
+++ b/v/vanilla_bean/rf_2r1w_sync_wrapper.v
@@ -113,11 +113,11 @@ module rf_2r1w_sync_wrapper
       : r1_addr_r;
 
   assign r0_data_n = (w_v_i & (r0_addr_r == w_addr_i))
-    ? (w_addr_i == '0 ? '0 : w_data_i)
+    ? w_data_i
     : (r0_v_r ? r0_safe_data : r0_data_r);
 
   assign r1_data_n = (w_v_i & (r1_addr_r == w_addr_i))
-    ? (w_addr_i == '0 ? '0 : w_data_i)
+    ? w_data_i
     : (r1_v_r ? r1_safe_data : r1_data_r);
    
   assign w_data_n = (r0_rw_same_addr | r1_rw_same_addr)


### PR DESCRIPTION
- including x0 logic in regfile module
- test to verify x0 operation

compare with https://github.com/bespoke-silicon-group/bsg_manycore/pull/9

```
coremark score = unchanged

area: 
Combinational area:              17496.410647
Buf/Inv area:                     4098.477703
Noncombinational area:           14031.032654
Macro/Black Box area:            78908.887695
Total cell area:                110436.330996


power:
                 Internal         Switching           Leakage            Total
Power Group      Power            Power               Power              Power   (   %    )  Attrs
--------------------------------------------------------------------------------------------------
io_pad             0.0000            0.0000            0.0000            0.0000  (   0.00%)
memory             4.0053        6.1730e-02        7.2476e+05            4.7918  (  31.07%)
black_box          0.0000            0.0000            0.0000            0.0000  (   0.00%)
clock_network      0.0000            0.0000            0.0000            0.0000  (   0.00%)
register           8.7520        2.5322e-02        1.3919e+05            8.9165  (  57.82%)
sequential         0.0000            0.0000            0.0000            0.0000  (   0.00%)
combinational      0.2325            1.2273        2.5413e+05            1.7139  (  11.11%)
--------------------------------------------------------------------------------------------------
Total             12.9899 mW         1.3143 mW     1.1181e+06 nW        15.4223 mW



timing:
  clock CLK (rise edge)                                             1.00       1.00
  clock network delay (ideal)                                       0.00       1.00
  proc/h_z/vanilla_core/icache_0/imem_0/macro_mem/CLK (tsmc40_1rw_lg10_w46_m4)     0.00     1.00 r
  library setup time                                               -0.15       0.85
  data required time                                                           0.85
  ---------------------------------------------------------------------------------------------------------
  data required time                                                           0.85
  data arrival time                                                           -0.85
  ---------------------------------------------------------------------------------------------------------
  slack (MET)                                                                  0.00





```