### PR TITLE
Added cuda lite runtime regression test to load binary from pre-loaded buffer

### DIFF
--- a/software/spmd/bsg_cuda_lite_runtime/binary_load_buffer/Makefile
+++ b/software/spmd/bsg_cuda_lite_runtime/binary_load_buffer/Makefile
@@ -1,0 +1,34 @@
+#########################################################
+# Network Configutaion
+# If not configured, Will use default Values
+	bsg_global_X ?= $(bsg_tiles_X)
+	bsg_global_Y ?= $(bsg_tiles_Y)+1
+
+#########################################################
+#Tile group configuration
+# If not configured, Will use default Values
+	bsg_tiles_org_X ?= 0
+	bsg_tiles_org_Y ?= 1
+
+# If not configured, Will use default Values
+	bsg_tiles_X ?= 2
+	bsg_tiles_Y ?= 2
+
+
+all: main.run
+
+
+KERNEL_NAME ?=kernel_binary_load_buffer
+
+OBJECT_FILES=main.o bsg_set_tile_x_y.o bsg_printf.o kernel_binary_load_buffer.o
+
+include ../../Makefile.include
+
+
+main.riscv: $(OBJECT_FILES) $(SPMD_COMMON_OBJECTS) ../../common/crt.o
+	$(RISCV_LINK) $(OBJECT_FILES) $(SPMD_COMMON_OBJECTS) -o $@ $(RISCV_LINK_OPTS)
+
+
+main.o: Makefile
+
+include ../../../mk/Makefile.tail_rules

--- a/software/spmd/bsg_cuda_lite_runtime/binary_load_buffer/kernel_binary_load_buffer.c
+++ b/software/spmd/bsg_cuda_lite_runtime/binary_load_buffer/kernel_binary_load_buffer.c
@@ -1,0 +1,8 @@
+//This is an empty kernel 
+
+#include "bsg_manycore.h"
+#include "bsg_set_tile_x_y.h"
+
+int  __attribute__ ((noinline)) kernel_binary_load_buffer() {
+  return 0;
+}

--- a/software/spmd/bsg_cuda_lite_runtime/binary_load_buffer/main.c
+++ b/software/spmd/bsg_cuda_lite_runtime/binary_load_buffer/main.c
@@ -1,0 +1,1 @@
+../main/main.c


### PR DESCRIPTION
instead of loading binary from a file in a given path. 
Related to PR # 419 in bsg_f1. 
