### PR TITLE
Volatile load bugfix

### DIFF
--- a/software/bsg_manycore_lib/bsg_tilegroup.h
+++ b/software/bsg_manycore_lib/bsg_tilegroup.h
@@ -80,7 +80,6 @@ void extern_store_int(int STRIPE *arr_ptr, unsigned elem_size, unsigned offset, 
             (unsigned) arr_ptr, elem_size, offset, val);
 #endif
     int *ptr = get_ptr_val(arr_ptr, elem_size, offset);
-    bsg_printf("store %x %d\n", arr_ptr, __bsg_id);
     *ptr = val;
 }
 

--- a/software/bsg_manycore_lib/bsg_tilegroup.h
+++ b/software/bsg_manycore_lib/bsg_tilegroup.h
@@ -80,6 +80,7 @@ void extern_store_int(int STRIPE *arr_ptr, unsigned elem_size, unsigned offset, 
             (unsigned) arr_ptr, elem_size, offset, val);
 #endif
     int *ptr = get_ptr_val(arr_ptr, elem_size, offset);
+    bsg_printf("store %x %d\n", arr_ptr, __bsg_id);
     *ptr = val;
 }
 
@@ -104,42 +105,62 @@ void extern_store_char(int STRIPE *arr_ptr, unsigned elem_size, unsigned offset,
 }
 
 
-float extern_load_float(int STRIPE *arr_ptr, unsigned elem_size, unsigned offset) {
+float extern_load_float(int STRIPE *arr_ptr, unsigned elem_size, unsigned offset,
+        unsigned is_vol) {
 #ifdef TILEGROUP_DEBUG
     bsg_printf("\nCalling extern_load_float(0x%x, %d, %d)\n",
             (unsigned) arr_ptr, elem_size, offset);
 #endif
     float *ptr = (float *) get_ptr_val(arr_ptr, elem_size, offset);
-    return *ptr;
+    if (is_vol) {
+        return *((volatile float *) ptr);
+    } else {
+        return *ptr;
+    }
 }
 
-int extern_load_int(int STRIPE *arr_ptr, unsigned elem_size, unsigned offset) {
+int extern_load_int(int STRIPE *arr_ptr, unsigned elem_size, unsigned offset,
+        unsigned is_vol) {
 #ifdef TILEGROUP_DEBUG
     bsg_printf("\nCalling extern_load_int(0x%x, %d, %d)\n",
             (unsigned) arr_ptr, elem_size, offset);
 #endif
     int *ptr = get_ptr_val(arr_ptr, elem_size, offset);
-    return *ptr;
+    if (is_vol) {
+        return *((volatile int *) ptr);
+    } else {
+        return *ptr;
+    }
 }
 
 
-short extern_load_short(int STRIPE *arr_ptr, unsigned elem_size, unsigned offset) {
+short extern_load_short(int STRIPE *arr_ptr, unsigned elem_size, unsigned offset,
+        unsigned is_vol) {
 #ifdef TILEGROUP_DEBUG
     bsg_printf("\nCalling extern_load_short(0x%x, %d, %d)\n",
             (unsigned) arr_ptr, elem_size, offset);
 #endif
     short *ptr = (short *) get_ptr_val(arr_ptr, elem_size, offset);
-    return *ptr;
+    if (is_vol) {
+        return *((volatile short *) ptr);
+    } else {
+        return *ptr;
+    }
 }
 
 
-char extern_load_char(int STRIPE *arr_ptr, unsigned elem_size, unsigned offset) {
+char extern_load_char(int STRIPE *arr_ptr, unsigned elem_size, unsigned offset,
+        unsigned is_vol) {
 #ifdef TILEGROUP_DEBUG
     bsg_printf("\nCalling extern_load_char(0x%x, %d, %d)\n",
             (unsigned) arr_ptr, elem_size, offset);
 #endif
     char *ptr = (char *) get_ptr_val(arr_ptr, elem_size, offset);
-    return *ptr;
+    if (is_vol) {
+        return *((volatile char *) ptr);
+    } else {
+        return *ptr;
+    }
 }
 
 

--- a/software/manycore-llvm-pass/manycore/Manycore.cpp
+++ b/software/manycore-llvm-pass/manycore/Manycore.cpp
@@ -67,6 +67,7 @@ void replace_mem_op(Module &M, Instruction *op, bool isStore) {
     IRBuilder<> builder(op);
     Function *mem_op_fn;
     Value *ptr_op, *val_op;
+    bool isVol;
     unsigned value_elem_size;
     if (isStore) {
         errs() << "Replace Store begin\n";
@@ -76,6 +77,7 @@ void replace_mem_op(Module &M, Instruction *op, bool isStore) {
     } else {
         errs() << "Replace load begin\n";
         ptr_op = cast<LoadInst>(op)->getPointerOperand();
+        isVol = cast<LoadInst>(op)->isVolatile();
         value_elem_size = cast<LoadInst>(op)->getType()->getPrimitiveSizeInBits() / 8;
     }
     op->dump();
@@ -118,7 +120,11 @@ void replace_mem_op(Module &M, Instruction *op, bool isStore) {
         args_vector.push_back(ConstantInt::get(int32, struct_size, false));
         args_vector.push_back(ConstantInt::get(int32, struct_off, false));
     }
-    if (isStore) { args_vector.push_back(val_op);}
+    if (isStore) {
+        args_vector.push_back(val_op);
+    } else {
+        args_vector.push_back(ConstantInt::get(int32, isVol, false));
+    }
 
     ArrayRef<Value *> args = ArrayRef<Value *>(args_vector);
 

--- a/software/spmd/striped_hello/main.c
+++ b/software/spmd/striped_hello/main.c
@@ -79,7 +79,8 @@ void remote_load_store_test(int id) {
     int other_id = (id) ? 0 : 3;
     for (int i = 0; i < N; i++) {
         A[i][other_id] = (other_id * 2) + i * 5;
-        while (A[i][id] != (id * 2) + i * 5);
+        volatile int STRIPE *my_val = &A[i][id];
+        while (*my_val != (id * 2) + i * 5);
     }
     bsg_printf("Passed remote_load_store_test; id = %d\n", id);
 }
@@ -127,10 +128,10 @@ int main()
 
     int bsg_id = bsg_x * bsg_tiles_X + bsg_y;
 
-    if ((bsg_x == 0) && (bsg_y == 0)) {
+    if (bsg_id == 0) {
         remote_load_store_test(bsg_id);
     }
-    if ((bsg_x == bsg_tiles_X-1) && (bsg_y == bsg_tiles_Y-1)) {
+    if (bsg_id == 3) {
         remote_load_store_test(bsg_id);
 
         indexing_test();


### PR DESCRIPTION
This fixes the issue with the `striped_hello` spmd test timing out (#114) by making the LLVM pass respect the programmer's use of `volatile`, as well as fixing an issue where the test wasn't agnostic to manycore size.