### PR TITLE
Refactor tile group shared memory to support floating point

### DIFF
--- a/software/bsg_manycore_lib/bsg_manycore.h
+++ b/software/bsg_manycore_lib/bsg_manycore.h
@@ -29,6 +29,7 @@ typedef volatile void *bsg_remote_void_ptr;
 
 #define bsg_tile_group_shared_mem(type,lc_sh,size) type lc_sh[((size + ((bsg_tiles_X * bsg_tiles_Y) -1))/(bsg_tiles_X * bsg_tiles_Y))]
 #define bsg_tile_group_shared_load(type,lc_sh,index,val) (  (val) = *(bsg_tile_group_shared_ptr(type,(lc_sh),(index)))	)
+#define bsg_tile_group_shared_load_direct(type,lc_sh,index) (*(bsg_tile_group_shared_ptr(type,(lc_sh),(index))))
 #define bsg_tile_group_shared_store(type,lc_sh,index,val) (  *(bsg_tile_group_shared_ptr(type,(lc_sh),(index))) = (val)	)
 
 

--- a/software/bsg_manycore_lib/bsg_manycore.h
+++ b/software/bsg_manycore_lib/bsg_manycore.h
@@ -28,8 +28,8 @@ typedef volatile void *bsg_remote_void_ptr;
 #define bsg_host_dram_load(addr, val) do { val = *(bsg_host_dram_ptr((addr)));} while (0)
 
 #define bsg_tile_group_shared_mem(type,lc_sh,size) type lc_sh[((size + ((bsg_tiles_X * bsg_tiles_Y) -1))/(bsg_tiles_X * bsg_tiles_Y))]
-#define bsg_tile_group_shared_load(lc_sh,index,val) (  (val) = *(bsg_tile_group_shared_ptr((lc_sh),(index)))	)
-#define bsg_tile_group_shared_store(lc_sh,index,val) (  *(bsg_tile_group_shared_ptr((lc_sh),(index))) = (val)	)
+#define bsg_tile_group_shared_load(type,lc_sh,index,val) (  (val) = *(bsg_tile_group_shared_ptr(type,(lc_sh),(index)))	)
+#define bsg_tile_group_shared_store(type,lc_sh,index,val) (  *(bsg_tile_group_shared_ptr(type,(lc_sh),(index))) = (val)	)
 
 
 #define bsg_remote_store_uint8(x,y,local_addr,val)  do { *((bsg_remote_uint8_ptr)  (bsg_remote_ptr((x),(y),(local_addr)))) = (unsigned char) (val); } while (0)

--- a/software/bsg_manycore_lib/bsg_manycore_arch.h
+++ b/software/bsg_manycore_lib/bsg_manycore_arch.h
@@ -71,6 +71,22 @@
                                                                | ((int) (local_addr)   )                     \
                                                              )                                               \
                                         )
+
+#define bsg_tile_group_remote_int_ptr(x,y,local_addr) ((bsg_remote_int_ptr) (   (REMOTE_EPA_PREFIX << REMOTE_EPA_MASK_SHIFTS) \
+                                                                              | ((y) << Y_CORD_SHIFTS )                     \
+                                                                              | ((x) << X_CORD_SHIFTS )                     \
+                                                                              | ((int) (local_addr)   )                     \
+                                                                            )                                               \
+                                                      )
+
+#define bsg_tile_group_remote_float_ptr(x,y,local_addr) ((bsg_remote_float_ptr) (   (REMOTE_EPA_PREFIX << REMOTE_EPA_MASK_SHIFTS) \
+                                                                                  | ((y) << Y_CORD_SHIFTS )                     \
+                                                                                  | ((x) << X_CORD_SHIFTS )                     \
+                                                                                  | ((int) (local_addr)   )                     \
+                                                                                )                                               \
+                                                        )
+
+
 //Used for global network access
 #define bsg_global_ptr(x,y,local_addr) ((bsg_remote_int_ptr) (   (GLOBAL_EPA_PREFIX << GLOBAL_EPA_MASK_SHIFTS) \
                                                                | ((y) << Y_CORD_SHIFTS )                     \
@@ -92,7 +108,11 @@
                                         & (   (1 << bsg_remote_addr_bits) - 1 )         \
                                      )
 
