### PR TITLE
Manycore ELF configuration options

### DIFF
--- a/machines/1x1/Makefile.machine.include
+++ b/machines/1x1/Makefile.machine.include
@@ -3,4 +3,4 @@ BSG_GLOBAL_Y            = 2
 BSG_VCACHE_SET          = 256
 BSG_VCACHE_WAY          = 2
 BSG_VCACHE_BLOCK_SIZE   = 8
-BSG_DRAM_SIZE           = 536870912  # 2^29 words (2GB)
+BSG_DRAM_SIZE           = 268435456  # 2^28 words (1GB)

--- a/machines/1x1/Makefile.machine.include
+++ b/machines/1x1/Makefile.machine.include
@@ -3,4 +3,4 @@ BSG_GLOBAL_Y            = 2
 BSG_VCACHE_SET          = 256
 BSG_VCACHE_WAY          = 2
 BSG_VCACHE_BLOCK_SIZE   = 8
-BSG_DRAM_SIZE           = 2**29  # in word (2GB)
+BSG_DRAM_SIZE           = 536870912  # 2^29 words (2GB)

--- a/machines/2x2/Makefile.machine.include
+++ b/machines/2x2/Makefile.machine.include
@@ -3,4 +3,4 @@ BSG_GLOBAL_Y            = 3
 BSG_VCACHE_SET          = 256
 BSG_VCACHE_WAY          = 2
 BSG_VCACHE_BLOCK_SIZE   = 8
-BSG_DRAM_SIZE           = 2**29  # in word (2GB)
+BSG_DRAM_SIZE           = 536870912  # 2^29 words (2GB)

--- a/machines/4x4/Makefile.machine.include
+++ b/machines/4x4/Makefile.machine.include
@@ -3,4 +3,4 @@ BSG_GLOBAL_Y            = 5
 BSG_VCACHE_SET          = 256
 BSG_VCACHE_WAY          = 2
 BSG_VCACHE_BLOCK_SIZE   = 8
-BSG_DRAM_SIZE           = 2**29  # in word (2GB)
+BSG_DRAM_SIZE           = 536870912  # 2^29 words (2GB)

--- a/machines/Makefile
+++ b/machines/Makefile
@@ -1,3 +1,9 @@
+find-dir-with = $(shell /usr/bin/perl -e 'chomp($$_ = `pwd`); while ($$_ ne "" && ! -e "$$_/$(1)") { m:(.*)/[^/]+/??:; $$_ = $$1; } print;')
+
+ifndef BSG_MANYCORE_DIR
+  export BSG_MANYCORE_DIR := $(call find-dir-with,.BSG_MANYCORE_ROOT)
+endif
+
 MACHINES = 1x1 2x2 4x4
 
 SIMV = $(addsuffix /simv, $(MACHINES))

--- a/software/mk/Makefile.builddefs
+++ b/software/mk/Makefile.builddefs
@@ -5,18 +5,19 @@ include $(BSG_MACHINE_PATH)/Makefile.machine.include
 # BSG Manycore ELF Configuration
 BSG_ELF_OFF_CHIP_MEM     ?= 1
 BSG_ELF_DEFAULT_DATA_LOC ?= LOCAL
-BSG_ELF_DRAM_SIZE        ?= $(BSG_DRAM_SIZE)
+BSG_ELF_DRAM_SIZE        ?= $(shell echo $$(( $(BSG_DRAM_SIZE) * 4 )) )
 BSG_ELF_VCACHE_SIZE      ?= $(shell echo \
-                              $(BSG_GLOBAL_X)*$(BSG_VCACHE_SET)*$(BSG_VCACHE_WAY)*$(BSG_VCACHE_BLOCK_SIZE) \
+                              $(BSG_GLOBAL_X)*$(BSG_VCACHE_SET)*$(BSG_VCACHE_WAY)*$(BSG_VCACHE_BLOCK_SIZE)*4 \
                               | bc)
 # EVA of stack pointer
+BSG_ELF_DRAM_EVA_OFFSET = 0x80000000
 ifeq ($(BSG_ELF_DEFAULT_DATA_LOC), LOCAL)
 BSG_ELF_STACK_PTR ?= 0x00001ffc
 else
   ifeq ($(BSG_ELF_OFF_CHIP_MEM), 1)
-  BSG_ELF_STACK_PTR ?= $(shell echo $(BSG_ELF_DRAM_SIZE)-4 | bc)
+  BSG_ELF_STACK_PTR ?= $(shell echo $$(( $(BSG_ELF_DRAM_EVA_OFFSET) + $(BSG_ELF_DRAM_SIZE) - 4 )) )
   else
