### PR TITLE
Toolchain newlib patch

### DIFF
--- a/software/riscv-tools/Makefile
+++ b/software/riscv-tools/Makefile
@@ -81,7 +81,7 @@ replace-newlib:
 	cd $(TOOLCHAIN_REPO) && git config --file=.gitmodules submodule.riscv-newlib.branch $(BSG_NEWLIB_BRANCH)
 	cd $(TOOLCHAIN_REPO) && git apply ../$(BSG_NEWLIB_PATCH)
 	cd $(TOOLCHAIN_REPO) && git submodule sync
-	cd $(TOOLCHAIN_REPO) && git submodule update --init --recursive riscv-newlib
+	cd $(TOOLCHAIN_REPO) && git submodule update --remote riscv-newlib
 
 checkout-spike:
 	@echo "====================================="

--- a/software/riscv-tools/Makefile
+++ b/software/riscv-tools/Makefile
@@ -29,10 +29,12 @@
 
 TOOLCHAIN_REPO=riscv-gnu-toolchain
 TOOLCHAIN_URL=https://github.com/riscv/$(TOOLCHAIN_REPO)
+TOOLCHAIN_VERSION=a03290eab661e2aa58288ad164f908bbbcc2169c
 DEPENDS_DIR=$(CURDIR)/depends
 
 BSG_NEWLIB_URL=https://github.com/bespoke-silicon-group/bsg_newlib_dramfs.git
 BSG_NEWLIB_BRANCH=dramfs
+BSG_NEWLIB_PATCH=newlib.patch
 
 SPIKE_REPO=riscv-isa-sim
 SPIKE_URL=https://github.com/riscv/riscv-isa-sim.git
@@ -70,11 +72,14 @@ checkout-repos:
 	@echo "Cloning riscv-toolchain repo..."
 	@echo "====================================="
 	@rm -rf $(TOOLCHAIN_REPO);
-	git clone --recursive $(TOOLCHAIN_URL);
+	git clone $(TOOLCHAIN_URL);
+	cd $(TOOLCHAIN_REPO) && git checkout $(TOOLCHAIN_VERSION);
+	cd $(TOOLCHAIN_REPO) && git submodule update --init --recursive;
 
 replace-newlib:
 	cd $(TOOLCHAIN_REPO) && git config --file=.gitmodules submodule.riscv-newlib.url $(BSG_NEWLIB_URL)
 	cd $(TOOLCHAIN_REPO) && git config --file=.gitmodules submodule.riscv-newlib.branch $(BSG_NEWLIB_BRANCH)
+	cd $(TOOLCHAIN_REPO) && git apply ../$(BSG_NEWLIB_PATCH)
 	cd $(TOOLCHAIN_REPO) && git submodule sync
 	cd $(TOOLCHAIN_REPO) && git submodule update --init --recursive riscv-newlib
 

--- a/software/riscv-tools/Makefile
+++ b/software/riscv-tools/Makefile
@@ -27,10 +27,15 @@
 #
 .DEFAULT_GOAL := help
 
+TARGET_ARCH   := rv32imaf
+TARGET_ABI    := ilp32 # TODO: Test ilp32f for potential performance improvement
+TARGET_CFLAGS := '-fno-common -ffp-contract=off -mno-fdiv'
+
 TOOLCHAIN_REPO=riscv-gnu-toolchain
 TOOLCHAIN_URL=https://github.com/riscv/$(TOOLCHAIN_REPO)
-TOOLCHAIN_VERSION=a03290eab661e2aa58288ad164f908bbbcc2169c
+TOOLCHAIN_VERSION=8b239b71678fd397968c4885dc2b760cecd7c861
 DEPENDS_DIR=$(CURDIR)/depends
+
 
 BSG_NEWLIB_URL=https://github.com/bespoke-silicon-group/bsg_newlib_dramfs.git
 BSG_NEWLIB_BRANCH=dramfs
@@ -114,13 +119,13 @@ configure-riscv-gnu-tools:
 	@echo "Configuring toolchain..."
 	@echo "====================================="
 	cd riscv-gnu-toolchain && \