-#define bsg_tile_group_shared_ptr(lc_sh,index)	( bsg_remote_ptr( ((index)%bsg_tiles_X) , (((index)/bsg_tiles_X)%bsg_tiles_Y) ,(&((lc_sh)[((index)/(bsg_tiles_X * bsg_tiles_Y))]))) )
+#define CREATE_COMMAND_BY_TYPE(type) bsg_tile_group_remote_ ## type ## _ptr
 
+#define bsg_tile_group_shared_ptr(type,lc_sh,index) ( CREATE_COMMAND_BY_TYPE(type)  ( ((index)%bsg_tiles_X),                                  \
+                                                                                    (((index)/bsg_tiles_X)%bsg_tiles_Y),                      \
+                                                                                    (&((lc_sh)[((index)/(bsg_tiles_X * bsg_tiles_Y))]))) )
+                                                    
 #define bsg_io_mutex_ptr(local_addr)  bsg_global_ptr( IO_X_INDEX, IO_Y_INDEX, (local_addr))  
 #endif

--- a/software/bsg_manycore_lib/bsg_manycore_arch.h
+++ b/software/bsg_manycore_lib/bsg_manycore_arch.h
@@ -72,19 +72,15 @@
                                                              )                                               \
                                         )
 
-#define bsg_tile_group_remote_int_ptr(x,y,local_addr) ((bsg_remote_int_ptr) (   (REMOTE_EPA_PREFIX << REMOTE_EPA_MASK_SHIFTS) \
-                                                                              | ((y) << Y_CORD_SHIFTS )                     \
-                                                                              | ((x) << X_CORD_SHIFTS )                     \
-                                                                              | ((int) (local_addr)   )                     \
-                                                                            )                                               \
-                                                      )
+#define CREATE_POINTER_BY_TYPE(type) bsg_remote_ ## type ## _ptr
 
-#define bsg_tile_group_remote_float_ptr(x,y,local_addr) ((bsg_remote_float_ptr) (   (REMOTE_EPA_PREFIX << REMOTE_EPA_MASK_SHIFTS) \
-                                                                                  | ((y) << Y_CORD_SHIFTS )                     \
-                                                                                  | ((x) << X_CORD_SHIFTS )                     \
-                                                                                  | ((int) (local_addr)   )                     \
-                                                                                )                                               \
-                                                        )
+#define bsg_tile_group_remote_ptr(type,x,y,local_addr) ( (CREATE_POINTER_BY_TYPE(type)) (   (REMOTE_EPA_PREFIX << REMOTE_EPA_MASK_SHIFTS)  \
+                                                                                          | ((y) << Y_CORD_SHIFTS )                        \
+                                                                                          | ((x) << X_CORD_SHIFTS )                        \
+                                                                                          | ((int) (local_addr)   )                        \
+                                                                                        )                                                  \
+                                                       )
+
 
 
 //Used for global network access
@@ -108,11 +104,11 @@
                                         & (   (1 << bsg_remote_addr_bits) - 1 )         \
                                      )
 
-#define CREATE_COMMAND_BY_TYPE(type) bsg_tile_group_remote_ ## type ## _ptr
-
-#define bsg_tile_group_shared_ptr(type,lc_sh,index) ( CREATE_COMMAND_BY_TYPE(type)  ( ((index)%bsg_tiles_X),                                  \
-                                                                                    (((index)/bsg_tiles_X)%bsg_tiles_Y),                      \
-                                                                                    (&((lc_sh)[((index)/(bsg_tiles_X * bsg_tiles_Y))]))) )
+#define bsg_tile_group_shared_ptr(type,lc_sh,index) ( bsg_tile_group_remote_ptr  ( type,                                                   \
+                                                                                   ((index)%bsg_tiles_X),                                  \
+                                                                                   (((index)/bsg_tiles_X)%bsg_tiles_Y),                    \
+                                                                                   (&((lc_sh)[((index)/(bsg_tiles_X * bsg_tiles_Y))]))) )
+ 
                                                     
 #define bsg_io_mutex_ptr(local_addr)  bsg_global_ptr( IO_X_INDEX, IO_Y_INDEX, (local_addr))  
 #endif