-  BSG_ELF_STACK_PTR ?= $(shell echo $(BSG_ELF_VCACHE_SIZE)-4 | bc)
+  BSG_ELF_STACK_PTR ?= $(shell echo $$(( $(BSG_ELF_DRAM_EVA_OFFSET) + $(BSG_ELF_VCACHE_SIZE) - 4 )) )
   endif
 endif
 

--- a/software/mk/Makefile.builddefs
+++ b/software/mk/Makefile.builddefs
@@ -1,3 +1,26 @@
+# BSG Manycore Machine Configuration
+BSG_MACHINE_PATH ?= $(BSG_MANYCORE_DIR)/machines/4x4
+include $(BSG_MACHINE_PATH)/Makefile.machine.include
+
+# BSG Manycore ELF Configuration
+BSG_ELF_OFF_CHIP_MEM     ?= 1
+BSG_ELF_DEFAULT_DATA_LOC ?= LOCAL
+BSG_ELF_DRAM_SIZE        ?= $(BSG_DRAM_SIZE)
+BSG_ELF_VCACHE_SIZE      ?= $(shell echo \
+                              $(BSG_GLOBAL_X)*$(BSG_VCACHE_SET)*$(BSG_VCACHE_WAY)*$(BSG_VCACHE_BLOCK_SIZE) \
+                              | bc)
+# EVA of stack pointer
+ifeq ($(BSG_ELF_DEFAULT_DATA_LOC), LOCAL)
+BSG_ELF_STACK_PTR ?= 0x00001ffc
+else
+  ifeq ($(BSG_ELF_OFF_CHIP_MEM), 1)
+  BSG_ELF_STACK_PTR ?= $(shell echo $(BSG_ELF_DRAM_SIZE)-4 | bc)
+  else
+  BSG_ELF_STACK_PTR ?= $(shell echo $(BSG_ELF_VCACHE_SIZE)-4 | bc)
+  endif
+endif
+
+
 ifeq ($(RISCV_BIN_DIR),)
 $(error RISCV_BIN_DIR not defined)
 endif
@@ -35,8 +58,8 @@ RISCV_GCC_OPTS +=-Dbsg_tiles_X=$(bsg_tiles_X) -Dbsg_tiles_Y=$(bsg_tiles_Y)
 RISCV_GCC_OPTS +=-Dbsg_global_X=$(bsg_global_X) -Dbsg_global_Y=$(bsg_global_Y)
 RISCV_GCC_OPTS +=-Dbsg_group_size=$(bsg_group_size)
 ifeq ($(BSG_NEWLIB), 1)
-	ARGC ?= 1
-	ARGV ?= main
+  ARGC ?= 1
+  ARGV ?= main
 
   RISCV_GCC_OPTS +=-D__bsg_newlib
   RISCV_GCC_OPTS +=-D__bsg_argc=$(ARGC)
@@ -68,30 +91,52 @@ BSG_MANYCORE_LIB_OBJS+= bsg_printf.o
 BSG_MANYCORE_LIB = bsg_manycore_lib.a
 
 CRT_OBJ ?= crt.o
-LINK_SCRIPT ?= $(BSG_MANYCORE_DIR)/software/spmd/common/link_dmem2.ld
-RISCV_LINK_OPTS ?= 
 
-ifndef CLANG
-	RISCV_GCC_OPTS += -mno-fdiv
+
+ifeq ($(BSG_ELF_OFF_CHIP_MEM), 1)
+  ifeq ($(BSG_ELF_DEFAULT_DATA_LOC), LOCAL)
+    LINK_SCRIPT ?= $(BSG_MANYCORE_DIR)/software/spmd/common/link_dmem.ld
+  else ifeq ($(BSG_ELF_DEFAULT_DATA_LOC), SHARED)
+    LINK_SCRIPT ?= $(BSG_MANYCORE_DIR)/software/spmd/common/link_dram.ld
+  else
+    $(error Invalid BSG_ELF_DEFAULT_VAL_LOC = $(BSG_ELF_DEFAULT_VAL_LOC); Only LOCAL and SHARED are valid)
+  endif
+else ifeq ($(BSG_ELF_OFF_CHIP_MEM), 0)
+  ifeq ($(BSG_ELF_DEFAULT_DATA_LOC), LOCAL)
+    LINK_SCRIPT ?= $(BSG_MANYCORE_DIR)/software/spmd/common/link_dmem2.ld
+  else ifeq ($(BSG_ELF_DEFAULT_DATA_LOC), SHARED)
+    LINK_SCRIPT ?= $(BSG_MANYCORE_DIR)/software/spmd/common/link_dram2.ld
+  else
+    $(error Invalid BSG_ELF_DEFAULT_VAL_LOC = $(BSG_ELF_DEFAULT_VAL_LOC); Only LOCAL and SHARED are valid)
+  endif
+else
+  $(error Invalid BSG_ELF_OFF_CHIP_MEM = $(BSG_ELF_OFF_CHIP_MEM); Only 0 and 1 are valid)
 endif
