### PR TITLE
Parameterized HW tracing of Branch & JALR target-PCs

### DIFF
--- a/machines/4x4/Makefile.machine.include
+++ b/machines/4x4/Makefile.machine.include
@@ -8,3 +8,4 @@ BSG_MACHINE_DRAM_BANK_SIZE_WORDS      = 134217728
 BSG_MACHINE_DRAM_INCLUDED             = 1
 BSG_MACHINE_MAX_EPA_WIDTH             = 28
 BSG_MACHINE_MEM_CFG                   = e_mem_cfg_default
+BSG_MACHINE_BRANCH_TRACE_EN           = 0

--- a/machines/9x15/Makefile.machine.include
+++ b/machines/9x15/Makefile.machine.include
@@ -8,3 +8,4 @@ BSG_MACHINE_DRAM_BANK_SIZE_WORDS      = 33554432
 BSG_MACHINE_DRAM_INCLUDED             = 1
 BSG_MACHINE_MAX_EPA_WIDTH             = 28
 BSG_MACHINE_MEM_CFG                   = e_mem_cfg_default
+BSG_MACHINE_BRANCH_TRACE_EN           = 0

--- a/machines/Makefile
+++ b/machines/Makefile
@@ -41,6 +41,7 @@ define set_machine_variables
 	$(eval VCS_DEFINES += +define+BSG_MACHINE_DRAM_INCLUDED=${BSG_MACHINE_DRAM_INCLUDED})
 	$(eval VCS_DEFINES += +define+BSG_MACHINE_MAX_EPA_WIDTH=${BSG_MACHINE_MAX_EPA_WIDTH})
 	$(eval VCS_DEFINES += +define+BSG_MACHINE_MEM_CFG=${BSG_MACHINE_MEM_CFG})
+	$(eval VCS_DEFINES += +define+BSG_MACHINE_BRANCH_TRACE_EN=${BSG_MACHINE_BRANCH_TRACE_EN})
 endef
 
 %/simv : %/Makefile.machine.include $(VSOURCES) $(VINCLUDES) $(VHEADERS) 

--- a/machines/arch_filelist.mk
+++ b/machines/arch_filelist.mk
@@ -12,6 +12,7 @@ VHEADERS += $(BASEJUMP_STL_DIR)/bsg_misc/bsg_defines.v
 VHEADERS += $(BASEJUMP_STL_DIR)/bsg_noc/bsg_noc_pkg.v
 VHEADERS += $(BASEJUMP_STL_DIR)/bsg_cache/bsg_cache_pkg.v
 VHEADERS += $(BASEJUMP_STL_DIR)/bsg_fpu/bsg_fpu_pkg.v
+VHEADERS += $(BSG_MANYCORE_DIR)/v/bsg_manycore_addr_pkg.v
 
 VSOURCES += $(BASEJUMP_STL_DIR)/bsg_misc/bsg_less_than.v
 VSOURCES += $(BASEJUMP_STL_DIR)/bsg_misc/bsg_reduce.v

--- a/software/bsg_manycore_lib/bsg_manycore.h
+++ b/software/bsg_manycore_lib/bsg_manycore.h
@@ -59,6 +59,8 @@ typedef volatile void *bsg_remote_void_ptr;
 #define bsg_print_time()   do {  bsg_remote_int_ptr ptr = bsg_remote_ptr_io(IO_X_INDEX,0xEAD4); *ptr = ((bsg_y << 16) + bsg_x); } while(0)
 
 #define bsg_putchar( c )       do {  bsg_remote_uint8_ptr ptr = (bsg_remote_uint8_ptr) bsg_remote_ptr_io(IO_X_INDEX,0xEADC); *ptr = c; } while(0)
