### PR TITLE
Fix toolchain-building script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,5 +11,5 @@ machines:
 	make -C machines/
 
 tools:
-	make -C software/spmd/riscv-tools checkout-all
-	make -C software/spmd/riscv-tools build-all
+	make -C software/riscv-tools checkout-all
+	make -C software/riscv-tools build-all

--- a/software/riscv-tools/Makefile
+++ b/software/riscv-tools/Makefile
@@ -76,7 +76,7 @@ replace-newlib:
 	cd $(TOOLCHAIN_REPO) && git config --file=.gitmodules submodule.riscv-newlib.url $(BSG_NEWLIB_URL)
 	cd $(TOOLCHAIN_REPO) && git config --file=.gitmodules submodule.riscv-newlib.branch $(BSG_NEWLIB_BRANCH)
 	cd $(TOOLCHAIN_REPO) && git submodule sync
-	cd $(TOOLCHAIN_REPO) && git submodule update --init --recursive --remote riscv-newlib
+	cd $(TOOLCHAIN_REPO) && git submodule update --init --recursive riscv-newlib
 
 checkout-spike:
 	@echo "====================================="


### PR DESCRIPTION
- Fix building toolchain scripts. The correct toolchain path is
  'software/riscv-tools' instead of 'software/spmd/riscv-tools'.
- Remove '--remote' from git submodule command in
  'software/riscv-tools/Makefile' for compatability with Centos 6.
  '--remote' only works with git version 2.x.
  Git version 1.7x such as the one on Centos 6 does not have this options.