+
+RISCV_LINK_OPTS ?= 
 
 ifneq ($(BSG_NEWLIB), 1)
   RISCV_LINK_OPTS += -nostdlib
 endif
 
-RISCV_LINK_OPTS = -march=$(ARCH_OP) -nostartfiles -ffast-math -lc -lm -lgcc -l:$(CRT_OBJ)\
-									-L $(BSG_MANYCORE_DIR)/software/spmd/common $(RISCV_LINK_EXTRA_OPTS)
+RISCV_LINK_OPTS += -march=$(ARCH_OP) -nostartfiles -ffast-math -lc -lm -lgcc -l:$(CRT_OBJ)\
+                   -L $(BSG_MANYCORE_DIR)/software/spmd/common $(RISCV_LINK_EXTRA_OPTS)
 
-CRT_OBJ ?= crt.o
-LINK_SCRIPT ?= $(BSG_MANYCORE_DIR)/software/spmd/common/link_dmem.ld
-#RISCV_LINK_EXTRA_OPTS ?=
+RISCV_LINK_OPTS += -Wl,--defsym,bsg_group_size=$(bsg_group_size) \
+                   -Wl,--defsym,_bsg_elf_dram_size=$(BSG_ELF_DRAM_SIZE) \
+                   -Wl,--defsym,_bsg_elf_vcache_size=$(BSG_ELF_VCACHE_SIZE) \
+                   -Wl,--defsym,_bsg_elf_stack_ptr=$(BSG_ELF_STACK_PTR) \
+                   -Wl,--no-check-sections # TODO: temporary fix to solve this problem: \
+https://stackoverflow.com/questions/56518056/risc-v-linker-throwing-sections-lma-overlap-error-despite-lmas-belonging-to-dif
+
+RISCV_LINK = $(RISCV_GCC) -t -T $(LINK_SCRIPT)
+
+
+ifndef CLANG
+  RISCV_GCC_OPTS += -mno-fdiv
+endif
 
 spmd_defs = -DPREALLOCATE=0 -DHOST_DEBUG=0
-
-RISCV_LINK = $(RISCV_GCC) -t -T $(LINK_SCRIPT) \
-						 -Wl,--defsym,bsg_group_size=$(bsg_group_size) \
-						 -Wl,--no-check-sections # TODO: temporary fix to solve this problem: \
-https://stackoverflow.com/questions/56518056/risc-v-linker-throwing-sections-lma-overlap-error-despite-lmas-belonging-to-dif
 
 ifdef CLANG
 export LLVM_DIR   = /mnt/bsg/diskbits/neilryan/llvm/llvm-install

--- a/software/mk/Makefile.builddefs
+++ b/software/mk/Makefile.builddefs
@@ -123,14 +123,14 @@ endif
 RISCV_LINK_OPTS += -march=$(ARCH_OP) -nostartfiles -ffast-math -lc -lm -lgcc -l:$(CRT_OBJ)\
                    -L $(BSG_MANYCORE_DIR)/software/spmd/common $(RISCV_LINK_EXTRA_OPTS)
 
-RISCV_LINK_OPTS += -Wl,--defsym,bsg_group_size=$(bsg_group_size) \
+RISCV_LINK_SYMS += -Wl,--defsym,bsg_group_size=$(bsg_group_size) \
                    -Wl,--defsym,_bsg_elf_dram_size=$(BSG_ELF_DRAM_SIZE) \
                    -Wl,--defsym,_bsg_elf_vcache_size=$(BSG_ELF_VCACHE_SIZE) \
                    -Wl,--defsym,_bsg_elf_stack_ptr=$(BSG_ELF_STACK_PTR) \
                    -Wl,--no-check-sections # TODO: temporary fix to solve this problem: \
 https://stackoverflow.com/questions/56518056/risc-v-linker-throwing-sections-lma-overlap-error-despite-lmas-belonging-to-dif
 
