### PR TITLE
Removed greenlight submodule

### DIFF
--- a/software/spmd/specint2000/Makefile
+++ b/software/spmd/specint2000/Makefile
@@ -4,13 +4,17 @@ BENCHMARKS+= 175.vpr
 
 RUNS = $(patsubst %,%.run,$(BENCHMARKS))
 
-all: $(RUNS)
+all: checkout
+	$(MAKE) $(RUNS)
 
 %.run:
-	make -f Makefile.$*
-	make -f Makefile.$* clean
+	$(MAKE) -f Makefile.$*
+	$(MAKE) -f Makefile.$* clean
+
+checkout:
+	git clone git@bitbucket.org:taylor-bsg/greenlight.git 2> /dev/null || (cd greenlight ; git pull)
 
 clean:
 	for benchmark in $(BENCHMARKS) ; do \
-	make -f Makefile.$$benchmark clean; \
+	$(MAKE) -f Makefile.$$benchmark clean; \
 	done;

--- a/software/spmd/specint2000/Makefile.000.plain
+++ b/software/spmd/specint2000/Makefile.000.plain
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL = all
 
-BENCHMARK_DIR = $(BSG_MANYCORE_DIR)/imports/greenlight/benchmarks/spec2000/CINT2000/000.test
+BENCHMARK_DIR = $(BENCHMARK_TOP)/000.test
 BENCHMARK_OBJS = raw.o plain.o
 BENCHMARK_INPS =
 PROG_NAME = plain

--- a/software/spmd/specint2000/Makefile.000.test
+++ b/software/spmd/specint2000/Makefile.000.test
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL = all
 
-BENCHMARK_DIR = $(BSG_MANYCORE_DIR)/imports/greenlight/benchmarks/spec2000/CINT2000/000.test
+BENCHMARK_DIR = $(BENCHMARK_TOP)/000.test
 BENCHMARK_OBJS = raw.o test.o
 BENCHMARK_INPS =
 PROG_NAME = test

--- a/software/spmd/specint2000/Makefile.175.vpr
+++ b/software/spmd/specint2000/Makefile.175.vpr
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL = all
 
-BENCHMARK_DIR = $(BSG_MANYCORE_DIR)/imports/greenlight/benchmarks/spec2000/CINT2000/175.vpr
+BENCHMARK_DIR = $(BENCHMARK_TOP)/175.vpr
 
 PROG_NAME = vpr
 

--- a/software/spmd/specint2000/Makefile.300.twolf
+++ b/software/spmd/specint2000/Makefile.300.twolf
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL = all
 
-BENCHMARK_DIR = $(BSG_MANYCORE_DIR)/imports/greenlight/benchmarks/spec2000/CINT2000/300.twolf
+BENCHMARK_DIR = $(BENCHMARK_TOP)/300.twolf
 
 PROG_NAME = twolf
 

--- a/software/spmd/specint2000/Makefile.common
+++ b/software/spmd/specint2000/Makefile.common
@@ -3,6 +3,8 @@ bsg_tiles_Y = 1
 BSG_FPU_OP = 0
 BSG_NEWLIB = 1
 
+BENCHMARK_TOP = $(BSG_MANYCORE_DIR)/software/spmd/specint2000/greenlight/benchmarks/spec2000/CINT2000
+
 OBJECT_FILES := $(BENCHMARK_OBJS)
 IN_FILES := $(BENCHMARK_INPS)
 

--- a/software/spmd/specint2000/README.md
+++ b/software/spmd/specint2000/README.md
@@ -1,6 +1,8 @@
 SPECInt2000 Benchamarks on Manycore
 ===================================
 
+- Initial setup:
+	`make checkout`
 - Benchmarks imported from RAW's greenlight repo
 - `rawlib/`: Since `greenlight` was originally written for raw, it uses 
   some raw library functions to run spec benchamrks. This folder


### PR DESCRIPTION
Removed greenlight submodule as it is not open sourced. And added a rule in specint Makefile to clone it when necessary.