### PR TITLE
Expose spmd_loader_done signal to outside world

### DIFF
--- a/testbenches/common/v/bsg_nonsynth_manycore_io_complex.v
+++ b/testbenches/common/v/bsg_nonsynth_manycore_io_complex.v
@@ -35,6 +35,7 @@ module bsg_nonsynth_manycore_io_complex
   (
     input clk_i
     , input reset_i
+    , output loader_done_o
 
     , input [link_sif_width_lp-1:0] io_link_sif_i
     , output [link_sif_width_lp-1:0] io_link_sif_o
@@ -149,6 +150,7 @@ module bsg_nonsynth_manycore_io_complex
   ) loader (
     .clk_i(clk_i)
     ,.reset_i(reset_i)
+    ,.done_o(loader_done_o)
 
     ,.packet_o(out_packet_li)
     ,.v_o(out_v_li)

--- a/testbenches/common/v/bsg_nonsynth_manycore_spmd_loader.v
+++ b/testbenches/common/v/bsg_nonsynth_manycore_spmd_loader.v
@@ -23,6 +23,7 @@ module bsg_nonsynth_manycore_spmd_loader
   ( 
     input clk_i
     , input reset_i
+    , output done_o
 
     , output [packet_width_lp-1:0] packet_o
     , output logic v_o
@@ -74,6 +75,7 @@ module bsg_nonsynth_manycore_spmd_loader
   end
 
   logic loader_done_r, loader_done_n;
+  assign done_o = loader_done_r;
  
   always_comb begin
     if (reset_i) begin


### PR DESCRIPTION
Expose loader_done signal to testbench, so that we can reduce manycore clock frequency when loading program to speed up simulation