+#define bsg_putchar_err( c )       do {  bsg_remote_uint8_ptr ptr = (bsg_remote_uint8_ptr) bsg_remote_ptr_io(IO_X_INDEX,0xEEE0); *ptr = c; } while(0)
+
 static inline void bsg_print_int(int i)
 {
         bsg_remote_int_ptr ptr = (bsg_remote_int_ptr)bsg_remote_ptr_io(IO_X_INDEX,0xEAE0);

--- a/software/spmd/hello/main.c
+++ b/software/spmd/hello/main.c
@@ -33,6 +33,7 @@ int main()
   *************************************************************************/
   if ((__bsg_x == bsg_tiles_X-1) && (__bsg_y == bsg_tiles_Y-1)) {
 
+     /* STDOUT */
      bsg_printf("\nManycore>> Hello from core %d, %d in group origin=(%d,%d).\n", \
                         __bsg_x, __bsg_y, __bsg_grp_org_x, __bsg_grp_org_y);
 
@@ -40,6 +41,15 @@ int main()
      for(i=0; i<4; i++)
         bsg_printf("%08x,",data[i]);
      bsg_printf("\n\n");
+
+     /* STDERR */
+     char stderr_msg[] = "\nManycore stderr>> Hello!\n\n";
+     int i = 0;
+
+     while(stderr_msg[i]) {
+       bsg_putchar_err(stderr_msg[i]);
+       i++;
+     }
 
   /************************************************************************
     Terminates the Simulation

--- a/testbenches/common/v/bsg_nonsynth_manycore_monitor.v
+++ b/testbenches/common/v/bsg_nonsynth_manycore_monitor.v
@@ -6,6 +6,10 @@
 `include "bsg_manycore_packet.vh"
 
 module bsg_nonsynth_manycore_monitor
+ 
+  // Import address parameters
+  import bsg_manycore_addr_pkg::*;
+
   #(parameter x_cord_width_p="inv"
     , parameter y_cord_width_p="inv"
     , parameter addr_width_p="inv"
@@ -153,22 +157,22 @@ module bsg_nonsynth_manycore_monitor
     if (~reset_i) begin
       if (v_i & we_i) begin
         if (~addr_i[addr_width_p-1]) begin
-          if (epa_addr == 16'hEAD0) begin
+          if (epa_addr == bsg_finish_epa_gp) begin
             $display("[INFO][MONITOR] RECEIVED BSG_FINISH PACKET from tile y,x=%2d,%2d, data=%x, time=%0t",
               src_y_cord_i, src_x_cord_i, data_i, $time);
             $finish;
           end
-          else if (epa_addr == 16'hEAD4) begin
+          else if (epa_addr == bsg_time_epa_gp) begin
             $display("[INFO][MONITOR] RECEIVED TIME BSG_PACKET from tile y,x=%2d,%2d, data=%x, time=%0t",
               src_y_cord_i, src_x_cord_i, data_i, $time);
           end
-          else if (epa_addr == 16'hEAD8) begin
+          else if (epa_addr == bsg_fail_epa_gp) begin
             $display("[INFO][MONITOR] RECEIVED BSG_FAIL PACKET from tile y,x=%2d,%2d, data=%x, time=%0t",
               src_y_cord_i, src_x_cord_i, data_i, $time);
             $finish;
           end
-          else if (epa_addr == 16'hEADC || epa_addr == 16'hEEE0) begin
-            out_fd = (epa_addr == 16'hEADC) 
+          else if (epa_addr == bsg_stdout_epa_gp || epa_addr == bsg_stderr_epa_gp) begin
+            out_fd = (epa_addr == bsg_stdout_epa_gp) 
                        ? 32'h8000_0001  // 0xEADC => stdout
                        : 32'h8000_0002; // 0xEEE0 => stderr
 
@@ -178,13 +182,13 @@ module bsg_nonsynth_manycore_monitor
               end
             end
           end
-          else if (epa_addr == 16'hEEE4) begin
+          else if (epa_addr == bsg_branch_trace_epa_gp) begin
             // Branch and JALR trace
             $fwrite('h8000_0002, "BSG_BRANCH_TRACE t=%0t x=%0d y=%0d target=%x\n"
                       , $time, src_x_cord_i, src_y_cord_i, data_i
                    );
           end
-          else if (epa_addr == 16'h0D0C) begin
+          else if (epa_addr == bsg_print_stat_epa_gp) begin
             $display("[INFO][MONITOR] RECEIVED PRINT_STAT PACKET from tile y,x=%2d,%2d, data=%x, time=%0t",
               src_y_cord_i, src_x_cord_i, data_i, $time);      
           end
@@ -205,7 +209,7 @@ module bsg_nonsynth_manycore_monitor
 
   // print stat trigger
   //
-  assign print_stat_v_o = v_i & (epa_addr == 16'hD0C);
+  assign print_stat_v_o = v_i & (epa_addr == bsg_print_stat_epa_gp);
   assign print_stat_tag_o = data_i;
 
 endmodule

--- a/testbenches/common/v/bsg_nonsynth_manycore_monitor.v
+++ b/testbenches/common/v/bsg_nonsynth_manycore_monitor.v
@@ -178,6 +178,12 @@ module bsg_nonsynth_manycore_monitor
               end
             end
           end
+          else if (epa_addr == 16'hEEE4) begin
+            // Branch and JALR trace
+            $fwrite('h8000_0002, "BSG_BRANCH_TRACE t=%0t x=%0d y=%0d target=%x\n"
+                      , $time, src_x_cord_i, src_y_cord_i, data_i
+                   );
+          end
           else if (epa_addr == 16'h0D0C) begin
             $display("[INFO][MONITOR] RECEIVED PRINT_STAT PACKET from tile y,x=%2d,%2d, data=%x, time=%0t",
               src_y_cord_i, src_x_cord_i, data_i, $time);      

--- a/testbenches/common/v/bsg_nonsynth_manycore_monitor.v
+++ b/testbenches/common/v/bsg_nonsynth_manycore_monitor.v
@@ -145,6 +145,7 @@ module bsg_nonsynth_manycore_monitor
   //
   logic [15:0] epa_addr;
   assign epa_addr = {addr_i[13:0], 2'b00};
+  integer out_fd;
 
 
 
@@ -166,10 +167,14 @@ module bsg_nonsynth_manycore_monitor
               src_y_cord_i, src_x_cord_i, data_i, $time);
             $finish;
           end
-          else if (epa_addr == 16'hEADC) begin
+          else if (epa_addr == 16'hEADC || epa_addr == 16'hEEE0) begin
+            out_fd = (epa_addr == 16'hEADC) 
+                       ? 32'h8000_0001  // 0xEADC => stdout
+                       : 32'h8000_0002; // 0xEEE0 => stderr
+
             for (integer i = 0; i < 4; i++) begin
               if (mask_i[i]) begin
-                $write("%c", data_i[i*8+:8]);
+                $fwrite(out_fd, "%c", data_i[i*8+:8]);
               end
             end
           end

--- a/testbenches/common/v/spmd_testbench.v
+++ b/testbenches/common/v/spmd_testbench.v
@@ -17,6 +17,7 @@ module spmd_testbench;
   parameter bsg_dram_included_p = `BSG_MACHINE_DRAM_INCLUDED;
   parameter bsg_max_epa_width_p = `BSG_MACHINE_MAX_EPA_WIDTH;
   parameter bsg_mem_cfg_e bsg_mem_cfg_p = `BSG_MACHINE_MEM_CFG;
+  parameter bsg_branch_trace_en_p = `BSG_MACHINE_BRANCH_TRACE_EN;
 
   // constant params
 
@@ -28,6 +29,7 @@ module spmd_testbench;
   parameter icache_tag_width_p = 12;
   parameter epa_byte_addr_width_p = 18;
   parameter load_id_width_p = 12;
+  parameter branch_trace_epa_p = 32'h4000_eee4;
 
   parameter axi_id_width_p = 6;
   parameter axi_addr_width_p = 64;
@@ -115,6 +117,8 @@ module spmd_testbench;
     ,.dram_ch_addr_width_p(dram_ch_addr_width_p)
     ,.num_tiles_x_p(bsg_global_x_p)
     ,.num_tiles_y_p(bsg_global_y_p)
+    ,.branch_trace_epa_p(branch_trace_epa_p)
+    ,.branch_trace_en_p(bsg_branch_trace_en_p)
   ) DUT (
     .clk_i(clk)
     ,.reset_i(reset)

--- a/testbenches/common/v/spmd_testbench.v
+++ b/testbenches/common/v/spmd_testbench.v
@@ -29,7 +29,6 @@ module spmd_testbench;
   parameter icache_tag_width_p = 12;
   parameter epa_byte_addr_width_p = 18;
   parameter load_id_width_p = 12;
-  parameter branch_trace_epa_p = 32'h4000_eee4;
 
   parameter axi_id_width_p = 6;
   parameter axi_addr_width_p = 64;
@@ -117,7 +116,6 @@ module spmd_testbench;
     ,.dram_ch_addr_width_p(dram_ch_addr_width_p)
     ,.num_tiles_x_p(bsg_global_x_p)
     ,.num_tiles_y_p(bsg_global_y_p)
-    ,.branch_trace_epa_p(branch_trace_epa_p)
     ,.branch_trace_en_p(bsg_branch_trace_en_p)
   ) DUT (
     .clk_i(clk)

--- a/v/bsg_manycore.v
+++ b/v/bsg_manycore.v
@@ -91,7 +91,6 @@ module bsg_manycore
   , parameter IO_row_idx_p = 0
 
   // EPA parameter
-  , parameter branch_trace_epa_p = "inv" // EPA for branch/jalr trace on stderr
 
   // Enable branch/jalr trace
   , parameter branch_trace_en_p = 0
@@ -194,7 +193,6 @@ module bsg_manycore
                 .dram_ch_start_col_p ( dram_ch_start_col_p ),
                 .hetero_type_p( hetero_type_vec_p[r][c] ),
                 .debug_p(debug_p)
-                ,.branch_trace_epa_p(branch_trace_epa_p)
                 ,.branch_trace_en_p(branch_trace_en_p)
                 ,.num_tiles_x_p(num_tiles_x_p)
                 ,.vcache_block_size_in_words_p(vcache_block_size_in_words_p)

--- a/v/bsg_manycore.v
+++ b/v/bsg_manycore.v
@@ -90,6 +90,12 @@ module bsg_manycore
   //The IO router row index
   , parameter IO_row_idx_p = 0
 
+  // EPA parameter
+  , parameter branch_trace_epa_p = "inv" // EPA for branch/jalr trace on stderr
+
+  // Enable branch/jalr trace
+  , parameter branch_trace_en_p = 0
+
   , localparam x_cord_width_lp = `BSG_SAFE_CLOG2(num_tiles_x_p)
   , localparam y_cord_width_lp = `BSG_SAFE_CLOG2(num_tiles_y_p + extra_io_rows_p) // extra row for I/O at bottom of chip
   , localparam link_sif_width_lp =
@@ -188,6 +194,8 @@ module bsg_manycore
                 .dram_ch_start_col_p ( dram_ch_start_col_p ),
                 .hetero_type_p( hetero_type_vec_p[r][c] ),
                 .debug_p(debug_p)
+                ,.branch_trace_epa_p(branch_trace_epa_p)
+                ,.branch_trace_en_p(branch_trace_en_p)
                 ,.num_tiles_x_p(num_tiles_x_p)
                 ,.vcache_block_size_in_words_p(vcache_block_size_in_words_p)
                 ,.vcache_sets_p(vcache_sets_p)

--- a/v/bsg_manycore_addr_pkg.v
+++ b/v/bsg_manycore_addr_pkg.v
@@ -1,0 +1,29 @@
+/**
+ *    bsg_manycore_addr_pkg.v
+ *
+ *    Manycore address constants
+ */
+
+package bsg_manycore_addr_pkg;
+
+  // NPA prefixes
+  parameter bsg_dram_npa_prefix_gp = 32'h8000_0000;
+  parameter bsg_io_npa_prefix_gp   = 32'h4000_0000;
+
+  // IO EPA (word address)
+  parameter bsg_finish_epa_gp       = 16'head0;
+  parameter bsg_time_epa_gp         = 16'head4;
+  parameter bsg_fail_epa_gp         = 16'head8;
+  parameter bsg_stdout_epa_gp       = 16'headc;
+  parameter bsg_stderr_epa_gp       = 16'heee0;
+  parameter bsg_branch_trace_epa_gp = 16'heee4;
+  parameter bsg_print_stat_epa_gp   = 16'h0d0c;
+
+  parameter bsg_finish_npa_gp       = bsg_io_npa_prefix_gp | 32'(bsg_finish_epa_gp      );
+  parameter bsg_time_npa_gp         = bsg_io_npa_prefix_gp | 32'(bsg_time_epa_gp        );
+  parameter bsg_fail_npa_gp         = bsg_io_npa_prefix_gp | 32'(bsg_fail_epa_gp        );
+  parameter bsg_stdout_npa_gp       = bsg_io_npa_prefix_gp | 32'(bsg_stdout_epa_gp      );
+  parameter bsg_stderr_npa_gp       = bsg_io_npa_prefix_gp | 32'(bsg_stderr_epa_gp      );
+  parameter bsg_branch_trace_npa_gp = bsg_io_npa_prefix_gp | 32'(bsg_branch_trace_epa_gp);
+
+endpackage;

--- a/v/bsg_manycore_hetero_socket.v
+++ b/v/bsg_manycore_hetero_socket.v
@@ -14,34 +14,36 @@
 
 `include "bsg_manycore_packet.vh"
 
-`define HETERO_TYPE_MACRO(BMC_TYPE,BMC_TYPE_MODULE)             \
-   if (hetero_type_p == (BMC_TYPE))                             \
-     begin: h                                                   \
-        BMC_TYPE_MODULE #(.x_cord_width_p(x_cord_width_p)       \
-                          ,.y_cord_width_p(y_cord_width_p)      \
-                          ,.data_width_p(data_width_p)          \
-                          ,.addr_width_p(addr_width_p)          \
-                          ,.load_id_width_p(load_id_width_p)    \
-                          ,.dmem_size_p (dmem_size_p )          \
-                          ,.epa_byte_addr_width_p(epa_byte_addr_width_p)  \
-                          ,.dram_ch_addr_width_p ( dram_ch_addr_width_p )  \
-                          ,.dram_ch_start_col_p  ( dram_ch_start_col_p) \
-                          ,.vcache_size_p(vcache_size_p) \
+`define HETERO_TYPE_MACRO(BMC_TYPE,BMC_TYPE_MODULE)                                    \
+   if (hetero_type_p == (BMC_TYPE))                                                    \
+     begin: h                                                                          \
+        BMC_TYPE_MODULE #(.x_cord_width_p(x_cord_width_p)                              \
+                          ,.y_cord_width_p(y_cord_width_p)                             \
+                          ,.data_width_p(data_width_p)                                 \
+                          ,.addr_width_p(addr_width_p)                                 \
+                          ,.load_id_width_p(load_id_width_p)                           \
+                          ,.dmem_size_p (dmem_size_p )                                 \
+                          ,.epa_byte_addr_width_p(epa_byte_addr_width_p)               \
+                          ,.dram_ch_addr_width_p ( dram_ch_addr_width_p )              \
+                          ,.dram_ch_start_col_p  ( dram_ch_start_col_p)                \
+                          ,.vcache_size_p(vcache_size_p)                               \
                           ,.vcache_block_size_in_words_p(vcache_block_size_in_words_p) \
-                          ,.vcache_sets_p(vcache_sets_p) \
-                          ,.debug_p(debug_p)                    \
-			                    ,.icache_entries_p(icache_entries_p)            \
-                          ,.icache_tag_width_p (icache_tag_width_p) \
-            		          ,.max_out_credits_p(max_out_credits_p)\
-                          ,.num_tiles_x_p(num_tiles_x_p)    \
-                          ) z                                   \
-          (.clk_i                                               \
-           ,.reset_i                                            \
-           ,.link_sif_i                                         \
-           ,.link_sif_o                                         \
-           ,.my_x_i                                             \
-           ,.my_y_i                                             \
-           );                                                   \
+                          ,.vcache_sets_p(vcache_sets_p)                               \
+                          ,.debug_p(debug_p)                                           \
+                          ,.branch_trace_epa_p(branch_trace_epa_p)                             \
+                          ,.branch_trace_en_p(branch_trace_en_p)                                 \
+			                    ,.icache_entries_p(icache_entries_p)                         \
+                          ,.icache_tag_width_p (icache_tag_width_p)                    \
+            		          ,.max_out_credits_p(max_out_credits_p)                       \
+                          ,.num_tiles_x_p(num_tiles_x_p)                               \
+                          ) z                                                          \
+          (.clk_i                                                                      \
+           ,.reset_i                                                                   \
+           ,.link_sif_i                                                                \
+           ,.link_sif_o                                                                \
+           ,.my_x_i                                                                    \
+           ,.my_y_i                                                                    \
+           );                                                                          \
      end
 
 module bsg_manycore_hetero_socket
@@ -58,6 +60,8 @@ module bsg_manycore_hetero_socket
     , parameter dram_ch_start_col_p = 0
     , parameter vcache_size_p = "inv"
     , parameter debug_p = 0
+    , parameter branch_trace_epa_p = "inv"
+    , parameter branch_trace_en_p = 0
     , parameter max_out_credits_p = 200
     , parameter hetero_type_p = 0
     , parameter num_tiles_x_p="inv"

--- a/v/bsg_manycore_hetero_socket.v
+++ b/v/bsg_manycore_hetero_socket.v
@@ -30,7 +30,6 @@
                           ,.vcache_block_size_in_words_p(vcache_block_size_in_words_p) \
                           ,.vcache_sets_p(vcache_sets_p)                               \
                           ,.debug_p(debug_p)                                           \
-                          ,.branch_trace_epa_p(branch_trace_epa_p)                             \
                           ,.branch_trace_en_p(branch_trace_en_p)                                 \
 			                    ,.icache_entries_p(icache_entries_p)                         \
                           ,.icache_tag_width_p (icache_tag_width_p)                    \
@@ -60,7 +59,6 @@ module bsg_manycore_hetero_socket
     , parameter dram_ch_start_col_p = 0
     , parameter vcache_size_p = "inv"
     , parameter debug_p = 0
-    , parameter branch_trace_epa_p = "inv"
     , parameter branch_trace_en_p = 0
     , parameter max_out_credits_p = 200
     , parameter hetero_type_p = 0

--- a/v/bsg_manycore_tile.v
+++ b/v/bsg_manycore_tile.v
@@ -32,7 +32,6 @@ module bsg_manycore_tile
     , parameter hetero_type_p = 0
     , parameter debug_p = 0
 
-    , parameter branch_trace_epa_p = "inv"
     , parameter branch_trace_en_p = 0
 
     , localparam link_sif_width_lp =
@@ -101,7 +100,6 @@ module bsg_manycore_tile
     ,.vcache_block_size_in_words_p(vcache_block_size_in_words_p)
     ,.vcache_sets_p(vcache_sets_p)
 
-    ,.branch_trace_epa_p(branch_trace_epa_p)
     ,.branch_trace_en_p(branch_trace_en_p)
 
     ,.debug_p(debug_p)

--- a/v/bsg_manycore_tile.v
+++ b/v/bsg_manycore_tile.v
@@ -32,6 +32,9 @@ module bsg_manycore_tile
     , parameter hetero_type_p = 0
     , parameter debug_p = 0
 
+    , parameter branch_trace_epa_p = "inv"
+    , parameter branch_trace_en_p = 0
+
     , localparam link_sif_width_lp =
     `bsg_manycore_link_sif_width(addr_width_p,data_width_p,x_cord_width_p,y_cord_width_p,
       load_id_width_p)
@@ -97,6 +100,9 @@ module bsg_manycore_tile
     ,.num_tiles_x_p(num_tiles_x_p)
     ,.vcache_block_size_in_words_p(vcache_block_size_in_words_p)
     ,.vcache_sets_p(vcache_sets_p)
+
+    ,.branch_trace_epa_p(branch_trace_epa_p)
+    ,.branch_trace_en_p(branch_trace_en_p)
 
     ,.debug_p(debug_p)
   ) proc (

--- a/v/vanilla_bean/bsg_manycore_proc_vanilla.v
+++ b/v/vanilla_bean/bsg_manycore_proc_vanilla.v
@@ -32,6 +32,10 @@ module bsg_manycore_proc_vanilla
     , parameter proc_fifo_els_p = 4
     , parameter debug_p = 1
 
+    , parameter branch_trace_epa_p = "inv"
+    
+    , parameter branch_trace_en_p = 0
+
     , localparam credit_counter_width_lp=$clog2(max_out_credits_p+1)
     , localparam icache_addr_width_lp = `BSG_SAFE_CLOG2(icache_entries_p)
     , localparam dmem_addr_width_lp = `BSG_SAFE_CLOG2(dmem_size_p)
@@ -289,6 +293,8 @@ module bsg_manycore_proc_vanilla
     ,.icache_tag_width_p(icache_tag_width_p)
     ,.x_cord_width_p(x_cord_width_p)
     ,.y_cord_width_p(y_cord_width_p)
+    ,.branch_trace_epa_p(branch_trace_epa_p)
+    ,.branch_trace_en_p(branch_trace_en_p)
   ) vcore (
     .clk_i(clk_i)
     ,.reset_i(reset_i | freeze)

--- a/v/vanilla_bean/bsg_manycore_proc_vanilla.v
+++ b/v/vanilla_bean/bsg_manycore_proc_vanilla.v
@@ -32,7 +32,6 @@ module bsg_manycore_proc_vanilla
     , parameter proc_fifo_els_p = 4
     , parameter debug_p = 1
 
-    , parameter branch_trace_epa_p = "inv"
     
     , parameter branch_trace_en_p = 0
 
@@ -293,7 +292,6 @@ module bsg_manycore_proc_vanilla
     ,.icache_tag_width_p(icache_tag_width_p)
     ,.x_cord_width_p(x_cord_width_p)
     ,.y_cord_width_p(y_cord_width_p)
-    ,.branch_trace_epa_p(branch_trace_epa_p)
     ,.branch_trace_en_p(branch_trace_en_p)
   ) vcore (
     .clk_i(clk_i)

--- a/v/vanilla_bean/lsu.v
+++ b/v/vanilla_bean/lsu.v
@@ -14,12 +14,13 @@
 
 
 module lsu
+
+  // Import address parameters
+  import bsg_manycore_addr_pkg::*;
+
   #(parameter data_width_p="inv"
     , parameter pc_width_p="inv"
     , parameter dmem_size_p="inv"
-
-    // EPA parameters
-    , parameter branch_trace_epa_p="inv"
 
     // Enables branch & jalr target-addr stream on stderr
     , parameter branch_trace_en_p="inv"
@@ -72,7 +73,7 @@ module lsu
   logic [data_width_p-1:0] miss_addr;
 
   assign mem_addr = exe_rs1_i + mem_offset_i;
-  assign miss_addr = (pc_plus4_i - 'h4) | 32'h80000000;
+  assign miss_addr = (pc_plus4_i - 'h4) | bsg_dram_npa_prefix_gp;
 
   // store data mask
   //
@@ -157,7 +158,7 @@ module lsu
     swap_aq: exe_decode_i.op_is_swap_aq,
     swap_rl: exe_decode_i.op_is_swap_rl,
     mask: store_mask,
-    addr: (stream_target_pc ? branch_trace_epa_p : (icache_miss_i ? miss_addr : mem_addr)),
+    addr: (stream_target_pc ? bsg_branch_trace_npa_gp : (icache_miss_i ? miss_addr : mem_addr)),
     payload: payload
   };
 

--- a/v/vanilla_bean/vanilla_core.v
+++ b/v/vanilla_bean/vanilla_core.v
@@ -7,6 +7,10 @@
 `include "parameters.vh"
 
 module vanilla_core
+
+  // Import address parameters
+  import bsg_manycore_addr_pkg::*;
+
   #(parameter data_width_p="inv"
     , parameter dmem_size_p="inv"
     
@@ -15,9 +19,6 @@ module vanilla_core
 
     , parameter x_cord_width_p="inv"
     , parameter y_cord_width_p="inv"
-
-    // EPA parameters
-    , parameter branch_trace_epa_p="inv"
 
     // Enables branch & jalr target-addr stream on stderr
     , parameter branch_trace_en_p=0
@@ -322,7 +323,7 @@ module vanilla_core
 
   // synopsys translate_off
   logic [data_width_p-1:0] exe_pc;
-  assign exe_pc = (exe_r.pc_plus4 - 'd4) | 32'h80000000;
+  assign exe_pc = (exe_r.pc_plus4 - 'd4) | bsg_dram_npa_prefix_gp;
   // synopsys translate_on
 
   // EXE forwarding muxes
@@ -497,7 +498,6 @@ module vanilla_core
     .data_width_p(data_width_p)
     ,.pc_width_p(pc_width_lp)
     ,.dmem_size_p(dmem_size_p)
-    ,.branch_trace_epa_p(branch_trace_epa_p)
     ,.branch_trace_en_p(branch_trace_en_p)
   ) lsu0 (
     .exe_decode_i(exe_r.decode)


### PR DESCRIPTION
- Mapped EPA=0xEEE0 to stderr to have separate streams for program output and trace. Also, Newlib std streams could be separated.
- New bsg_manycore_lib macro bsg_putchar_err to write char to stderr stream.