### PR TITLE
Toolchain updates

### DIFF
--- a/machines/Makefile
+++ b/machines/Makefile
@@ -4,7 +4,7 @@ ifndef BSG_MANYCORE_DIR
   export BSG_MANYCORE_DIR := $(call find-dir-with,.BSG_MANYCORE_ROOT)
 endif
 
-export BASEJUMP_STL_DIR := ../../basejump_stl
+export BASEJUMP_STL_DIR := $(BSG_MANYCORE_DIR)/../basejump_stl
 
 # Sets "VCS" variable
 include $(BSG_MANYCORE_DIR)/../bsg_cadenv/cadenv.mk

--- a/software/riscv-tools/Makefile
+++ b/software/riscv-tools/Makefile
@@ -105,7 +105,7 @@ configure-riscv-gnu-tools:
 	@echo "Configuring toolchain..."
 	@echo "====================================="
 	cd riscv-gnu-toolchain && \
-		./configure --prefix=$(RISCV) --disable-linux --with-arch=rv32ima --with-abi=ilp32
+		./configure --prefix=$(RISCV) --disable-linux --with-arch=rv32imaf --with-abi=ilp32
 
 build-riscv-gnu-tools: configure-riscv-gnu-tools
 	@echo "====================================="

--- a/software/riscv-tools/Makefile
+++ b/software/riscv-tools/Makefile
@@ -25,6 +25,8 @@
 # assumed already installed: autoconf automake libtool curl gmp gawk bison flex texinfo gperf gcc48 gsed
 #
 #
+.DEFAULT_GOAL := help
+
 TOOLCHAIN_REPO=riscv-gnu-toolchain
 TOOLCHAIN_URL=https://github.com/riscv/$(TOOLCHAIN_REPO)
 DEPENDS_DIR=$(CURDIR)/depends
@@ -51,7 +53,8 @@ export PATH
 export SHELL:=$(SHELL)
 
 
-nothing:
+help:
+	@cat README.md
 
 checkout-repos:
 	mkdir -p $(DEPENDS_DIR);	
@@ -94,7 +97,7 @@ build-deps:
 	for dep_tool in $(DEPENDS_LIST); do 	\
 		tar xf $$dep_tool.tar.xz &&      \
 		cd $$dep_tool	&&	\
-		./configure --prefix=$(DEPENDS_DIR) && make && make install; \
+		./configure --prefix=$(DEPENDS_DIR) && $(MAKE) && $(MAKE) install; \
 		cd ..;	\
 	done
 
@@ -109,23 +112,28 @@ build-riscv-gnu-tools: configure-riscv-gnu-tools
 	@echo "====================================="
 	@echo "Building toolchain..."
 	@echo "====================================="
-	cd riscv-gnu-toolchain && make -j 16 newlib && make install
+	cd riscv-gnu-toolchain && $(MAKE) -j 16 newlib && $(MAKE) install
 
 build-spike:
 	@echo "====================================="
 	@echo "Building $(SPIKE_REPO)..."
 	@echo "====================================="
 	cd $(SPIKE_REPO) && ./configure --prefix=$(RISCV)
-	cd $(SPIKE_REPO) && make && make install
+	cd $(SPIKE_REPO) && $(MAKE) && $(MAKE) install
 
 build-all: build-deps build-riscv-gnu-tools build-spike
 
 rebuild-newlib:
-	make -C $(TOOLCHAIN_REPO)/build-newlib
-	make -C $(TOOLCHAIN_REPO)/build-newlib install
+	$(MAKE) -C $(TOOLCHAIN_REPO)/build-newlib
+	$(MAKE) -C $(TOOLCHAIN_REPO)/build-newlib install
 
-install-with-builds: checkout-all build-all
-install-clean: install-with-builds clean-builds
+install-with-builds: 
+	$(MAKE) checkout-all 
+	$(MAKE) build-all
+
+install-clean: 
+	$(MAKE) install-with-builds 
+	$(MAKE) clean-builds
 
 clean-builds:
 	rm -rf $(DEPENDS_DIR) $(TOOLCHAIN_REPO) $(SPIKE_REPO)

--- a/software/riscv-tools/Makefile
+++ b/software/riscv-tools/Makefile
@@ -25,6 +25,8 @@
 # assumed already installed: autoconf automake libtool curl gmp gawk bison flex texinfo gperf gcc48 gsed
 #
 #
+.DEFAULT_GOAL := install-tools
+
 TOOLCHAIN_REPO=riscv-gnu-toolchain
 TOOLCHAIN_URL=https://github.com/riscv/$(TOOLCHAIN_REPO)
 DEPENDS_DIR=$(CURDIR)/depends
@@ -124,13 +126,16 @@ rebuild-newlib:
 	make -C $(TOOLCHAIN_REPO)/build-newlib
 	make -C $(TOOLCHAIN_REPO)/build-newlib install
 
