### PR TITLE
Added a Variable that allows cadenv to be ignored in Makefile.verilog

### DIFF
--- a/software/mk/Makefile.verilog
+++ b/software/mk/Makefile.verilog
@@ -6,8 +6,10 @@ COVERAGE=
 PROG_NAME ?= main
 
 ########################################
+ifneq ($(IGNORE_CADENV),)
+$(warning "Ignoring cadenv")
 # select the tools
-ifneq ($(HOSTNAME),xor.cs.washington.edu)
+else ifneq ($(HOSTNAME),xor.cs.washington.edu)
 # Checking the VCS settings
 ifeq ($(VCS),)
 $(error Please define the $$VCS which points to the VCS binaries )
@@ -17,7 +19,7 @@ ifeq ($(DVE),)
 $(error Please define the $$DVE which points to the DVE binaries )
 endif
 #Using the cadenv.mk to setup the VCS
-else
+else 
 include $(CAD_DIR)/cadenv.mk
 endif 
 ########################################


### PR DESCRIPTION
including bsg_cadenv is unnecessary for F1 Cosimulation. Cloning it isn't currently isn't part of the Bladerunner flow.

So, I've added a variable that allows VCS/DVE/Cadenv to be ignored.