--- a/software/spmd/bsg_cuda_lite_runtime/float_vec_add_shared_mem/Makefile
+++ b/software/spmd/bsg_cuda_lite_runtime/float_vec_add_shared_mem/Makefile
@@ -1,0 +1,46 @@
+#########################################################
+# Network Configutaion
+# If not configured, Will use default Values
+	bsg_global_X ?= $(bsg_tiles_X)
+	bsg_global_Y ?= $(bsg_tiles_Y)+1
+
+#########################################################
+#Tile group configuration
+# If not configured, Will use default Values
+	bsg_tiles_org_X ?= 0
+	bsg_tiles_org_Y ?= 1
+
+# If not configured, Will use default Values
+	bsg_tiles_X ?= 2
+	bsg_tiles_Y ?= 2
+
+
+all: main.run
+
+# Rule to write processor execution logs. To be used after the
+# verilog simulation.
+#
+# Redirects verilog standard output starting with "X<x_cord>_Y<y_cord>.pelog" 
+# to a unique log file for each coordinate in the manycore. This can be useful 
+# for a quick debug of processor or program running on it.
+proc_exe_logs: X0_Y0.pelog X1_Y0.pelog
+
+KERNEL_NAME ?=kernel_float_vec_add_shared_mem
+
+OBJECT_FILES=main.o bsg_set_tile_x_y.o bsg_printf.o kernel_float_vec_add_shared_mem.o
+
+include ../../Makefile.include
+
+#########################################################
+#            FPU OPTION
+#     The number of horizon node must be two and must 
+#     be vanilla core 
+BSG_FPU_OP=0
+
+main.riscv: $(OBJECT_FILES) $(SPMD_COMMON_OBJECTS) ../../common/crt.o
+	$(RISCV_LINK) $(OBJECT_FILES) $(SPMD_COMMON_OBJECTS) -o $@ $(RISCV_LINK_OPTS)
+
+
+main.o: Makefile
+
+include ../../../mk/Makefile.tail_rules

--- a/software/spmd/bsg_cuda_lite_runtime/float_vec_add_shared_mem/kernel_float_vec_add_shared_mem.c
+++ b/software/spmd/bsg_cuda_lite_runtime/float_vec_add_shared_mem/kernel_float_vec_add_shared_mem.c
@@ -1,0 +1,61 @@
+//This kernel adds two floating point vectors using
+// shared memory, each tile group loads a block into
+// shared memory and performs addition, and stores it back. 
+
+#include "bsg_manycore.h"
+#include "bsg_set_tile_x_y.h"
+
+#define BSG_TILE_GROUP_X_DIM bsg_tiles_X
+#define BSG_TILE_GROUP_Y_DIM bsg_tiles_Y
+#include "bsg_tile_group_barrier.h"
+INIT_TILE_GROUP_BARRIER(r_barrier, c_barrier, 0, bsg_tiles_X-1, 0, bsg_tiles_Y-1);
+
+
+
+int  __attribute__ ((noinline)) kernel_float_vec_add_shared_mem(float *A, float *B, float *C, int N, int block_size_x) {
+
+	// Declare tile-group shared memroy with specific size
+	bsg_tile_group_shared_mem (float, sh_A, block_size_x);
+	bsg_tile_group_shared_mem (float, sh_B, block_size_x); 
+	bsg_tile_group_shared_mem (float, sh_C, block_size_x); 
+
+
+	int start_x = block_size_x * (__bsg_tile_group_id_y * __bsg_grid_dim_x + __bsg_tile_group_id_x); 
+
+
+	for (int iter_x = __bsg_id; iter_x < block_size_x; iter_x += bsg_tiles_X * bsg_tiles_Y) { 
+		// Store from DRAM into tile-group shared memory
+		bsg_tile_group_shared_store(float, sh_A, iter_x, A[start_x + iter_x]); 
+		bsg_tile_group_shared_store(float, sh_B, iter_x, B[start_x + iter_x]); 
+		
+	}
+
+
+	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
+
+
+	for (int iter_x = __bsg_id; iter_x < block_size_x; iter_x += bsg_tiles_X * bsg_tiles_Y) { 
+		float lc_A, lc_B;
+		// Load from tile group shared memory and store into local variable lc_A & lc_B
+		bsg_tile_group_shared_load (float, sh_A, iter_x, lc_A);
+		bsg_tile_group_shared_load (float, sh_B, iter_x, lc_B);
+
+		// Store the sum of lc_A and lc_B into tile-group shared memroy sh_C
+		bsg_tile_group_shared_store (float, sh_C, iter_x, (lc_A + lc_B));
+	}
+
+	
+	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
+
+
+	for (int iter_x = __bsg_id; iter_x < block_size_x; iter_x += bsg_tiles_X * bsg_tiles_Y) { 
+		// Load from tile-group shared memory lc_C and store the result into DRAM 
+		bsg_tile_group_shared_load(float, sh_C, iter_x, C[start_x + iter_x]); 
+	}
+
+
+	bsg_tile_group_barrier(&r_barrier, &c_barrier);
+
+
+  return 0;
+}

