### PR TITLE
Fixed bug in bsg_cuda_lite_runtime.h

### DIFF
--- a/software/bsg_manycore_lib/bsg_cuda_lite_runtime.h
+++ b/software/bsg_manycore_lib/bsg_cuda_lite_runtime.h
@@ -78,9 +78,7 @@ int write_finish_signal ()
 
 
 #define __wait_until_valid_func()                                            \
-        asm("__wait_until_valid_func:");                                     \
-        bsg_set_tile_x_y();                                                  \
-        asm("                                                                \		
+        asm("__wait_until_valid_func:                                        \
                lw         t0           ,    cuda_kernel_not_loaded_val;      \
                la         s0           ,    cuda_kernel_ptr;                 \
                lr.w       t1           ,    0 (  s0  );                      \


### PR DESCRIPTION
Fixed the race bug related to bsg_set_tile_x_y() that was being called at the beginning of cuda lite runtime binary loaded into tiles, the function initializes bsg_x/y/id/tile_group_id symbols, but is too slow in cosim, and is not done when the host starts sending the correct values for symbols, causing the symbols to take the wrong values. 
There is no longer a need to call bsg_set_tile_x_y() in cuda_lite kernels, therefore it is removed.
Credit and huge thanks to @drichmond for his help! 
