### PR TITLE
Added CUDA runtime symbols that are set by host's CUDA API

### DIFF
--- a/software/bsg_manycore_lib/bsg_cuda_lite_runtime.h
+++ b/software/bsg_manycore_lib/bsg_cuda_lite_runtime.h
@@ -16,7 +16,7 @@
 #include "bsg_manycore.h"
 #include "bsg_set_tile_x_y.h"
 
-int kernel_regs[4] __attribute__ ((section ("CUDA_RTL"))) = { 0x0 }; 
+//int kernel_regs[4] __attribute__ ((section ("CUDA_RTL"))) = { 0x0 }; 
 
 //This defines the offset of the runtime variables 
 #define CUDAL_PARAM_BASE_ADDR   0x1100
@@ -65,21 +65,32 @@ int write_signal ()
 }
 
 
+int cuda_kernel_ptr = 0;
+int cuda_argc = 0;
+int cuda_argv_ptr = 0; 
+int cuda_finish_signal_addr = 0; 
+
+
 #define __wait_until_valid_func()                                            \
         asm("__wait_until_valid_func:");                                     \
         bsg_set_tile_x_y();                                                  \
-        asm("                                                                \
-               li         s0           ,    0x1100;                          \
+        asm("                                                                \		
+               la         s0           ,    cuda_kernel_ptr;                 \
                li         t0           ,    0x1;                             \
                lr.w       t1           ,    0 (  s0  );                      \
                bne        t0           ,    t1        ,     __init_param;    \
                lr.w.aq    t0           ,    0 (  s0  );                      \
                                                                              \
              __init_param:                                                   \
-                lw        s1           ,     0 ( s0  );                      \
-                lw        s2           ,     4 ( s0  );                      \
-                lw        s3           ,     8 ( s0  );                      \
-                lw        s4           ,    12 ( s0  );                      \
+                la        t0           ,    cuda_kernel_ptr;                 \
+                lw        s1           ,     0 ( t0  );                      \
+                la        t0           ,    cuda_argc;                       \
+                lw        s2           ,     0 ( t0  );                      \
+                la        t0           ,    cuda_argv_ptr;                   \
+                lw        s3           ,     0 ( t0  );                      \
+                la        t0           ,    cuda_finish_signal_addr;         \
+                lw        s4           ,     0 ( t0  );                      \
+                                                                             \
                                                                              \
              __load_argument:                                                \
                 lw        a0           ,     0 ( s3  );                      \

--- a/software/spmd/bsg_cuda_lite_runtime/matrix_mul/kernel_matrix_mul.c
+++ b/software/spmd/bsg_cuda_lite_runtime/matrix_mul/kernel_matrix_mul.c
@@ -16,8 +16,8 @@ int  __attribute__ ((noinline)) kernel_matrix_mul(int *A, int *B, int *C, int M,
 
 	int start_y = __bsg_tile_group_id_y * block_size_y;
 	int start_x = __bsg_tile_group_id_x * block_size_x;
-	int end_y = M < (start_y + block_size_y) ? P : (start_y + block_size_y);
-	int end_x = P < (start_x + block_size_x) ? M : (start_x + block_size_x);
+	int end_y = M < (start_y + block_size_y) ? M : (start_y + block_size_y);
+	int end_x = P < (start_x + block_size_x) ? P : (start_x + block_size_x);
 
 	for (int iter_y = start_y + __bsg_y; iter_y < end_y; iter_y += bsg_tiles_Y) { 
 		for (int iter_x = start_x + __bsg_x; iter_x < end_x; iter_x += bsg_tiles_X) { 

--- a/software/spmd/bsg_cuda_lite_runtime/matrix_mul/kernel_matrix_mul.c
+++ b/software/spmd/bsg_cuda_lite_runtime/matrix_mul/kernel_matrix_mul.c
@@ -16,8 +16,10 @@ int  __attribute__ ((noinline)) kernel_matrix_mul(int *A, int *B, int *C, int M,
 
 	int start_y = __bsg_tile_group_id_y * block_size_y;
 	int start_x = __bsg_tile_group_id_x * block_size_x;
-	int end_y = M < (start_y + block_size_y) ? M : (start_y + block_size_y);
-	int end_x = P < (start_x + block_size_x) ? P : (start_x + block_size_x);
+	int end_y = start_y + block_size_y;
+	int end_x = start_x + block_size_x;
+	//int end_y = M < (start_y + block_size_y) ? M : (start_y + block_size_y);
+	//int end_x = P < (start_x + block_size_x) ? P : (start_x + block_size_x);
 
 	for (int iter_y = start_y + __bsg_y; iter_y < end_y; iter_y += bsg_tiles_Y) { 
 		for (int iter_x = start_x + __bsg_x; iter_x < end_x; iter_x += bsg_tiles_X) { 


### PR DESCRIPTION
This PR addresses issue #175 on bsg_f1.
Introduced 6 new symbols in the bsg_cuda_lite_runtime.h header file, cuda_kernel_ptr, cuda_argc, cuda_argv_ptr, cuda_finish_signal_addrl, cuda_finish_signal_val and cuda_kernel_not_loaded_val. The symbols are set by the CUDA API after binary is loaded onto tiles. 

**Should only be merged in together with PR #298 on bsg_f1**