### PR TITLE
Added a cuda lite runtime memset test to check the functionality of h…

### DIFF
--- a/software/spmd/bsg_cuda_lite_runtime/memset/Makefile
+++ b/software/spmd/bsg_cuda_lite_runtime/memset/Makefile
@@ -1,0 +1,53 @@
+#########################################################
+# Network Configutaion
+# If not configured, Will use default Values
+#	bsg_global_X ?= $(bsg_tiles_X)
+#	bsg_global_Y ?= $(bsg_tiles_Y)+1
+
+bsg_global_X = 4
+bsg_global_Y = 4
+
+#########################################################
+#Tile group configuration
+# If not configured, Will use default Values
+#	bsg_tiles_org_X ?= 0
+#	bsg_tiles_org_Y ?= 1
+bsg_tiles_org_X =0
+bsg_tiles_org_Y =1
+
+# If not configured, Will use default Values
+#	bsg_tiles_X ?= 2
+#	bsg_tiles_Y ?= 2
+bsg_tiles_X = 2
+bsg_tiles_Y = 2
+
+
+all: main.run
+
+# Rule to write processor execution logs. To be used after the
+# verilog simulation.
+#
+# Redirects verilog standard output starting with "X<x_cord>_Y<y_cord>.pelog" 
+# to a unique log file for each coordinate in the manycore. This can be useful 
+# for a quick debug of processor or program running on it.
+proc_exe_logs: X0_Y0.pelog X1_Y0.pelog
+
+KERNEL_NAME ?=kernel_memset
+
+OBJECT_FILES=main.o bsg_set_tile_x_y.o bsg_printf.o kernel_memset.o
+
+include ../../Makefile.include
+
+#########################################################
+#            FPU OPTION
+#     The number of horizon node must be two and must 
+#     be vanilla core 
+BSG_FPU_OP=0
+
+main.riscv: $(OBJECT_FILES) $(SPMD_COMMON_OBJECTS) ../../common/crt.o
+	$(RISCV_LINK) $(OBJECT_FILES) $(SPMD_COMMON_OBJECTS) -o $@ $(RISCV_LINK_OPTS)
+
+
+main.o: Makefile
+
+include ../../../mk/Makefile.tail_rules

--- a/software/spmd/bsg_cuda_lite_runtime/memset/kernel_memset.c
+++ b/software/spmd/bsg_cuda_lite_runtime/memset/kernel_memset.c
@@ -1,0 +1,16 @@
+//This kernel performs a barrier among all tiles in tile group 
+
+#include "bsg_manycore.h"
+#include "bsg_set_tile_x_y.h"
+
+
+#define BSG_TILE_GROUP_X_DIM bsg_tiles_X
+#define BSG_TILE_GROUP_Y_DIM bsg_tiles_Y
+#include "bsg_tile_group_barrier.h"
+INIT_TILE_GROUP_BARRIER(r_barrier, c_barrier, 0, bsg_tiles_X-1, 0, bsg_tiles_Y-1);
+
+
+int  __attribute__ ((noinline)) kernel_memset() {
+  bsg_tile_group_barrier(&r_barrier, &c_barrier);
+  return 0;
+}

--- a/software/spmd/bsg_cuda_lite_runtime/memset/main.c
+++ b/software/spmd/bsg_cuda_lite_runtime/memset/main.c
@@ -1,0 +1,1 @@
+../main/main.c


### PR DESCRIPTION
Adds a cuda-lite-runtime regression test to check the functionality of hb_mc_device_memset in the CUDA Lite API. 
Rebased and ready to merge. Related to PR #309 in bsg_f1.