### PR TITLE
Revert "Fix toolchain-building script"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,5 +11,5 @@ machines:
 	make -C machines/
 
 tools:
-	make -C software/riscv-tools checkout-all
-	make -C software/riscv-tools build-all
+	make -C software/spmd/riscv-tools checkout-all
+	make -C software/spmd/riscv-tools build-all

--- a/software/riscv-tools/Makefile
+++ b/software/riscv-tools/Makefile
@@ -76,7 +76,7 @@ replace-newlib:
 	cd $(TOOLCHAIN_REPO) && git config --file=.gitmodules submodule.riscv-newlib.url $(BSG_NEWLIB_URL)
 	cd $(TOOLCHAIN_REPO) && git config --file=.gitmodules submodule.riscv-newlib.branch $(BSG_NEWLIB_BRANCH)
 	cd $(TOOLCHAIN_REPO) && git submodule sync
-	cd $(TOOLCHAIN_REPO) && git submodule update --init --recursive riscv-newlib
+	cd $(TOOLCHAIN_REPO) && git submodule update --init --recursive --remote riscv-newlib
 
 checkout-spike:
 	@echo "====================================="


### PR DESCRIPTION
This fix is not working on XOR. Reverting it to modify and make it work with newer versions.