-clean:
+install-tools: checkout-all build-all clean-builds
+
+clean-builds:
+	rm -rf $(DEPENDS_DIR) $(TOOLCHAIN_REPO) $(SPIKE_REPO)
+
+clean-install:
 	rm -rf riscv-install
 
-really-clean: clean
-	rm -rf $(TOOLCHAIN_REPO)
-	rm -rf $(DEPENDS_DIR)
-
+clean-all:
+	rm -rf $(DEPENDS_DIR) $(TOOLCHAIN_REPO) $(SPIKE_REPO) riscv-install
 
 installs:
 	sudo apt-get install autoconf automake libtool curl gawk bison flex texinfo gperf \

--- a/software/riscv-tools/Makefile
+++ b/software/riscv-tools/Makefile
@@ -25,8 +25,6 @@
 # assumed already installed: autoconf automake libtool curl gmp gawk bison flex texinfo gperf gcc48 gsed
 #
 #
-.DEFAULT_GOAL := install-tools
-
 TOOLCHAIN_REPO=riscv-gnu-toolchain
 TOOLCHAIN_URL=https://github.com/riscv/$(TOOLCHAIN_REPO)
 DEPENDS_DIR=$(CURDIR)/depends
@@ -126,7 +124,8 @@ rebuild-newlib:
 	make -C $(TOOLCHAIN_REPO)/build-newlib
 	make -C $(TOOLCHAIN_REPO)/build-newlib install
 
-install-tools: checkout-all build-all clean-builds
+install-with-builds: checkout-all build-all
+install-clean: install-with-builds clean-builds
 
 clean-builds:
 	rm -rf $(DEPENDS_DIR) $(TOOLCHAIN_REPO) $(SPIKE_REPO)

--- a/software/riscv-tools/README.md
+++ b/software/riscv-tools/README.md
@@ -1,17 +1,17 @@
 Clean installation of tools:
 
-`make`: Install tools in `./riscv-install` directory
+- `make`: Install tools in `./riscv-install` directory
 
 
 For installation preseving builds:
 
-`make checkout-all`: Clone required repos and apply patches.
-`make build-all`: Compile and install tools in `./riscv-install` directory.
+- `make checkout-all`: Clone required repos and apply patches.
+- `make build-all`: Compile and install tools in `./riscv-install` directory.
 
 
 Misc:
 
-`make rebuild-newlib`: To re-compile and install Newlib. Useful for Newlib development.
-`make clean-builds`: Remove source and build directories.
-`make clean-install`: Remove install directories.
-`make clean-all`: Remove everthing created by the Makefile.
+- `make rebuild-newlib`: To re-compile and install Newlib. Useful for Newlib development.
+- `make clean-builds`: Remove source and build directories.
+- `make clean-install`: Remove install directories.
+- `make clean-all`: Remove everthing created by the Makefile.

--- a/software/riscv-tools/README.md
+++ b/software/riscv-tools/README.md
@@ -1,16 +1,17 @@
 Clean installation of tools:
 
-- `make`: Install tools in `./riscv-install` directory
+- `make install-clean`: Install tools in `./riscv-install` directory
 
 
 For installation preseving builds:
 
-- `make checkout-all`: Clone required repos and apply patches.
-- `make build-all`: Compile and install tools in `./riscv-install` directory.
-
+- `make install-with-builds`: Install tools in `./riscv-install` preserving build in 
+                              respective source directories.
 
 Misc:
 
+- `make checkout-all`: Clone required repos and apply patches.
+- `make build-all`: Compile and install tools in `./riscv-install` directory.
 - `make rebuild-newlib`: To re-compile and install Newlib. Useful for Newlib development.
 - `make clean-builds`: Remove source and build directories.
 - `make clean-install`: Remove install directories.

--- a/software/riscv-tools/README.md
+++ b/software/riscv-tools/README.md
@@ -1,3 +1,17 @@
-Typically you will do
-make checkout-all 
-make build-all
+Clean installation of tools:
+
+`make`: Install tools in `./riscv-install` directory
+
+
+For installation preseving builds:
+
+`make checkout-all`: Clone required repos and apply patches.
+`make build-all`: Compile and install tools in `./riscv-install` directory.
+
+
+Misc:
+
+`make rebuild-newlib`: To re-compile and install Newlib. Useful for Newlib development.
+`make clean-builds`: Remove source and build directories.
+`make clean-install`: Remove install directories.
+`make clean-all`: Remove everthing created by the Makefile.


### PR DESCRIPTION
- Added `f` extension to target ISA for riscv-gnu-toolchain installation.
- Added `install-clean` and `install-with-builds` to install tools without and with builds preserved respectively.
- Updated readme.