-RISCV_LINK = $(RISCV_GCC) -t -T $(LINK_SCRIPT)
+RISCV_LINK = $(RISCV_GCC) -t -T $(LINK_SCRIPT) $(RISCV_LINK_SYMS)
 
 
 ifndef CLANG

--- a/software/spmd/beebs/Makefile
+++ b/software/spmd/beebs/Makefile
@@ -4,6 +4,9 @@ ifndef BSG_MANYCORE_DIR
   export BSG_MANYCORE_DIR := $(call find-dir-with,.BSG_MANYCORE_ROOT)
 endif
 
+BSG_MACHINE_PATH = $(BSG_MANYCORE_DIR)/machines/1x1
+BSG_ELF_OFFCHIP_MEM = 0
+BSG_ELF_DEFAULT_DATA_LOC = SHARED
 SPMD_COMMON_OBJECTS =
 BSG_NEWLIB = 1
 
@@ -17,7 +20,6 @@ include $(BSG_MANYCORE_DIR)/software/spmd/beebs/Makefile.bmarklist
 bsg_tiles_X = 1
 bsg_tiles_Y = 1
 
-LINK_SCRIPT = $(BSG_MANYCORE_DIR)/software/spmd/common/link_dram.ld
 REPEAT_FACTOR = 2 # Number of iterations each benchmark is run
 
 BEEBS_DIR := $(BSG_MANYCORE_DIR)/imports/beebs
@@ -43,7 +45,7 @@ all: beebs.configure.touchfile
 # Just copy the installed binary
 %.riscv:  $(COMMON_SRCS) $(BSG_MANYCORE_LIB) $(wildcard $(BEEBS_DIR)/src/%/*)
 	make -C $(BUILD_DIR)/src/$* clean
-	make -C $(BUILD_DIR)/src/$* install
+	make -C $(BUILD_DIR)/src/$* install V=1
 	cp $(BUILD_DIR)/bin/$* $@
 
 

--- a/software/spmd/beebs/Makefile
+++ b/software/spmd/beebs/Makefile
@@ -17,7 +17,7 @@ include $(BSG_MANYCORE_DIR)/software/spmd/beebs/Makefile.bmarklist
 bsg_tiles_X = 1
 bsg_tiles_Y = 1
 
-LINK_SCRIPT = $(BSG_MANYCORE_DIR)/software/spmd/common/link_dram2.ld
+LINK_SCRIPT = $(BSG_MANYCORE_DIR)/software/spmd/common/link_dram.ld
 REPEAT_FACTOR = 2 # Number of iterations each benchmark is run
 
 BEEBS_DIR := $(BSG_MANYCORE_DIR)/imports/beebs
@@ -63,8 +63,7 @@ COMMON_SRCS   = $(RUN_DIR)/../common/args.c \
                 $(RUN_DIR)/../../bsg_manycore_lib/bsg_newlib_intf.c \
 								$(RUN_DIR)/lfs.c
 BEEBS_LDFLAGS = "-t -T $(LINK_SCRIPT) -march=$(ARCH_OP) -nostartfiles -ffast-math -lc -lm -lgcc \
-						     -Wl,--defsym,bsg_group_size=$(bsg_group_size) \
-						     -Wl,--no-check-sections \
+								 $(RISCV_LINK_SYMS) \
 								 -I$(BEEBS_DIR)/support \
 								 $(COMMON_SRCS) \
 								 -L$(RUN_DIR) -l:$(BSG_MANYCORE_LIB)"

--- a/software/spmd/common/link_dmem.ld
+++ b/software/spmd/common/link_dmem.ld
@@ -32,7 +32,7 @@ MEMORY
   DRAM_T_VMA (rx) : ORIGIN = 0x0, LENGTH = 16M
 
   /* DRAM data VMA */
-  DRAM_D_VMA (rw) : ORIGIN = 0x81000000, LENGTH = 2032M /* 2048M - 16M */
+  DRAM_D_VMA (rw) : ORIGIN = 0x81000000, LENGTH = (_bsg_elf_dram_size - 16M)
 }
 
 
@@ -134,7 +134,7 @@ SECTIONS
   _bsg_data_end_addr = . - SIZEOF(.striped.data.dmem) 
                          + (SIZEOF(.striped.data.dmem) / bsg_group_size);
 
