### PR TITLE
Simple program to test fast heavy printing

### DIFF
--- a/software/spmd/putchar_stream/Makefile
+++ b/software/spmd/putchar_stream/Makefile
@@ -1,0 +1,19 @@
+bsg_tiles_org_X =0
+bsg_tiles_org_Y =1
+bsg_tiles_X = 1
+bsg_tiles_Y = 1
+
+
+all: main.run
+
+OBJECT_FILES=main.o
+
+include ../Makefile.include
+
+main.riscv: $(OBJECT_FILES) $(SPMD_COMMON_OBJECTS) $(BSG_MANYCORE_LIB) crt.o
+	$(RISCV_LINK) $(OBJECT_FILES) $(SPMD_COMMON_OBJECTS) -L. -l:$(BSG_MANYCORE_LIB) -o $@ $(RISCV_LINK_OPTS)
+
+
+main.o: Makefile
+
+include ../../mk/Makefile.tail_rules

--- a/software/spmd/putchar_stream/main.c
+++ b/software/spmd/putchar_stream/main.c
@@ -1,0 +1,18 @@
+#include "bsg_manycore.h"
+#include "bsg_set_tile_x_y.h"
+
+int main() {
+  bsg_set_tile_x_y();
+
+  int stream_len = 1000;
+
+  bsg_putchar('\n');
+
+  for(int i=0; i<stream_len; i++) {
+    bsg_putchar('$');
+  }
+
+  bsg_putchar('\n');
+
+  bsg_finish();
+}


### PR DESCRIPTION
A simple program to push the IO interface to limits -- fills up fifos in IO interface and network routers and cause a stall in the core. This uncovered a minor issue in bsg_f1's fifo interface where credits are being returned even when the fifo is full.