### PR TITLE
Bug fix bsg_id calculation from __bsg_x/y

### DIFF
--- a/software/bsg_manycore_lib/bsg_set_tile_x_y.c
+++ b/software/bsg_manycore_lib/bsg_set_tile_x_y.c
@@ -39,5 +39,5 @@ void bsg_set_tile_x_y()
 
   __bsg_grp_org_x  = * grp_org_x_p;
   __bsg_grp_org_y  = * grp_org_y_p;
-  __bsg_id = __bsg_x * bsg_tiles_X + __bsg_y;
+  __bsg_id = __bsg_y * bsg_tiles_X + __bsg_x;
 }


### PR DESCRIPTION
__bsg_id is being calculated incorrectly. This was based on the assumption that X/Y dimensions of the manycore are always the same, which is no longer true. 
Regression tests passed. Ready to merge. 