-  _sp = 0x1ffc;
+  _sp = _bsg_elf_stack_ptr;
 
   ASSERT(_bsg_data_end_addr < 0x2000, 
          "[ Error ] during linking, local dmem overflow, please check the dmem usage"

--- a/software/spmd/common/link_dmem2.ld
+++ b/software/spmd/common/link_dmem2.ld
@@ -27,7 +27,7 @@ MEMORY
   DMEM_VMA (rw) : ORIGIN = 0x1000, LENGTH = 4K
 
   /* VCACHE LMA */
-  VCACHE_LMA (rw) : ORIGIN = 0x80000000, LENGTH = 64K
+  VCACHE_LMA (rw) : ORIGIN = 0x80000000, LENGTH = _bsg_elf_vcache_size
 }
 
 
@@ -129,7 +129,7 @@ SECTIONS
   _bsg_data_end_addr = . - SIZEOF(.striped.data.dmem) 
                          + (SIZEOF(.striped.data.dmem) / bsg_group_size);
 
-  _sp = 0x1ffc;
+  _sp = _bsg_elf_stack_ptr;
 
   ASSERT(_bsg_data_end_addr < 0x2000, 
          "[ Error ] during linking, local dmem overflow, please check the dmem usage"

--- a/software/spmd/common/link_dram.ld
+++ b/software/spmd/common/link_dram.ld
@@ -31,7 +31,7 @@ MEMORY
   DRAM_T_VMA (rx) : ORIGIN = 0x0, LENGTH = 16M
 
   /* DRAM data VMA */
-  DRAM_D_VMA (rw) : ORIGIN = 0x81000000, LENGTH = 2032M /* 2048M - 16M */
+  DRAM_D_VMA (rw) : ORIGIN = 0x81000000, LENGTH = (_bsg_elf_dram_size - 16M)
 }
 
 
@@ -201,5 +201,5 @@ SECTIONS
   _bsg_dram_d_end_addr = . ;
   _bsg_dram_end_addr = . ;
 
-  _sp = 0xbffffffc; /* End of 1st ch of dram: 28-bit dram ch width */
+  _sp = _bsg_elf_stack_ptr;
 }

--- a/software/spmd/common/link_dram2.ld
+++ b/software/spmd/common/link_dram2.ld
@@ -26,7 +26,7 @@ MEMORY
   DMEM_VMA (rw) : ORIGIN = 0x1000, LENGTH = 4K
 
   /* VCACHE LMA */
-  VCACHE_LMA (rw) : ORIGIN = 0x80000000, LENGTH = 64K
+  VCACHE_LMA (rw) : ORIGIN = 0x80000000, LENGTH = _bsg_elf_vcache_size
 }
 
 
@@ -197,5 +197,5 @@ SECTIONS
   _bsg_dram_d_end_addr = _bsg_dram_d_start_addr + SIZEOF(.data.dram) ;
   _bsg_dram_end_addr = _bsg_dram_d_end_addr ;
 
-  _sp = 0x8000fffc; /* End of vcache */
+  _sp = _bsg_elf_stack_ptr;
 }

--- a/software/spmd/fhello/Makefile
+++ b/software/spmd/fhello/Makefile
@@ -1,3 +1,5 @@
+BSG_MACHINE_PATH = $(BSG_MANYCORE_DIR)/machines/1x1
+BSG_ELF_DEFAULT_DATA_LOC = SHARED
 BSG_NEWLIB = 1
 bsg_tiles_X = 1
 bsg_tiles_Y = 1
@@ -19,18 +21,7 @@ else
 
 all: main.run
 
-LINK_SCRIPT = $(BSG_MANYCORE_DIR)/software/spmd/common/link_dram.ld
-
 endif
-
-
-# Rule to write processor execution logs. To be used after the
-# verilog simulation.
-#
-# Redirects verilog standard output starting with "X<x_cord>_Y<y_cord>.pelog" 
-# to a unique log file for each coordinate in the manycore. This can be useful 
-# for a quick debug of processor or program running on it.
-proc_exe_logs: X0_Y2.pelog
 
 OBJECT_FILES=main.o
 IN_FILES=hello.txt


### PR DESCRIPTION
- `BSG_ELF_OFF_CHIP_MEM = {0|1}`:  0 => Only use vcache EVA range, 1 => use DRAM EVA range
- `BSG_ELF_DEFAULT_DATA_LOC = {LOCAL|SHARED}`:  Default location of data section; `LOCAL`=>DMEM, `SHARED`=DRAM/VCACHE.
- `BSG_ELF_DRAM_SIZE`: Total DRAM size
- `BSG_ELF_VCACHE_SIZE`: Total VCACHE size
- `BSG_ELF_STACK_PTR`:  If data section is in dmem, `= 0x1ffc`, else if dram exists `=BSG_DRAM_SIZE-4`, else `=BSG_VCACHE_SIZE-4` 