-		./configure --prefix=$(RISCV) --disable-linux --with-arch=rv32imaf --with-abi=ilp32
+		./configure --prefix=$(RISCV) --disable-linux --with-arch=$(TARGET_ARCH) --with-abi=$(TARGET_ABI)
 
 build-riscv-gnu-tools: configure-riscv-gnu-tools
 	@echo "====================================="
 	@echo "Building toolchain..."
 	@echo "====================================="
-	cd riscv-gnu-toolchain && $(MAKE) -j 16 newlib && $(MAKE) install
+	cd riscv-gnu-toolchain && $(MAKE) -j 16 CFLAGS_FOR_TARGET_EXTRA=$(TARGET_CFLAGS)
 
 build-spike:
 	@echo "====================================="

--- a/software/riscv-tools/Makefile
+++ b/software/riscv-tools/Makefile
@@ -29,7 +29,8 @@
 
 TARGET_ARCH       := rv32imaf
 TARGET_ABI        := ilp32 # TODO: Test ilp32f for potential performance improvement
-TARGET_CFLAGS     := '-fno-common -ffp-contract=off -mno-fdiv'
+TARGET_CFLAGS     := '-fno-common -ffp-contract=off -mno-fdiv' # Turn off fma, fdiv and fexp instructions
+                                                               # as manycore's FPU doesn't support them.
 
 TOOLCHAIN_REPO    := riscv-gnu-toolchain
 TOOLCHAIN_URL     := https://github.com/riscv/$(TOOLCHAIN_REPO)

--- a/software/riscv-tools/Makefile
+++ b/software/riscv-tools/Makefile
@@ -27,23 +27,25 @@
 #
 .DEFAULT_GOAL := help
 
-TARGET_ARCH   := rv32imaf
-TARGET_ABI    := ilp32 # TODO: Test ilp32f for potential performance improvement
-TARGET_CFLAGS := '-fno-common -ffp-contract=off -mno-fdiv'
+TARGET_ARCH       := rv32imaf
+TARGET_ABI        := ilp32 # TODO: Test ilp32f for potential performance improvement
+TARGET_CFLAGS     := '-fno-common -ffp-contract=off -mno-fdiv'
 
-TOOLCHAIN_REPO=riscv-gnu-toolchain
-TOOLCHAIN_URL=https://github.com/riscv/$(TOOLCHAIN_REPO)
-TOOLCHAIN_VERSION=8b239b71678fd397968c4885dc2b760cecd7c861
-DEPENDS_DIR=$(CURDIR)/depends
+TOOLCHAIN_REPO    := riscv-gnu-toolchain
+TOOLCHAIN_URL     := https://github.com/riscv/$(TOOLCHAIN_REPO)
+TOOLCHAIN_VERSION := a03290eab661e2aa58288ad164f908bbbcc2169c
 
+DEPENDS_DIR       := $(CURDIR)/depends
 
-BSG_NEWLIB_URL=https://github.com/bespoke-silicon-group/bsg_newlib_dramfs.git
-BSG_NEWLIB_BRANCH=dramfs
-BSG_NEWLIB_PATCH=newlib.patch
+NEWLIB_URL        := https://github.com/bespoke-silicon-group/bsg_newlib_dramfs.git
+NEWLIB_BRANCH     := dramfs
+NEWLIB_VERSION    := 1341d8b68f8eeec01b36de67c27bb2875e70c6f6
+NEWLIB_PATCH      := newlib.patch
 
-SPIKE_REPO=riscv-isa-sim
-SPIKE_URL=https://github.com/riscv/riscv-isa-sim.git
-SPIKE_PATCH=spike.patch
+SPIKE_REPO        := riscv-isa-sim
+SPIKE_URL         := https://github.com/riscv/riscv-isa-sim.git
+SPIKE_PATCH       := spike.patch
+SPIKE_TAG         := v1.0.0
 
 export PATH:=$(DEPENDS_DIR)/bin:$(PATH)
 
@@ -82,11 +84,12 @@ checkout-repos:
 	cd $(TOOLCHAIN_REPO) && git submodule update --init --recursive;
 
 replace-newlib:
