### PR TITLE
Minimal test to reproduce expf issue

### DIFF
--- a/software/spmd/expf/Makefile
+++ b/software/spmd/expf/Makefile
@@ -1,0 +1,35 @@
+BSG_ELF_DEFAULT_DATA_LOC = SHARED
+bsg_tiles_X = 1
+bsg_tiles_Y = 1
+BSG_NEWLIB = 1
+MAX_CYCLES=1000000
+
+ifdef SPIKE
+
+all: main.spike
+
+RISCV_GCC_EXTRA_OPTS += -D__spike__
+LINK_SCRIPT = $(BSG_MANYCORE_DIR)/software/spmd/common/spike.ld
+
+else
+
+all: main.run
+
+endif
+
+OBJECT_FILES=main.o
+
+ifdef DEBUG
+	RISCV_EXTRA_OPTS += -g
+	RISCV_EXTRA_OPTS += -O0
+endif
+
+include ../Makefile.include
+
+main.riscv: $(OBJECT_FILES) $(SPMD_COMMON_OBJECTS) $(BSG_MANYCORE_LIB) crt.o
+	$(RISCV_LINK) $(OBJECT_FILES) $(SPMD_COMMON_OBJECTS) -L. -l:$(BSG_MANYCORE_LIB) -o $@ $(RISCV_LINK_OPTS) -l:$(BSG_MANYCORE_LIB)
+
+
+main.o: Makefile
+
+include ../../mk/Makefile.tail_rules

--- a/software/spmd/expf/main.c
+++ b/software/spmd/expf/main.c
@@ -1,0 +1,17 @@
+#include <math.h>
+#include <stdio.h>
+
+float data = 3.4;
+
+int main() {
+  union {
+    int i;
+    float f;
+  } res;
+
+  res.f = expf(data);
+
+  printf("%x\n", res.i);
+
+  return 0;
+}


### PR DESCRIPTION
Test to compare manycore's expf result with Spike's result and they are mismatching! Seems to reproduce the FP issue concisely.

@tommydcjung You could use this to debug FP issue:

`make`: run this test on manycore
`make SPIKE=1`: run this Spike.

Fun fact: Spike result matches x86 result (bitwise)! x86 might be implementing ieee754 after all...