--- a/software/spmd/bsg_cuda_lite_runtime/float_vec_add_shared_mem/main.c
+++ b/software/spmd/bsg_cuda_lite_runtime/float_vec_add_shared_mem/main.c
@@ -1,0 +1,1 @@
+../main/main.c

--- a/software/spmd/bsg_cuda_lite_runtime/matrix_mul_shared_mem/kernel_matrix_mul_shared_mem.c
+++ b/software/spmd/bsg_cuda_lite_runtime/matrix_mul_shared_mem/kernel_matrix_mul_shared_mem.c
@@ -22,7 +22,7 @@ void __attribute__ ((noinline)) subblock2shmem (int *A, int *sh_dest, int M, int
 	for (int iter_y = __bsg_y; iter_y < block_size_y; iter_y += bsg_tiles_Y) { 
 		for (int iter_x = __bsg_x; iter_x < block_size_x; iter_x += bsg_tiles_X) { 
 			// sh_dest[iter_y][iter_x] <-- A[iter_y + start_y][iter_x + start_x]
-			bsg_tile_group_shared_store (sh_dest, (iter_y * block_size_x + iter_x), A[((iter_y + start_y) * N + iter_x + start_x)]);
+			bsg_tile_group_shared_store (int, sh_dest, (iter_y * block_size_x + iter_x), A[((iter_y + start_y) * N + iter_x + start_x)]);
 		}
 	}
 	return; 
@@ -37,7 +37,7 @@ void __attribute__ ((noinline)) subblock2shmem_xposed (int *A, int *sh_dest, int
 	for (int iter_y = __bsg_y; iter_y < block_size_y; iter_y += bsg_tiles_Y) { 
 		for (int iter_x = __bsg_x; iter_x < block_size_x; iter_x += bsg_tiles_X) { 
 			// sh_dest[iter_x][iter_y] <-- A[iter_y + start_y][iter_x + start_x]
-			bsg_tile_group_shared_store (sh_dest, (iter_x * block_size_y + iter_y), A[((iter_y + start_y) * N + iter_x + start_x)]);
+			bsg_tile_group_shared_store (int, sh_dest, (iter_x * block_size_y + iter_y), A[((iter_y + start_y) * N + iter_x + start_x)]);
 		}
 	}
 	return; 
@@ -52,7 +52,7 @@ void __attribute__ ((noinline)) shmem2subblock (int *A, int *sh_src, int M, int 
 	for (int iter_y = __bsg_y; iter_y < block_size_y; iter_y += bsg_tiles_Y) { 
 		for (int iter_x = __bsg_x; iter_x < block_size_x; iter_x += bsg_tiles_X) { 
 			// A[iter_y + start_y][iter_x + start_x] <-- sh_src[iter_y][iter_x]
-			bsg_tile_group_shared_load (sh_src, (iter_y * block_size_x + iter_x), A[((iter_y + start_y) * N + iter_x + start_x)]);
+			bsg_tile_group_shared_load (int, sh_src, (iter_y * block_size_x + iter_x), A[((iter_y + start_y) * N + iter_x + start_x)]);
 		}
 	}
 	return; 
@@ -69,21 +69,21 @@ void __attribute__ ((noinline)) subblock_shmem_matrix_mul_xposed (int *sh_A, int
 			int lc_A, lc_B;
 			for (int k = 0; k < BLOCK_WIDTH; k ++) { 
 				// lc_A <-- sh_A[iter_y][iter_x]
-				bsg_tile_group_shared_load (sh_A, (iter_y * BLOCK_WIDTH + k), lc_A); 
+				bsg_tile_group_shared_load (int, sh_A, (iter_y * BLOCK_WIDTH + k), lc_A); 
 				// lc_B <-- sh_B[iter_y][iter_x]	remember B is transposed
-				bsg_tile_group_shared_load (sh_B, (iter_x * BLOCK_WIDTH + k), lc_B);
+				bsg_tile_group_shared_load (int, sh_B, (iter_x * BLOCK_WIDTH + k), lc_B);
 				sum += lc_A * lc_B;
 			}
 
 			if (!block_num) { 
 				// sh_C[iter_y][iter_x] <-- sum
-				bsg_tile_group_shared_store (sh_C, (iter_y * block_size_x + iter_x), sum);
+				bsg_tile_group_shared_store (int, sh_C, (iter_y * block_size_x + iter_x), sum);
 			}
 			else { 
 				int lc_C;
 				// sh_C[iter_y][iter_x] += sum
-				bsg_tile_group_shared_load (sh_C, (iter_y * block_size_x + iter_x), lc_C);
-				bsg_tile_group_shared_store (sh_C, (iter_y * block_size_x + iter_x), lc_C + sum);
+				bsg_tile_group_shared_load (int, sh_C, (iter_y * block_size_x + iter_x), lc_C);
+				bsg_tile_group_shared_store (int, sh_C, (iter_y * block_size_x + iter_x), lc_C + sum);
 			} 
 		}
 	}

--- a/software/spmd/bsg_cuda_lite_runtime/shared_mem/kernel_shared_mem.c
+++ b/software/spmd/bsg_cuda_lite_runtime/shared_mem/kernel_shared_mem.c
@@ -17,7 +17,7 @@ int  __attribute__ ((noinline)) kernel_shared_mem (int *A, int N) {
 	bsg_tile_group_shared_mem (int, sh_arr, N); 
 
 	for (int iter_x = __bsg_id; iter_x < N; iter_x += bsg_tiles_X * bsg_tiles_Y) {
-		bsg_tile_group_shared_store(sh_arr, iter_x, iter_x);
+		bsg_tile_group_shared_store(int, sh_arr, iter_x, iter_x);
 	}
 
 
@@ -26,7 +26,7 @@ int  __attribute__ ((noinline)) kernel_shared_mem (int *A, int N) {
 
 	int block_size = N / (bsg_tiles_X * bsg_tiles_Y);
 	for (int iter_x = __bsg_id * block_size; iter_x < (__bsg_id + 1) * block_size; iter_x ++) { 
-		bsg_tile_group_shared_load(sh_arr, iter_x, A[iter_x]);
+		bsg_tile_group_shared_load(int, sh_arr, iter_x, A[iter_x]);
 	}
 
 

--- a/software/spmd/bsg_cuda_lite_runtime/shared_mem_load_store/kernel_shared_mem_load_store.c
+++ b/software/spmd/bsg_cuda_lite_runtime/shared_mem_load_store/kernel_shared_mem_load_store.c
@@ -27,7 +27,7 @@ int  __attribute__ ((noinline)) kernel_shared_mem_load_store(int *A_in, int *A_o
 	// Load a (block_size_y * block_size_x) block of A_in into tile_group_shared memory 
 	for (int iter_y = __bsg_y; iter_y < block_size_y; iter_y += bsg_tiles_Y) { 
 		for (int iter_x = __bsg_x; iter_x < block_size_x; iter_x += bsg_tiles_X) { 
-			bsg_tile_group_shared_store (sh_A, (iter_y * block_size_x + iter_x) , A_in[(start_y + iter_y) * N + (start_x + iter_x)]);
+			bsg_tile_group_shared_store (int, sh_A, (iter_y * block_size_x + iter_x) , A_in[(start_y + iter_y) * N + (start_x + iter_x)]);
 		}
 	}
 
@@ -38,7 +38,7 @@ int  __attribute__ ((noinline)) kernel_shared_mem_load_store(int *A_in, int *A_o
 	// Store the same (block_size_y * block_size_x) block of shared memory into A_out
 	for (int iter_y = __bsg_y; iter_y < block_size_y; iter_y += bsg_tiles_Y) { 
 		for (int iter_x = __bsg_x; iter_x < block_size_x; iter_x += bsg_tiles_X) { 
-			bsg_tile_group_shared_load (sh_A, (iter_y * block_size_x + iter_x) , A_out[(start_y + iter_y) * N + (start_x + iter_x)]);
+			bsg_tile_group_shared_load (int, sh_A, (iter_y * block_size_x + iter_x) , A_out[(start_y + iter_y) * N + (start_x + iter_x)]);
 		}
 	}
 

--- a/software/spmd/bsg_cuda_lite_runtime/vec_add_shared_mem/kernel_vec_add_shared_mem.c
+++ b/software/spmd/bsg_cuda_lite_runtime/vec_add_shared_mem/kernel_vec_add_shared_mem.c
@@ -23,8 +23,8 @@ int  __attribute__ ((noinline)) kernel_vec_add_shared_mem(int *A, int *B, int *C
 
 	for (int iter_x = __bsg_id; iter_x < block_size_x; iter_x += bsg_tiles_X * bsg_tiles_Y) { 
 		// Store from DRAM into tile-group shared memory
-		bsg_tile_group_shared_store(sh_A, iter_x, A[start_x + iter_x]); 
-		bsg_tile_group_shared_store(sh_B, iter_x, B[start_x + iter_x]); 
+		bsg_tile_group_shared_store(int, sh_A, iter_x, A[start_x + iter_x]); 
+		bsg_tile_group_shared_store(int, sh_B, iter_x, B[start_x + iter_x]); 
 		
 	}
 
@@ -35,11 +35,11 @@ int  __attribute__ ((noinline)) kernel_vec_add_shared_mem(int *A, int *B, int *C
 	for (int iter_x = __bsg_id; iter_x < block_size_x; iter_x += bsg_tiles_X * bsg_tiles_Y) { 
 		int lc_A, lc_B;
 		// Load from tile group shared memory and store into local variable lc_A & lc_B
-		bsg_tile_group_shared_load (sh_A, iter_x, lc_A);
-		bsg_tile_group_shared_load (sh_B, iter_x, lc_B);
+		bsg_tile_group_shared_load (int, sh_A, iter_x, lc_A);
+		bsg_tile_group_shared_load (int, sh_B, iter_x, lc_B);
 
 		// Store the sum of lc_A and lc_B into tile-group shared memroy sh_C
-		bsg_tile_group_shared_store (sh_C, iter_x, (lc_A + lc_B));
+		bsg_tile_group_shared_store (int, sh_C, iter_x, (lc_A + lc_B));
 	}
 
 	
@@ -48,7 +48,7 @@ int  __attribute__ ((noinline)) kernel_vec_add_shared_mem(int *A, int *B, int *C
 
 	for (int iter_x = __bsg_id; iter_x < block_size_x; iter_x += bsg_tiles_X * bsg_tiles_Y) { 
 		// Load from tile-group shared memory lc_C and store the result into DRAM 
-		bsg_tile_group_shared_load(sh_C, iter_x, C[start_x + iter_x]); 
+		bsg_tile_group_shared_load(int, sh_C, iter_x, C[start_x + iter_x]); 
 	}
 
 

--- a/software/spmd/bsg_tile_group_mem/main.c
+++ b/software/spmd/bsg_tile_group_mem/main.c
@@ -58,7 +58,7 @@ int main() {
 		//   Each tile stores its id to sh_mem[(id+2)%16] (which is in local memory of two tiles ahead)
 		//    Store to Shared Mem
         //----------------------------------------------------------------
-	bsg_tile_group_shared_store(shared_mem,((id+2)%16),id);
+	bsg_tile_group_shared_store(int, shared_mem,((id+2)%16),id);
 				
 				
         //----------------------------------------------------------------
@@ -70,7 +70,7 @@ int main() {
         //4. Each tile loads the first 16 elements of shared memory into local memory 	
         //----------------------------------------------------------------		
 	for (int idx = 0; idx < 16 ; idx ++ )
-		bsg_tile_group_shared_load(shared_mem,idx,local_var[idx]);
+		bsg_tile_group_shared_load(int, shared_mem,idx,local_var[idx]);
 		
 
         //----------------------------------------------------------------


### PR DESCRIPTION
1. Modified bsg_tile_group_shared_load/store macros to also take in the type (int or float) as input argument. 
2. Added a bsg_tile_group_remote_ptr macro that translates to a bsg_remote_int/float_ptr based on the given argument. 
3. Added a floating point vector addition with tile group shared memory cuda lite runtime regression test. 