-	cd $(TOOLCHAIN_REPO) && git config --file=.gitmodules submodule.riscv-newlib.url $(BSG_NEWLIB_URL)
-	cd $(TOOLCHAIN_REPO) && git config --file=.gitmodules submodule.riscv-newlib.branch $(BSG_NEWLIB_BRANCH)
-	cd $(TOOLCHAIN_REPO) && git apply ../$(BSG_NEWLIB_PATCH)
+	cd $(TOOLCHAIN_REPO) && git config --file=.gitmodules submodule.riscv-newlib.url $(NEWLIB_URL)
+	cd $(TOOLCHAIN_REPO) && git config --file=.gitmodules submodule.riscv-newlib.branch $(NEWLIB_BRANCH)
+	cd $(TOOLCHAIN_REPO) && git apply ../$(NEWLIB_PATCH)
 	cd $(TOOLCHAIN_REPO) && git submodule sync
 	cd $(TOOLCHAIN_REPO) && git submodule update --remote riscv-newlib
+	cd $(TOOLCHAIN_REPO)/riscv-newlib && git checkout $(NEWLIB_VERSION)
 
 checkout-spike:
 	@echo "====================================="
@@ -94,7 +97,7 @@ checkout-spike:
 	@echo "====================================="
 	@rm -rf $(SPIKE_REPO);
 	git clone --recursive $(SPIKE_URL);
-	cd $(SPIKE_REPO) && git checkout tags/v1.0.0
+	cd $(SPIKE_REPO) && git checkout tags/$(SPIKE_TAG)
 	cd $(SPIKE_REPO) && git apply ../$(SPIKE_PATCH)
 
 checkout-all: 

--- a/software/riscv-tools/newlib.patch
+++ b/software/riscv-tools/newlib.patch
@@ -1,0 +1,13 @@
+diff --git a/Makefile.in b/Makefile.in
+index a006b0a..c6fbdca 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -520,8 +520,6 @@ stamps/merge-newlib-nano: stamps/build-newlib-nano stamps/build-newlib
+ 		$(INSTALL_DIR)/$(NEWLIB_TUPLE)/lib/$${mld}/libg_nano.a; \
+ 	    cp $(builddir)/install-newlib-nano/$(NEWLIB_TUPLE)/lib/$${mld}/libgloss.a\
+ 		$(INSTALL_DIR)/$(NEWLIB_TUPLE)/lib/$${mld}/libgloss_nano.a; \
+-	    cp $(builddir)/install-newlib-nano/$(NEWLIB_TUPLE)/lib/$${mld}/crt0.o\
+-		$(INSTALL_DIR)/$(NEWLIB_TUPLE)/lib/$${mld}/crt0.o; \
+ 	done
+ # Copy nano header files into newlib install dir.
+ 	mkdir -p $(INSTALL_DIR)/$(NEWLIB_TUPLE)/include/newlib-nano; \


### PR DESCRIPTION
- Patch riscv-gnu-toolchain to fix a installation issue.
- Added target cflags -- this fixes expf issue!!
https://github.com/bespoke-silicon-group/bsg_manycore/blob/8e93b73a7a87ab11f348b3ec629dd79df9288d6b/software/riscv-tools/Makefile#L32
BSG Manycore's FPU needs a set of gcc flags, because it don't implement fused mul-add, fexp etc. We have those options in our C compilation flow. The issue was, they were not added to the library compilation flow, which caused the math library to be compiled assuming fma (fused mul-add) instructions are legal. Since we don't support fma instructions, expf which had fma instructions in it's compiled binary produces wrong results on our hardware. This addition tells the toolchain build flow to compile library code with provided cflags.

- Added back `--remote` flag to Newlib's `git submodule update` command. Git 1.8 and later versions have this feature of a submodule tracking a branch. This is required because bsg_manycore tracks our custom newlib port.
https://github.com/bespoke-silicon-group/bsg_manycore/blob/8e93b73a7a87ab11f348b3ec629dd79df9288d6b/software/riscv-tools/Makefile#L91