### PR TITLE
Added bsg_print_stats to cuda lite runtime regression tests

### DIFF
--- a/software/bsg_manycore_lib/bsg_manycore.h
+++ b/software/bsg_manycore_lib/bsg_manycore.h
@@ -128,14 +128,24 @@ inline void bsg_fence()      { __asm__ __volatile__("fence" :::); }
 
 #define bsg_commit_stores() do { bsg_fence(); /* fixme: add commit stores instr */  } while (0)
 
-// This micros are used to print the definiations in manycore program at compile time.
+// These micros are used to print the definiations in manycore program at compile time.
 // Useful for other program to the get the manycore configurations, like the number of tiles, buffer size etc.
 #define bsg_VALUE_TO_STRING(x) #x
 #define bsg_VALUE(x) bsg_VALUE_TO_STRING(x)
 #define bsg_VAR_NAME_VALUE(var) "MANYCORE_EXPORT #define " #var " "  bsg_VALUE(var)
 
+// These micros are used as tag for bsg_print_stat instruction to determine 
+// what tile group is sending the print_stat, and wether it is at the 
+// beginning or the end of kernel execution
+// The values for bsg_PRINT_STAT_START/END_VAL should match the micro
+// values inside bsg_manycore/software/py/vanilla_stats_parser.py
+// for parsing the vanilla_stats.log file 
+#define bsg_PRINT_STAT_START_VAL 0x00000000
+#define bsg_PRINT_STAT_END_VAL   0xdead0000
 
 #define bsg_print_stat(tag) do { bsg_remote_int_ptr ptr = bsg_remote_ptr_io(IO_X_INDEX,0xd0c); *ptr = tag; } while (0)
 
+#define bsg_print_stat_start(tag) { bsg_print_stat(((bsg_PRINT_STAT_START_VAL) + (tag))); } while(0)
+#define bsg_print_stat_end(tag)   { bsg_print_stat(((bsg_PRINT_STAT_END_VAL)   + (tag))); } while(0)
 
 #endif

--- a/software/bsg_manycore_lib/bsg_manycore.h
+++ b/software/bsg_manycore_lib/bsg_manycore.h
@@ -145,7 +145,7 @@ inline void bsg_fence()      { __asm__ __volatile__("fence" :::); }
 
 #define bsg_print_stat(tag) do { bsg_remote_int_ptr ptr = bsg_remote_ptr_io(IO_X_INDEX,0xd0c); *ptr = tag; } while (0)
 
-#define bsg_print_stat_start(tag) { bsg_print_stat(((bsg_PRINT_STAT_START_VAL) + (tag))); } while(0)
-#define bsg_print_stat_end(tag)   { bsg_print_stat(((bsg_PRINT_STAT_END_VAL)   + (tag))); } while(0)
+#define bsg_print_stat_start(tag) { if (__bsg_id == 0) {bsg_print_stat(((bsg_PRINT_STAT_START_VAL) + (tag)));} } while(0)
+#define bsg_print_stat_end(tag)   { if (__bsg_id == 0) {bsg_print_stat(((bsg_PRINT_STAT_END_VAL)   + (tag)));} } while(0)
 
 #endif

--- a/software/bsg_manycore_lib/bsg_set_tile_x_y.c
+++ b/software/bsg_manycore_lib/bsg_set_tile_x_y.c
@@ -14,6 +14,7 @@ int __bsg_grid_dim_x = -1;
 int __bsg_grid_dim_y = -1;
 int __bsg_tile_group_id_x = -1;
 int __bsg_tile_group_id_y = -1;
+int __bsg_tile_group_id = -1;
 
 void bsg_set_tile_x_y()
 {
@@ -48,4 +49,5 @@ void bsg_set_tile_x_y()
   __bsg_grid_dim_y = 1;
   __bsg_tile_group_id_x = 0;
   __bsg_tile_group_id_y = 0;
+  __bsg_tile_group_id = 0;
 }

--- a/software/bsg_manycore_lib/bsg_set_tile_x_y.h
+++ b/software/bsg_manycore_lib/bsg_set_tile_x_y.h
@@ -1,3 +1,21 @@
+/* Each application launched onto the manycore is represented by a grid of tile groups.        */
+/* A grid is a two diemsnional structure represeting the entire application, with each         */
+/* element of grid being a tile group with X and Y coordinates bsg_tile_group_id_x/y,          */
+/* and the flat coordiante of bsg_tile_group_id, which is calculate using grid dimensions      */
+/* __bsg_x               --> The X coordinate of tile inside its tile group                    */
+/* __bsg_y               --> The Y coordiante of tile inside its tile group                    */
+/* __bsg_id              --> The flat index of tile inside tile group                          */
+/*                            __bsg_id = __bsg_y * __bsg_tiles_X + __bsg_x                     */
+/* __bsg_grp_org_x       --> The X coordinate of the tile group origin tile                    */
+/* __bsg_grp_org_y       --> The Y coordinate of the tile group origin tile                    */
+/* __bsg_grid_dim_x      --> X dimension of grid, or number of tile groups in the X dimensions */
+/* __bsg_grid_dim_y      --> Y dimension of grid, or number of tile groups in the Y dimensions */
+/* __bsg_tile_group_id_x --> X coordinate of tile group within the application's grid          */
+/* __bsg_tile_group_id_y --> Y coordinate of tile group within the application's grid          */
+/* __bsg_tile_group_id_x --> flat index of tile group within the application's grid            */
+/*                            __bsg_tile_group_id = __bsg_tile_group_id_y * __bsg_grid_dim_x   */
+/*                                                  + __bsg_tile_group_id_x                    */
+
 extern int __bsg_x;               //The X Cord inside a tile group
 extern int __bsg_y;               //The Y Cord inside a tile group
 extern int __bsg_id;              //The ID of a tile in tile group

--- a/software/bsg_manycore_lib/bsg_set_tile_x_y.h
+++ b/software/bsg_manycore_lib/bsg_set_tile_x_y.h
@@ -7,6 +7,7 @@ extern int __bsg_grid_dim_x;	  //The X Dimensions of the grid of tile groups
 extern int __bsg_grid_dim_y;	  //The Y Dimensions of the grid of tile groups
 extern int __bsg_tile_group_id_x; //The X Cord of the tile group within the grid
 extern int __bsg_tile_group_id_y; //The Y Cord of the tile group within the grid
+extern int __bsg_tile_group_id;   //The flat tile group id within the grid
 
 //----------------------------------------------------------
 //bsg_x and bsg_y is going to be deprecated.

--- a/software/spmd/bsg_cuda_lite_runtime/dram_device_allocated/kernel_dram_device_allocated.c
+++ b/software/spmd/bsg_cuda_lite_runtime/dram_device_allocated/kernel_dram_device_allocated.c
@@ -15,7 +15,7 @@ volatile int A[N] __attribute__((section(".dram")));
 int  __attribute__ ((noinline)) kernel_dram_device_allocated(int *addr, int block_size_x) {
 
 	if (__bsg_id == 0)
-		bsg_print_stat(__bsg_tile_group_id);
+		bsg_print_stat_start(__bsg_tile_group_id);
 
 	int start_x = block_size_x * (__bsg_tile_group_id_y * __bsg_grid_dim_x + __bsg_tile_group_id_x); 
 	for (int iter_x = __bsg_id; iter_x < block_size_x; iter_x += bsg_tiles_X * bsg_tiles_Y) { 
@@ -27,7 +27,7 @@ int  __attribute__ ((noinline)) kernel_dram_device_allocated(int *addr, int bloc
 	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
 
 	if (__bsg_id == 0)
-		bsg_print_stat(1000 + __bsg_tile_group_id);
+		bsg_print_stat_end(__bsg_tile_group_id);
 
 	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
 

--- a/software/spmd/bsg_cuda_lite_runtime/dram_device_allocated/kernel_dram_device_allocated.c
+++ b/software/spmd/bsg_cuda_lite_runtime/dram_device_allocated/kernel_dram_device_allocated.c
@@ -14,12 +14,20 @@ volatile int A[N] __attribute__((section(".dram")));
 
 int  __attribute__ ((noinline)) kernel_dram_device_allocated(int *addr, int block_size_x) {
 
+	if (__bsg_id == 0)
+		bsg_print_stat(__bsg_tile_group_id);
+
 	int start_x = block_size_x * (__bsg_tile_group_id_y * __bsg_grid_dim_x + __bsg_tile_group_id_x); 
 	for (int iter_x = __bsg_id; iter_x < block_size_x; iter_x += bsg_tiles_X * bsg_tiles_Y) { 
 		A[start_x + iter_x] = start_x + iter_x;
 	}
 
 	*addr = &A[0];
+
+	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
+
+	if (__bsg_id == 0)
+		bsg_print_stat(1000 + __bsg_tile_group_id);
 
 	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
 

--- a/software/spmd/bsg_cuda_lite_runtime/dram_host_allocated/kernel_dram_host_allocated.c
+++ b/software/spmd/bsg_cuda_lite_runtime/dram_host_allocated/kernel_dram_host_allocated.c
@@ -10,7 +10,15 @@ INIT_TILE_GROUP_BARRIER(r_barrier, c_barrier, 0, bsg_tiles_X-1, 0, bsg_tiles_Y-1
 
 int  __attribute__ ((noinline)) kernel_dram_host_allocated(int *addr) {
 
+	if (__bsg_id == 0)
+		bsg_print_stat(__bsg_tile_group_id);
+
 	*addr = 0x1234;
+
+	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
+
+	if (__bsg_id == 0)
+		bsg_print_stat(1000 + __bsg_tile_group_id);
 
 	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
 

--- a/software/spmd/bsg_cuda_lite_runtime/dram_host_allocated/kernel_dram_host_allocated.c
+++ b/software/spmd/bsg_cuda_lite_runtime/dram_host_allocated/kernel_dram_host_allocated.c
@@ -11,14 +11,14 @@ INIT_TILE_GROUP_BARRIER(r_barrier, c_barrier, 0, bsg_tiles_X-1, 0, bsg_tiles_Y-1
 int  __attribute__ ((noinline)) kernel_dram_host_allocated(int *addr) {
 
 	if (__bsg_id == 0)
-		bsg_print_stat(__bsg_tile_group_id);
+		bsg_print_stat_start(__bsg_tile_group_id);
 
 	*addr = 0x1234;
 
 	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
 
 	if (__bsg_id == 0)
-		bsg_print_stat(1000 + __bsg_tile_group_id);
+		bsg_print_stat_end( __bsg_tile_group_id);
 
 	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
 

--- a/software/spmd/bsg_cuda_lite_runtime/float_all_ops/kernel_float_all_ops.c
+++ b/software/spmd/bsg_cuda_lite_runtime/float_all_ops/kernel_float_all_ops.c
@@ -21,7 +21,7 @@ int  __attribute__ ((noinline)) kernel_float_all_ops(float *A, float *B,
                                                      float *res_compare, float *res_convert,
                                                      int N, int block_size_x) {
 	if (__bsg_id == 0)
-		bsg_print_stat(__bsg_tile_group_id);
+		bsg_print_stat_start(__bsg_tile_group_id);
 
 	int start_x = block_size_x * (__bsg_tile_group_id_y * __bsg_grid_dim_x + __bsg_tile_group_id_x); 
 	for (int iter_x = __bsg_id; iter_x < block_size_x; iter_x += bsg_tiles_X * bsg_tiles_Y) { 
@@ -44,7 +44,7 @@ int  __attribute__ ((noinline)) kernel_float_all_ops(float *A, float *B,
 	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
 
 	if (__bsg_id == 0)
-		bsg_print_stat(1000 + __bsg_tile_group_id);
+		bsg_print_stat_end(__bsg_tile_group_id);
 
 	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
 

--- a/software/spmd/bsg_cuda_lite_runtime/float_all_ops/kernel_float_all_ops.c
+++ b/software/spmd/bsg_cuda_lite_runtime/float_all_ops/kernel_float_all_ops.c
@@ -20,6 +20,8 @@ int  __attribute__ ((noinline)) kernel_float_all_ops(float *A, float *B,
                                                      float *res_mul, float *res_div,
                                                      float *res_compare, float *res_convert,
                                                      int N, int block_size_x) {
+	if (__bsg_id == 0)
+		bsg_print_stat(__bsg_tile_group_id);
 
 	int start_x = block_size_x * (__bsg_tile_group_id_y * __bsg_grid_dim_x + __bsg_tile_group_id_x); 
 	for (int iter_x = __bsg_id; iter_x < block_size_x; iter_x += bsg_tiles_X * bsg_tiles_Y) { 
@@ -38,6 +40,11 @@ int  __attribute__ ((noinline)) kernel_float_all_ops(float *A, float *B,
 		data.hb_mc_float = A[i]; 
 		res_convert[i] = (float) data.hb_mc_int;
 	}
+
+	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
+
+	if (__bsg_id == 0)
+		bsg_print_stat(1000 + __bsg_tile_group_id);
 
 	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
 

--- a/software/spmd/bsg_cuda_lite_runtime/float_matrix_mul/kernel_float_matrix_mul.c
+++ b/software/spmd/bsg_cuda_lite_runtime/float_matrix_mul/kernel_float_matrix_mul.c
@@ -13,6 +13,8 @@ INIT_TILE_GROUP_BARRIER(r_barrier, c_barrier, 0, bsg_tiles_X-1, 0, bsg_tiles_Y-1
 
 int  __attribute__ ((noinline)) kernel_float_matrix_mul(float *A, float *B, float *C, int M, int N, int P, int block_size_y, int block_size_x) {
 
+	if (__bsg_id == 0)
+		bsg_print_stat(__bsg_tile_group_id);
 
 	int start_y = __bsg_tile_group_id_y * block_size_y;
 	int start_x = __bsg_tile_group_id_x * block_size_x;
@@ -30,6 +32,11 @@ int  __attribute__ ((noinline)) kernel_float_matrix_mul(float *A, float *B, floa
 			C[iter_y * P + iter_x] = sum;
 		}
 	}
+
+	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
+
+	if (__bsg_id == 0)
+		bsg_print_stat(1000 + __bsg_tile_group_id);
 
 	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
 

--- a/software/spmd/bsg_cuda_lite_runtime/float_matrix_mul/kernel_float_matrix_mul.c
+++ b/software/spmd/bsg_cuda_lite_runtime/float_matrix_mul/kernel_float_matrix_mul.c
@@ -14,7 +14,7 @@ INIT_TILE_GROUP_BARRIER(r_barrier, c_barrier, 0, bsg_tiles_X-1, 0, bsg_tiles_Y-1
 int  __attribute__ ((noinline)) kernel_float_matrix_mul(float *A, float *B, float *C, int M, int N, int P, int block_size_y, int block_size_x) {
 
 	if (__bsg_id == 0)
-		bsg_print_stat(__bsg_tile_group_id);
+		bsg_print_stat_start(__bsg_tile_group_id);
 
 	int start_y = __bsg_tile_group_id_y * block_size_y;
 	int start_x = __bsg_tile_group_id_x * block_size_x;
@@ -36,7 +36,7 @@ int  __attribute__ ((noinline)) kernel_float_matrix_mul(float *A, float *B, floa
 	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
 
 	if (__bsg_id == 0)
-		bsg_print_stat(1000 + __bsg_tile_group_id);
+		bsg_print_stat_end(__bsg_tile_group_id);
 
 	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
 

--- a/software/spmd/bsg_cuda_lite_runtime/float_matrix_mul_shared_mem/kernel_float_matrix_mul_shared_mem.c
+++ b/software/spmd/bsg_cuda_lite_runtime/float_matrix_mul_shared_mem/kernel_float_matrix_mul_shared_mem.c
@@ -98,7 +98,10 @@ void __attribute__ ((noinline)) subblock_shmem_matrix_mul_xposed (float *sh_A, f
 
 int  __attribute__ ((noinline)) kernel_float_matrix_mul_shared_mem(float *A, float *B, float *C, int M, int N, int P, int block_size_y, int block_size_x) {
 
-	
+
+	if (__bsg_id == 0)
+		bsg_print_stat(__bsg_tile_group_id);
+
 	// declare tile-group shared memory
 	bsg_tile_group_shared_mem (float, sh_A, (block_size_y * BLOCK_WIDTH));
 	bsg_tile_group_shared_mem (float, sh_B, (BLOCK_WIDTH * block_size_x));
@@ -123,6 +126,11 @@ int  __attribute__ ((noinline)) kernel_float_matrix_mul_shared_mem(float *A, flo
 	shmem2subblock (C, sh_C, M, P, block_size_y, block_size_x, __bsg_tile_group_id_y, __bsg_tile_group_id_x); 
 
 	bsg_tile_group_barrier (&r_barrier, &c_barrier) ;
+
+	if (__bsg_id == 0)
+		bsg_print_stat(1000 + __bsg_tile_group_id);
+
+	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
 
 	return 0;
 }

--- a/software/spmd/bsg_cuda_lite_runtime/float_matrix_mul_shared_mem/kernel_float_matrix_mul_shared_mem.c
+++ b/software/spmd/bsg_cuda_lite_runtime/float_matrix_mul_shared_mem/kernel_float_matrix_mul_shared_mem.c
@@ -100,7 +100,7 @@ int  __attribute__ ((noinline)) kernel_float_matrix_mul_shared_mem(float *A, flo
 
 
 	if (__bsg_id == 0)
-		bsg_print_stat(__bsg_tile_group_id);
+		bsg_print_stat_start(__bsg_tile_group_id);
 
 	// declare tile-group shared memory
 	bsg_tile_group_shared_mem (float, sh_A, (block_size_y * BLOCK_WIDTH));
@@ -128,7 +128,7 @@ int  __attribute__ ((noinline)) kernel_float_matrix_mul_shared_mem(float *A, flo
 	bsg_tile_group_barrier (&r_barrier, &c_barrier) ;
 
 	if (__bsg_id == 0)
-		bsg_print_stat(1000 + __bsg_tile_group_id);
+		bsg_print_stat_end(__bsg_tile_group_id);
 
 	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
 

--- a/software/spmd/bsg_cuda_lite_runtime/float_vec_add/kernel_float_vec_add.c
+++ b/software/spmd/bsg_cuda_lite_runtime/float_vec_add/kernel_float_vec_add.c
@@ -13,7 +13,7 @@ INIT_TILE_GROUP_BARRIER(r_barrier, c_barrier, 0, bsg_tiles_X-1, 0, bsg_tiles_Y-1
 int  __attribute__ ((noinline)) kernel_float_vec_add(float *A, float *B, float *C, int N, int block_size_x) {
 
 	if (__bsg_id == 0)
-		bsg_print_stat(__bsg_tile_group_id);
+		bsg_print_stat_start(__bsg_tile_group_id);
 
 	int start_x = block_size_x * (__bsg_tile_group_id_y * __bsg_grid_dim_x + __bsg_tile_group_id_x); 
 	for (int iter_x = __bsg_id; iter_x < block_size_x; iter_x += bsg_tiles_X * bsg_tiles_Y) { 
@@ -23,7 +23,7 @@ int  __attribute__ ((noinline)) kernel_float_vec_add(float *A, float *B, float *
 	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
 
 	if (__bsg_id == 0)
-		bsg_print_stat(1000 + __bsg_tile_group_id);
+		bsg_print_stat_end(__bsg_tile_group_id);
 
 	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
 

--- a/software/spmd/bsg_cuda_lite_runtime/float_vec_add/kernel_float_vec_add.c
+++ b/software/spmd/bsg_cuda_lite_runtime/float_vec_add/kernel_float_vec_add.c
@@ -12,10 +12,18 @@ INIT_TILE_GROUP_BARRIER(r_barrier, c_barrier, 0, bsg_tiles_X-1, 0, bsg_tiles_Y-1
 
 int  __attribute__ ((noinline)) kernel_float_vec_add(float *A, float *B, float *C, int N, int block_size_x) {
 
+	if (__bsg_id == 0)
+		bsg_print_stat(__bsg_tile_group_id);
+
 	int start_x = block_size_x * (__bsg_tile_group_id_y * __bsg_grid_dim_x + __bsg_tile_group_id_x); 
 	for (int iter_x = __bsg_id; iter_x < block_size_x; iter_x += bsg_tiles_X * bsg_tiles_Y) { 
 		C[start_x + iter_x] = A[start_x + iter_x] + B[start_x + iter_x];
 	}
+
+	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
+
+	if (__bsg_id == 0)
+		bsg_print_stat(1000 + __bsg_tile_group_id);
 
 	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
 

--- a/software/spmd/bsg_cuda_lite_runtime/float_vec_add_shared_mem/kernel_float_vec_add_shared_mem.c
+++ b/software/spmd/bsg_cuda_lite_runtime/float_vec_add_shared_mem/kernel_float_vec_add_shared_mem.c
@@ -15,7 +15,7 @@ INIT_TILE_GROUP_BARRIER(r_barrier, c_barrier, 0, bsg_tiles_X-1, 0, bsg_tiles_Y-1
 int  __attribute__ ((noinline)) kernel_float_vec_add_shared_mem(float *A, float *B, float *C, int N, int block_size_x) {
 
 	if (__bsg_id == 0)
-		bsg_print_stat(__bsg_tile_group_id);
+		bsg_print_stat_start(__bsg_tile_group_id);
 
 	// Declare tile-group shared memroy with specific size
 	bsg_tile_group_shared_mem (float, sh_A, block_size_x);
@@ -60,7 +60,7 @@ int  __attribute__ ((noinline)) kernel_float_vec_add_shared_mem(float *A, float 
 	bsg_tile_group_barrier(&r_barrier, &c_barrier);
 
 	if (__bsg_id == 0)
-		bsg_print_stat(1000 + __bsg_tile_group_id);
+		bsg_print_stat_end(__bsg_tile_group_id);
 
 	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
 

--- a/software/spmd/bsg_cuda_lite_runtime/float_vec_add_shared_mem/kernel_float_vec_add_shared_mem.c
+++ b/software/spmd/bsg_cuda_lite_runtime/float_vec_add_shared_mem/kernel_float_vec_add_shared_mem.c
@@ -14,6 +14,9 @@ INIT_TILE_GROUP_BARRIER(r_barrier, c_barrier, 0, bsg_tiles_X-1, 0, bsg_tiles_Y-1
 
 int  __attribute__ ((noinline)) kernel_float_vec_add_shared_mem(float *A, float *B, float *C, int N, int block_size_x) {
 
+	if (__bsg_id == 0)
+		bsg_print_stat(__bsg_tile_group_id);
+
 	// Declare tile-group shared memroy with specific size
 	bsg_tile_group_shared_mem (float, sh_A, block_size_x);
 	bsg_tile_group_shared_mem (float, sh_B, block_size_x); 
@@ -56,6 +59,10 @@ int  __attribute__ ((noinline)) kernel_float_vec_add_shared_mem(float *A, float 
 
 	bsg_tile_group_barrier(&r_barrier, &c_barrier);
 
+	if (__bsg_id == 0)
+		bsg_print_stat(1000 + __bsg_tile_group_id);
+
+	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
 
   return 0;
 }

--- a/software/spmd/bsg_cuda_lite_runtime/float_vec_div/kernel_float_vec_div.c
+++ b/software/spmd/bsg_cuda_lite_runtime/float_vec_div/kernel_float_vec_div.c
@@ -13,7 +13,7 @@ INIT_TILE_GROUP_BARRIER(r_barrier, c_barrier, 0, bsg_tiles_X-1, 0, bsg_tiles_Y-1
 int  __attribute__ ((noinline)) kernel_float_vec_div(float *A, float *B, float *C, int N, int block_size_x) {
 
 	if (__bsg_id == 0)
-		bsg_print_stat(__bsg_tile_group_id);
+		bsg_print_stat_start(__bsg_tile_group_id);
 
 	int start_x = block_size_x * (__bsg_tile_group_id_y * __bsg_grid_dim_x + __bsg_tile_group_id_x); 
 	for (int iter_x = __bsg_id; iter_x < block_size_x; iter_x += bsg_tiles_X * bsg_tiles_Y) { 
@@ -23,7 +23,7 @@ int  __attribute__ ((noinline)) kernel_float_vec_div(float *A, float *B, float *
 	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
 
 	if (__bsg_id == 0)
-		bsg_print_stat(1000 + __bsg_tile_group_id);
+		bsg_print_stat_end(__bsg_tile_group_id);
 
 	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
 

--- a/software/spmd/bsg_cuda_lite_runtime/float_vec_div/kernel_float_vec_div.c
+++ b/software/spmd/bsg_cuda_lite_runtime/float_vec_div/kernel_float_vec_div.c
@@ -12,10 +12,18 @@ INIT_TILE_GROUP_BARRIER(r_barrier, c_barrier, 0, bsg_tiles_X-1, 0, bsg_tiles_Y-1
 
 int  __attribute__ ((noinline)) kernel_float_vec_div(float *A, float *B, float *C, int N, int block_size_x) {
 
+	if (__bsg_id == 0)
+		bsg_print_stat(__bsg_tile_group_id);
+
 	int start_x = block_size_x * (__bsg_tile_group_id_y * __bsg_grid_dim_x + __bsg_tile_group_id_x); 
 	for (int iter_x = __bsg_id; iter_x < block_size_x; iter_x += bsg_tiles_X * bsg_tiles_Y) { 
 		C[start_x + iter_x] = A[start_x + iter_x] / B[start_x + iter_x];
 	}
+
+	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
+
+	if (__bsg_id == 0)
+		bsg_print_stat(1000 + __bsg_tile_group_id);
 
 	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
 

--- a/software/spmd/bsg_cuda_lite_runtime/float_vec_exp/kernel_float_vec_exp.c
+++ b/software/spmd/bsg_cuda_lite_runtime/float_vec_exp/kernel_float_vec_exp.c
@@ -13,10 +13,18 @@ INIT_TILE_GROUP_BARRIER(r_barrier, c_barrier, 0, bsg_tiles_X-1, 0, bsg_tiles_Y-1
 
 int  __attribute__ ((noinline)) kernel_float_vec_exp(float *A, float *B, int N, int block_size_x) {
 
+	if (__bsg_id == 0)
+		bsg_print_stat(__bsg_tile_group_id);
+
 	int start_x = block_size_x * (__bsg_tile_group_id_y * __bsg_grid_dim_x + __bsg_tile_group_id_x); 
 	for (int iter_x = __bsg_id; iter_x < block_size_x; iter_x += bsg_tiles_X * bsg_tiles_Y) { 
 		B[start_x + iter_x] = expf(A[start_x + iter_x]);
 	}
+
+	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
+
+	if (__bsg_id == 0)
+		bsg_print_stat(1000 + __bsg_tile_group_id);
 
 	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
 

--- a/software/spmd/bsg_cuda_lite_runtime/float_vec_exp/kernel_float_vec_exp.c
+++ b/software/spmd/bsg_cuda_lite_runtime/float_vec_exp/kernel_float_vec_exp.c
@@ -14,7 +14,7 @@ INIT_TILE_GROUP_BARRIER(r_barrier, c_barrier, 0, bsg_tiles_X-1, 0, bsg_tiles_Y-1
 int  __attribute__ ((noinline)) kernel_float_vec_exp(float *A, float *B, int N, int block_size_x) {
 
 	if (__bsg_id == 0)
-		bsg_print_stat(__bsg_tile_group_id);
+		bsg_print_stat_start(__bsg_tile_group_id);
 
 	int start_x = block_size_x * (__bsg_tile_group_id_y * __bsg_grid_dim_x + __bsg_tile_group_id_x); 
 	for (int iter_x = __bsg_id; iter_x < block_size_x; iter_x += bsg_tiles_X * bsg_tiles_Y) { 
@@ -24,7 +24,7 @@ int  __attribute__ ((noinline)) kernel_float_vec_exp(float *A, float *B, int N, 
 	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
 
 	if (__bsg_id == 0)
-		bsg_print_stat(1000 + __bsg_tile_group_id);
+		bsg_print_stat_end(__bsg_tile_group_id);
 
 	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
 

--- a/software/spmd/bsg_cuda_lite_runtime/float_vec_log/kernel_float_vec_log.c
+++ b/software/spmd/bsg_cuda_lite_runtime/float_vec_log/kernel_float_vec_log.c
@@ -14,7 +14,7 @@ INIT_TILE_GROUP_BARRIER(r_barrier, c_barrier, 0, bsg_tiles_X-1, 0, bsg_tiles_Y-1
 int  __attribute__ ((noinline)) kernel_float_vec_log(float *A, float *B, int N, int block_size_x) {
 
 	if (__bsg_id == 0)
-		bsg_print_stat(__bsg_tile_group_id);
+		bsg_print_stat_start(__bsg_tile_group_id);
 
 	int start_x = block_size_x * (__bsg_tile_group_id_y * __bsg_grid_dim_x + __bsg_tile_group_id_x); 
 	for (int iter_x = __bsg_id; iter_x < block_size_x; iter_x += bsg_tiles_X * bsg_tiles_Y) { 
@@ -24,7 +24,7 @@ int  __attribute__ ((noinline)) kernel_float_vec_log(float *A, float *B, int N, 
 	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
 
 	if (__bsg_id == 0)
-		bsg_print_stat(1000 + __bsg_tile_group_id);
+		bsg_print_stat_end(__bsg_tile_group_id);
 
 	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
 

--- a/software/spmd/bsg_cuda_lite_runtime/float_vec_log/kernel_float_vec_log.c
+++ b/software/spmd/bsg_cuda_lite_runtime/float_vec_log/kernel_float_vec_log.c
@@ -13,10 +13,18 @@ INIT_TILE_GROUP_BARRIER(r_barrier, c_barrier, 0, bsg_tiles_X-1, 0, bsg_tiles_Y-1
 
 int  __attribute__ ((noinline)) kernel_float_vec_log(float *A, float *B, int N, int block_size_x) {
 
+	if (__bsg_id == 0)
+		bsg_print_stat(__bsg_tile_group_id);
+
 	int start_x = block_size_x * (__bsg_tile_group_id_y * __bsg_grid_dim_x + __bsg_tile_group_id_x); 
 	for (int iter_x = __bsg_id; iter_x < block_size_x; iter_x += bsg_tiles_X * bsg_tiles_Y) { 
 		B[start_x + iter_x] = logf(A[start_x + iter_x]);
 	}
+
+	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
+
+	if (__bsg_id == 0)
+		bsg_print_stat(1000 + __bsg_tile_group_id);
 
 	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
 

--- a/software/spmd/bsg_cuda_lite_runtime/float_vec_mul/kernel_float_vec_mul.c
+++ b/software/spmd/bsg_cuda_lite_runtime/float_vec_mul/kernel_float_vec_mul.c
@@ -13,7 +13,7 @@ INIT_TILE_GROUP_BARRIER(r_barrier, c_barrier, 0, bsg_tiles_X-1, 0, bsg_tiles_Y-1
 int  __attribute__ ((noinline)) kernel_float_vec_mul(float *A, float *B, float *C, int N, int block_size_x) {
 
 	if (__bsg_id == 0)
-		bsg_print_stat(__bsg_tile_group_id);
+		bsg_print_stat_start(__bsg_tile_group_id);
 
 	int start_x = block_size_x * (__bsg_tile_group_id_y * __bsg_grid_dim_x + __bsg_tile_group_id_x); 
 	for (int iter_x = __bsg_id; iter_x < block_size_x; iter_x += bsg_tiles_X * bsg_tiles_Y) { 
@@ -23,7 +23,7 @@ int  __attribute__ ((noinline)) kernel_float_vec_mul(float *A, float *B, float *
 	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
 
 	if (__bsg_id == 0)
-		bsg_print_stat(1000 + __bsg_tile_group_id);
+		bsg_print_stat_end(__bsg_tile_group_id);
 
 	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
 

--- a/software/spmd/bsg_cuda_lite_runtime/float_vec_mul/kernel_float_vec_mul.c
+++ b/software/spmd/bsg_cuda_lite_runtime/float_vec_mul/kernel_float_vec_mul.c
@@ -12,10 +12,18 @@ INIT_TILE_GROUP_BARRIER(r_barrier, c_barrier, 0, bsg_tiles_X-1, 0, bsg_tiles_Y-1
 
 int  __attribute__ ((noinline)) kernel_float_vec_mul(float *A, float *B, float *C, int N, int block_size_x) {
 
+	if (__bsg_id == 0)
+		bsg_print_stat(__bsg_tile_group_id);
+
 	int start_x = block_size_x * (__bsg_tile_group_id_y * __bsg_grid_dim_x + __bsg_tile_group_id_x); 
 	for (int iter_x = __bsg_id; iter_x < block_size_x; iter_x += bsg_tiles_X * bsg_tiles_Y) { 
 		C[start_x + iter_x] = A[start_x + iter_x] * B[start_x + iter_x];
 	}
+
+	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
+
+	if (__bsg_id == 0)
+		bsg_print_stat(1000 + __bsg_tile_group_id);
 
 	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
 

--- a/software/spmd/bsg_cuda_lite_runtime/float_vec_sqrt/kernel_float_vec_sqrt.c
+++ b/software/spmd/bsg_cuda_lite_runtime/float_vec_sqrt/kernel_float_vec_sqrt.c
@@ -14,7 +14,7 @@ INIT_TILE_GROUP_BARRIER(r_barrier, c_barrier, 0, bsg_tiles_X-1, 0, bsg_tiles_Y-1
 int  __attribute__ ((noinline)) kernel_float_vec_sqrt(float *A, float *B, int N, int block_size_x) {
 
 	if (__bsg_id == 0)
-		bsg_print_stat(__bsg_tile_group_id);
+		bsg_print_stat_start(__bsg_tile_group_id);
 
 	int start_x = block_size_x * (__bsg_tile_group_id_y * __bsg_grid_dim_x + __bsg_tile_group_id_x); 
 	for (int iter_x = __bsg_id; iter_x < block_size_x; iter_x += bsg_tiles_X * bsg_tiles_Y) { 
@@ -24,7 +24,7 @@ int  __attribute__ ((noinline)) kernel_float_vec_sqrt(float *A, float *B, int N,
 	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
 
 	if (__bsg_id == 0)
-		bsg_print_stat(1000 + __bsg_tile_group_id);
+		bsg_print_stat_end(__bsg_tile_group_id);
 
 	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
 

--- a/software/spmd/bsg_cuda_lite_runtime/float_vec_sqrt/kernel_float_vec_sqrt.c
+++ b/software/spmd/bsg_cuda_lite_runtime/float_vec_sqrt/kernel_float_vec_sqrt.c
@@ -13,10 +13,18 @@ INIT_TILE_GROUP_BARRIER(r_barrier, c_barrier, 0, bsg_tiles_X-1, 0, bsg_tiles_Y-1
 
 int  __attribute__ ((noinline)) kernel_float_vec_sqrt(float *A, float *B, int N, int block_size_x) {
 
+	if (__bsg_id == 0)
+		bsg_print_stat(__bsg_tile_group_id);
+
 	int start_x = block_size_x * (__bsg_tile_group_id_y * __bsg_grid_dim_x + __bsg_tile_group_id_x); 
 	for (int iter_x = __bsg_id; iter_x < block_size_x; iter_x += bsg_tiles_X * bsg_tiles_Y) { 
 		B[start_x + iter_x] = sqrtf(A[start_x + iter_x]);
 	}
+
+	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
+
+	if (__bsg_id == 0)
+		bsg_print_stat(1000 + __bsg_tile_group_id);
 
 	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
 

--- a/software/spmd/bsg_cuda_lite_runtime/matrix_mul/kernel_matrix_mul.c
+++ b/software/spmd/bsg_cuda_lite_runtime/matrix_mul/kernel_matrix_mul.c
@@ -13,6 +13,8 @@ INIT_TILE_GROUP_BARRIER(r_barrier, c_barrier, 0, bsg_tiles_X-1, 0, bsg_tiles_Y-1
 
 int  __attribute__ ((noinline)) kernel_matrix_mul(int *A, int *B, int *C, int M, int N, int P, int block_size_y, int block_size_x) {
 
+	if (__bsg_id == 0)
+		bsg_print_stat(__bsg_tile_group_id);
 
 	int start_y = __bsg_tile_group_id_y * block_size_y;
 	int start_x = __bsg_tile_group_id_x * block_size_x;
@@ -30,6 +32,11 @@ int  __attribute__ ((noinline)) kernel_matrix_mul(int *A, int *B, int *C, int M,
 			C[iter_y * P + iter_x] = sum;
 		}
 	}
+
+	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
+
+	if (__bsg_id == 0)
+		bsg_print_stat(1000 + __bsg_tile_group_id);
 
 	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
 

--- a/software/spmd/bsg_cuda_lite_runtime/matrix_mul/kernel_matrix_mul.c
+++ b/software/spmd/bsg_cuda_lite_runtime/matrix_mul/kernel_matrix_mul.c
@@ -14,7 +14,7 @@ INIT_TILE_GROUP_BARRIER(r_barrier, c_barrier, 0, bsg_tiles_X-1, 0, bsg_tiles_Y-1
 int  __attribute__ ((noinline)) kernel_matrix_mul(int *A, int *B, int *C, int M, int N, int P, int block_size_y, int block_size_x) {
 
 	if (__bsg_id == 0)
-		bsg_print_stat(__bsg_tile_group_id);
+		bsg_print_stat_start(__bsg_tile_group_id);
 
 	int start_y = __bsg_tile_group_id_y * block_size_y;
 	int start_x = __bsg_tile_group_id_x * block_size_x;
@@ -36,7 +36,7 @@ int  __attribute__ ((noinline)) kernel_matrix_mul(int *A, int *B, int *C, int M,
 	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
 
 	if (__bsg_id == 0)
-		bsg_print_stat(1000 + __bsg_tile_group_id);
+		bsg_print_stat_end(__bsg_tile_group_id);
 
 	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
 

--- a/software/spmd/bsg_cuda_lite_runtime/matrix_mul_shared_mem/kernel_matrix_mul_shared_mem.c
+++ b/software/spmd/bsg_cuda_lite_runtime/matrix_mul_shared_mem/kernel_matrix_mul_shared_mem.c
@@ -99,7 +99,7 @@ void __attribute__ ((noinline)) subblock_shmem_matrix_mul_xposed (int *sh_A, int
 int  __attribute__ ((noinline)) kernel_matrix_mul_shared_mem(int *A, int *B, int *C, int M, int N, int P, int block_size_y, int block_size_x) {
 
 	if (__bsg_id == 0)
-		bsg_print_stat(__bsg_tile_group_id);
+		bsg_print_stat_start(__bsg_tile_group_id);
 
 	// declare tile-group shared memory
 	bsg_tile_group_shared_mem (int, sh_A, (block_size_y * BLOCK_WIDTH));
@@ -127,7 +127,7 @@ int  __attribute__ ((noinline)) kernel_matrix_mul_shared_mem(int *A, int *B, int
 	bsg_tile_group_barrier (&r_barrier, &c_barrier) ;
 
 	if (__bsg_id == 0)
-		bsg_print_stat(1000 + __bsg_tile_group_id);
+		bsg_print_stat_end(__bsg_tile_group_id);
 
 	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
 

--- a/software/spmd/bsg_cuda_lite_runtime/matrix_mul_shared_mem/kernel_matrix_mul_shared_mem.c
+++ b/software/spmd/bsg_cuda_lite_runtime/matrix_mul_shared_mem/kernel_matrix_mul_shared_mem.c
@@ -98,7 +98,9 @@ void __attribute__ ((noinline)) subblock_shmem_matrix_mul_xposed (int *sh_A, int
 
 int  __attribute__ ((noinline)) kernel_matrix_mul_shared_mem(int *A, int *B, int *C, int M, int N, int P, int block_size_y, int block_size_x) {
 
-	
+	if (__bsg_id == 0)
+		bsg_print_stat(__bsg_tile_group_id);
+
 	// declare tile-group shared memory
 	bsg_tile_group_shared_mem (int, sh_A, (block_size_y * BLOCK_WIDTH));
 	bsg_tile_group_shared_mem (int, sh_B, (BLOCK_WIDTH * block_size_x));
@@ -123,6 +125,11 @@ int  __attribute__ ((noinline)) kernel_matrix_mul_shared_mem(int *A, int *B, int
 	shmem2subblock (C, sh_C, M, P, block_size_y, block_size_x, __bsg_tile_group_id_y, __bsg_tile_group_id_x); 
 
 	bsg_tile_group_barrier (&r_barrier, &c_barrier) ;
+
+	if (__bsg_id == 0)
+		bsg_print_stat(1000 + __bsg_tile_group_id);
+
+	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
 
 	return 0;
 }

--- a/software/spmd/bsg_cuda_lite_runtime/max_pool2d/kernel_max_pool2d.c
+++ b/software/spmd/bsg_cuda_lite_runtime/max_pool2d/kernel_max_pool2d.c
@@ -15,6 +15,9 @@ INIT_TILE_GROUP_BARRIER(r_barrier, c_barrier, 0, bsg_tiles_X-1, 0, bsg_tiles_Y-1
 
 int  __attribute__ ((noinline)) kernel_max_pool2d(int *A, int *B, int M, int N, int P, int W, int block_size_y, int block_size_x) {
 
+	if (__bsg_id == 0)
+		bsg_print_stat(__bsg_tile_group_id);
+
 	int sub_block_y = M / P; // Should divide evenly	
 	int sub_block_x = N / W; // Should divide evenly	
 	int start_y = __bsg_tile_group_id_y * block_size_y;
@@ -43,6 +46,11 @@ int  __attribute__ ((noinline)) kernel_max_pool2d(int *A, int *B, int M, int N, 
 			B[iter_y * W + iter_x] = sub_max;
 		}
 	}
+
+	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
+
+	if (__bsg_id == 0)
+		bsg_print_stat(1000 + __bsg_tile_group_id);
 
 	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
 

--- a/software/spmd/bsg_cuda_lite_runtime/max_pool2d/kernel_max_pool2d.c
+++ b/software/spmd/bsg_cuda_lite_runtime/max_pool2d/kernel_max_pool2d.c
@@ -16,7 +16,7 @@ INIT_TILE_GROUP_BARRIER(r_barrier, c_barrier, 0, bsg_tiles_X-1, 0, bsg_tiles_Y-1
 int  __attribute__ ((noinline)) kernel_max_pool2d(int *A, int *B, int M, int N, int P, int W, int block_size_y, int block_size_x) {
 
 	if (__bsg_id == 0)
-		bsg_print_stat(__bsg_tile_group_id);
+		bsg_print_stat_start(__bsg_tile_group_id);
 
 	int sub_block_y = M / P; // Should divide evenly	
 	int sub_block_x = N / W; // Should divide evenly	
@@ -50,7 +50,7 @@ int  __attribute__ ((noinline)) kernel_max_pool2d(int *A, int *B, int M, int N, 
 	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
 
 	if (__bsg_id == 0)
-		bsg_print_stat(1000 + __bsg_tile_group_id);
+		bsg_print_stat_end(__bsg_tile_group_id);
 
 	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
 

--- a/software/spmd/bsg_cuda_lite_runtime/scalar_print/kernel_scalar_print.c
+++ b/software/spmd/bsg_cuda_lite_runtime/scalar_print/kernel_scalar_print.c
@@ -14,6 +14,9 @@ INIT_TILE_GROUP_BARRIER(r_barrier, c_barrier, 0, bsg_tiles_X-1, 0, bsg_tiles_Y-1
 
 int  __attribute__ ((noinline)) kernel_scalar_print() {
  
+  if (__bsg_id == 0)
+    bsg_print_stat(__bsg_tile_group_id);
+
   bsg_print_int(__bsg_id);
   bsg_print_unsigned(__bsg_id);
   bsg_print_hexadecimal(__bsg_id);
@@ -21,5 +24,11 @@ int  __attribute__ ((noinline)) kernel_scalar_print() {
   bsg_print_float_scientific(((float)__bsg_id) / 1000);
 
   bsg_tile_group_barrier(&r_barrier, &c_barrier);
+
+  if (__bsg_id == 0)
+    bsg_print_stat(1000 + __bsg_tile_group_id);
+
+  bsg_tile_group_barrier(&r_barrier, &c_barrier); 
+
   return 0;
 }

--- a/software/spmd/bsg_cuda_lite_runtime/scalar_print/kernel_scalar_print.c
+++ b/software/spmd/bsg_cuda_lite_runtime/scalar_print/kernel_scalar_print.c
@@ -15,7 +15,7 @@ INIT_TILE_GROUP_BARRIER(r_barrier, c_barrier, 0, bsg_tiles_X-1, 0, bsg_tiles_Y-1
 int  __attribute__ ((noinline)) kernel_scalar_print() {
  
   if (__bsg_id == 0)
-    bsg_print_stat(__bsg_tile_group_id);
+    bsg_print_stat_start(__bsg_tile_group_id);
 
   bsg_print_int(__bsg_id);
   bsg_print_unsigned(__bsg_id);
@@ -26,7 +26,7 @@ int  __attribute__ ((noinline)) kernel_scalar_print() {
   bsg_tile_group_barrier(&r_barrier, &c_barrier);
 
   if (__bsg_id == 0)
-    bsg_print_stat(1000 + __bsg_tile_group_id);
+    bsg_print_stat_end(__bsg_tile_group_id);
 
   bsg_tile_group_barrier(&r_barrier, &c_barrier); 
 

--- a/software/spmd/bsg_cuda_lite_runtime/shared_mem/kernel_shared_mem.c
+++ b/software/spmd/bsg_cuda_lite_runtime/shared_mem/kernel_shared_mem.c
@@ -14,6 +14,9 @@ INIT_TILE_GROUP_BARRIER(r_barrier, c_barrier, 0, bsg_tiles_X-1, 0, bsg_tiles_Y-1
 
 int  __attribute__ ((noinline)) kernel_shared_mem (int *A, int N) {
 
+	if (__bsg_id == 0)
+		bsg_print_stat(__bsg_tile_group_id);
+
 	bsg_tile_group_shared_mem (int, sh_arr, N); 
 
 	for (int iter_x = __bsg_id; iter_x < N; iter_x += bsg_tiles_X * bsg_tiles_Y) {
@@ -29,6 +32,11 @@ int  __attribute__ ((noinline)) kernel_shared_mem (int *A, int N) {
 		bsg_tile_group_shared_load(int, sh_arr, iter_x, A[iter_x]);
 	}
 
+
+	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
+
+	if (__bsg_id == 0)
+		bsg_print_stat(1000 + __bsg_tile_group_id);
 
 	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
 

--- a/software/spmd/bsg_cuda_lite_runtime/shared_mem/kernel_shared_mem.c
+++ b/software/spmd/bsg_cuda_lite_runtime/shared_mem/kernel_shared_mem.c
@@ -15,7 +15,7 @@ INIT_TILE_GROUP_BARRIER(r_barrier, c_barrier, 0, bsg_tiles_X-1, 0, bsg_tiles_Y-1
 int  __attribute__ ((noinline)) kernel_shared_mem (int *A, int N) {
 
 	if (__bsg_id == 0)
-		bsg_print_stat(__bsg_tile_group_id);
+		bsg_print_stat_start(__bsg_tile_group_id);
 
 	bsg_tile_group_shared_mem (int, sh_arr, N); 
 
@@ -36,7 +36,7 @@ int  __attribute__ ((noinline)) kernel_shared_mem (int *A, int N) {
 	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
 
 	if (__bsg_id == 0)
-		bsg_print_stat(1000 + __bsg_tile_group_id);
+		bsg_print_stat_end(__bsg_tile_group_id);
 
 	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
 

--- a/software/spmd/bsg_cuda_lite_runtime/shared_mem_load_store/kernel_shared_mem_load_store.c
+++ b/software/spmd/bsg_cuda_lite_runtime/shared_mem_load_store/kernel_shared_mem_load_store.c
@@ -15,10 +15,11 @@ INIT_TILE_GROUP_BARRIER(r_barrier, c_barrier, 0, bsg_tiles_X-1, 0, bsg_tiles_Y-1
 
 int  __attribute__ ((noinline)) kernel_shared_mem_load_store(int *A_in, int *A_out, int M, int N, int block_size_y, int block_size_x) {
 
+	if (__bsg_id == 0)
+		bsg_print_stat(__bsg_tile_group_id);
 	
 	// declare tile-group shared memory
 	bsg_tile_group_shared_mem (int, sh_A, (block_size_y * block_size_x));
-
 
 
 	int start_y = __bsg_tile_group_id_y * block_size_y;
@@ -45,6 +46,10 @@ int  __attribute__ ((noinline)) kernel_shared_mem_load_store(int *A_in, int *A_o
 
 	bsg_tile_group_barrier (&r_barrier, &c_barrier); 
 
+	if (__bsg_id == 0)
+		bsg_print_stat(1000 + __bsg_tile_group_id);
+
+	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
 
 	return 0;
 }

--- a/software/spmd/bsg_cuda_lite_runtime/shared_mem_load_store/kernel_shared_mem_load_store.c
+++ b/software/spmd/bsg_cuda_lite_runtime/shared_mem_load_store/kernel_shared_mem_load_store.c
@@ -16,7 +16,7 @@ INIT_TILE_GROUP_BARRIER(r_barrier, c_barrier, 0, bsg_tiles_X-1, 0, bsg_tiles_Y-1
 int  __attribute__ ((noinline)) kernel_shared_mem_load_store(int *A_in, int *A_out, int M, int N, int block_size_y, int block_size_x) {
 
 	if (__bsg_id == 0)
-		bsg_print_stat(__bsg_tile_group_id);
+		bsg_print_stat_start(__bsg_tile_group_id);
 	
 	// declare tile-group shared memory
 	bsg_tile_group_shared_mem (int, sh_A, (block_size_y * block_size_x));
@@ -47,7 +47,7 @@ int  __attribute__ ((noinline)) kernel_shared_mem_load_store(int *A_in, int *A_o
 	bsg_tile_group_barrier (&r_barrier, &c_barrier); 
 
 	if (__bsg_id == 0)
-		bsg_print_stat(1000 + __bsg_tile_group_id);
+		bsg_print_stat_end(__bsg_tile_group_id);
 
 	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
 

--- a/software/spmd/bsg_cuda_lite_runtime/stack_load/kernel_stack_load.c
+++ b/software/spmd/bsg_cuda_lite_runtime/stack_load/kernel_stack_load.c
@@ -13,8 +13,17 @@ INIT_TILE_GROUP_BARRIER(r_barrier, c_barrier, 0, bsg_tiles_X-1, 0, bsg_tiles_Y-1
 
 int  __attribute__ ((noinline)) kernel_stack_load(int *sum, int a1, int a2, int a3, int a4, int a5, int a6, int a7, int a8, int a9, int a10, int a11, int a12, int a13, int a14, int a15) {
 
+	if (__bsg_id == 0)
+		bsg_print_stat(__bsg_tile_group_id);
+
 	int res = a1 + a2 + a3 + a4 + a5 + a6 + a7 + a8 + a9 + a10 + a11 + a12 + a13 + 14 + a15;
 	sum[__bsg_id] = res;
 	bsg_tile_group_barrier(&r_barrier, &c_barrier);
+
+	if (__bsg_id == 0)
+		bsg_print_stat(1000 + __bsg_tile_group_id);
+
+	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
+
 	return 0;
 }

--- a/software/spmd/bsg_cuda_lite_runtime/stack_load/kernel_stack_load.c
+++ b/software/spmd/bsg_cuda_lite_runtime/stack_load/kernel_stack_load.c
@@ -14,14 +14,14 @@ INIT_TILE_GROUP_BARRIER(r_barrier, c_barrier, 0, bsg_tiles_X-1, 0, bsg_tiles_Y-1
 int  __attribute__ ((noinline)) kernel_stack_load(int *sum, int a1, int a2, int a3, int a4, int a5, int a6, int a7, int a8, int a9, int a10, int a11, int a12, int a13, int a14, int a15) {
 
 	if (__bsg_id == 0)
-		bsg_print_stat(__bsg_tile_group_id);
+		bsg_print_stat_start(__bsg_tile_group_id);
 
 	int res = a1 + a2 + a3 + a4 + a5 + a6 + a7 + a8 + a9 + a10 + a11 + a12 + a13 + 14 + a15;
 	sum[__bsg_id] = res;
 	bsg_tile_group_barrier(&r_barrier, &c_barrier);
 
 	if (__bsg_id == 0)
-		bsg_print_stat(1000 + __bsg_tile_group_id);
+		bsg_print_stat_end(__bsg_tile_group_id);
 
 	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
 

--- a/software/spmd/bsg_cuda_lite_runtime/tile_info/kernel_tile_info.c
+++ b/software/spmd/bsg_cuda_lite_runtime/tile_info/kernel_tile_info.c
@@ -10,6 +10,9 @@ INIT_TILE_GROUP_BARRIER(r_barrier, c_barrier, 0, bsg_tiles_X-1, 0, bsg_tiles_Y-1
 
 int  __attribute__ ((noinline)) kernel_tile_info() {
 
+	if (__bsg_id == 0)
+		bsg_print_stat(__bsg_tile_group_id);
+
 	bsg_remote_int_ptr origin_x_ptr;
 	bsg_remote_int_ptr origin_y_ptr;
 
@@ -33,6 +36,11 @@ int  __attribute__ ((noinline)) kernel_tile_info() {
 
 	
 	bsg_tile_group_barrier (&r_barrier, &c_barrier); 
+
+	if (__bsg_id == 0)
+		bsg_print_stat(1000 + __bsg_tile_group_id);
+
+	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
 
   return 0;
 }

--- a/software/spmd/bsg_cuda_lite_runtime/tile_info/kernel_tile_info.c
+++ b/software/spmd/bsg_cuda_lite_runtime/tile_info/kernel_tile_info.c
@@ -11,7 +11,7 @@ INIT_TILE_GROUP_BARRIER(r_barrier, c_barrier, 0, bsg_tiles_X-1, 0, bsg_tiles_Y-1
 int  __attribute__ ((noinline)) kernel_tile_info() {
 
 	if (__bsg_id == 0)
-		bsg_print_stat(__bsg_tile_group_id);
+		bsg_print_stat_start(__bsg_tile_group_id);
 
 	bsg_remote_int_ptr origin_x_ptr;
 	bsg_remote_int_ptr origin_y_ptr;
@@ -38,7 +38,7 @@ int  __attribute__ ((noinline)) kernel_tile_info() {
 	bsg_tile_group_barrier (&r_barrier, &c_barrier); 
 
 	if (__bsg_id == 0)
-		bsg_print_stat(1000 + __bsg_tile_group_id);
+		bsg_print_stat_end(__bsg_tile_group_id);
 
 	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
 

--- a/software/spmd/bsg_cuda_lite_runtime/vec_add/kernel_vec_add.c
+++ b/software/spmd/bsg_cuda_lite_runtime/vec_add/kernel_vec_add.c
@@ -13,7 +13,7 @@ INIT_TILE_GROUP_BARRIER(r_barrier, c_barrier, 0, bsg_tiles_X-1, 0, bsg_tiles_Y-1
 int  __attribute__ ((noinline)) kernel_vec_add(int *A, int *B, int *C, int N, int block_size_x) {
 
 	if (__bsg_id == 0)
-		bsg_print_stat(__bsg_tile_group_id);
+		bsg_print_stat_start(__bsg_tile_group_id);
 
 	int start_x = block_size_x * (__bsg_tile_group_id_y * __bsg_grid_dim_x + __bsg_tile_group_id_x); 
 	for (int iter_x = __bsg_id; iter_x < block_size_x; iter_x += bsg_tiles_X * bsg_tiles_Y) { 
@@ -23,7 +23,7 @@ int  __attribute__ ((noinline)) kernel_vec_add(int *A, int *B, int *C, int N, in
 	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
 
 	if (__bsg_id == 0)
-		bsg_print_stat(1000 + __bsg_tile_group_id);
+		bsg_print_stat_end(__bsg_tile_group_id);
 
 	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
 

--- a/software/spmd/bsg_cuda_lite_runtime/vec_add/kernel_vec_add.c
+++ b/software/spmd/bsg_cuda_lite_runtime/vec_add/kernel_vec_add.c
@@ -12,10 +12,18 @@ INIT_TILE_GROUP_BARRIER(r_barrier, c_barrier, 0, bsg_tiles_X-1, 0, bsg_tiles_Y-1
 
 int  __attribute__ ((noinline)) kernel_vec_add(int *A, int *B, int *C, int N, int block_size_x) {
 
+	if (__bsg_id == 0)
+		bsg_print_stat(__bsg_tile_group_id);
+
 	int start_x = block_size_x * (__bsg_tile_group_id_y * __bsg_grid_dim_x + __bsg_tile_group_id_x); 
 	for (int iter_x = __bsg_id; iter_x < block_size_x; iter_x += bsg_tiles_X * bsg_tiles_Y) { 
 		C[start_x + iter_x] = A[start_x + iter_x] + B[start_x + iter_x];
 	}
+
+	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
+
+	if (__bsg_id == 0)
+		bsg_print_stat(1000 + __bsg_tile_group_id);
 
 	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
 

--- a/software/spmd/bsg_cuda_lite_runtime/vec_add_parallel/kernel_vec_add_parallel.c
+++ b/software/spmd/bsg_cuda_lite_runtime/vec_add_parallel/kernel_vec_add_parallel.c
@@ -13,7 +13,7 @@ INIT_TILE_GROUP_BARRIER(r_barrier, c_barrier, 0, bsg_tiles_X-1, 0, bsg_tiles_Y-1
 int  __attribute__ ((noinline)) kernel_vec_add_parallel(int *A, int *B, int *C, int N, int block_size_x) {
 
 	if (__bsg_id == 0)
-		bsg_print_stat(__bsg_tile_group_id);
+		bsg_print_stat_start(__bsg_tile_group_id);
 
 	int start_x = block_size_x * (__bsg_tile_group_id_y * __bsg_grid_dim_x + __bsg_tile_group_id_x); 
 	for (int iter_x = __bsg_id; iter_x < block_size_x; iter_x += bsg_tiles_X * bsg_tiles_Y) { 
@@ -23,7 +23,7 @@ int  __attribute__ ((noinline)) kernel_vec_add_parallel(int *A, int *B, int *C, 
 	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
 
 	if (__bsg_id == 0)
-		bsg_print_stat(1000 + __bsg_tile_group_id);
+		bsg_print_stat_end(__bsg_tile_group_id);
 
 	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
 

--- a/software/spmd/bsg_cuda_lite_runtime/vec_add_parallel/kernel_vec_add_parallel.c
+++ b/software/spmd/bsg_cuda_lite_runtime/vec_add_parallel/kernel_vec_add_parallel.c
@@ -12,10 +12,18 @@ INIT_TILE_GROUP_BARRIER(r_barrier, c_barrier, 0, bsg_tiles_X-1, 0, bsg_tiles_Y-1
 
 int  __attribute__ ((noinline)) kernel_vec_add_parallel(int *A, int *B, int *C, int N, int block_size_x) {
 
+	if (__bsg_id == 0)
+		bsg_print_stat(__bsg_tile_group_id);
+
 	int start_x = block_size_x * (__bsg_tile_group_id_y * __bsg_grid_dim_x + __bsg_tile_group_id_x); 
 	for (int iter_x = __bsg_id; iter_x < block_size_x; iter_x += bsg_tiles_X * bsg_tiles_Y) { 
 		C[start_x + iter_x] = A[start_x + iter_x] + B[start_x + iter_x];
 	}
+
+	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
+
+	if (__bsg_id == 0)
+		bsg_print_stat(1000 + __bsg_tile_group_id);
 
 	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
 

--- a/software/spmd/bsg_cuda_lite_runtime/vec_add_parallel_multi_grid/kernel_vec_add_parallel_multi_grid.c
+++ b/software/spmd/bsg_cuda_lite_runtime/vec_add_parallel_multi_grid/kernel_vec_add_parallel_multi_grid.c
@@ -13,7 +13,7 @@ INIT_TILE_GROUP_BARRIER(r_barrier, c_barrier, 0, bsg_tiles_X-1, 0, bsg_tiles_Y-1
 int  __attribute__ ((noinline)) kernel_vec_add_parallel_multi_grid(int *A, int *B, int *C, int N, int block_size_x) {
 
 	if (__bsg_id == 0)
-		bsg_print_stat(__bsg_tile_group_id);
+		bsg_print_stat_start(__bsg_tile_group_id);
 
 	int start_x = block_size_x * (__bsg_tile_group_id_y * __bsg_grid_dim_x + __bsg_tile_group_id_x); 
 	for (int iter_x = __bsg_id; iter_x < block_size_x; iter_x += bsg_tiles_X * bsg_tiles_Y) { 
@@ -23,7 +23,7 @@ int  __attribute__ ((noinline)) kernel_vec_add_parallel_multi_grid(int *A, int *
 	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
 
 	if (__bsg_id == 0)
-		bsg_print_stat(1000 + __bsg_tile_group_id);
+		bsg_print_stat_end(__bsg_tile_group_id);
 
 	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
 

--- a/software/spmd/bsg_cuda_lite_runtime/vec_add_parallel_multi_grid/kernel_vec_add_parallel_multi_grid.c
+++ b/software/spmd/bsg_cuda_lite_runtime/vec_add_parallel_multi_grid/kernel_vec_add_parallel_multi_grid.c
@@ -12,10 +12,18 @@ INIT_TILE_GROUP_BARRIER(r_barrier, c_barrier, 0, bsg_tiles_X-1, 0, bsg_tiles_Y-1
 
 int  __attribute__ ((noinline)) kernel_vec_add_parallel_multi_grid(int *A, int *B, int *C, int N, int block_size_x) {
 
+	if (__bsg_id == 0)
+		bsg_print_stat(__bsg_tile_group_id);
+
 	int start_x = block_size_x * (__bsg_tile_group_id_y * __bsg_grid_dim_x + __bsg_tile_group_id_x); 
 	for (int iter_x = __bsg_id; iter_x < block_size_x; iter_x += bsg_tiles_X * bsg_tiles_Y) { 
 		C[start_x + iter_x] = A[start_x + iter_x] + B[start_x + iter_x];
 	}
+
+	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
+
+	if (__bsg_id == 0)
+		bsg_print_stat(1000 + __bsg_tile_group_id);
 
 	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
 

--- a/software/spmd/bsg_cuda_lite_runtime/vec_add_serial_multi_grid/kernel_vec_add_serial_multi_grid.c
+++ b/software/spmd/bsg_cuda_lite_runtime/vec_add_serial_multi_grid/kernel_vec_add_serial_multi_grid.c
@@ -12,10 +12,18 @@ INIT_TILE_GROUP_BARRIER(r_barrier, c_barrier, 0, bsg_tiles_X-1, 0, bsg_tiles_Y-1
 
 int  __attribute__ ((noinline)) kernel_vec_add_serial_multi_grid(int *A, int *B, int *C, int N, int block_size_x) {
 
+	if (__bsg_id == 0)
+		bsg_print_stat(__bsg_tile_group_id);
+
 	int start_x = block_size_x * (__bsg_tile_group_id_y * __bsg_grid_dim_x + __bsg_tile_group_id_x); 
 	for (int iter_x = __bsg_id; iter_x < block_size_x; iter_x += bsg_tiles_X * bsg_tiles_Y) { 
 		C[start_x + iter_x] = A[start_x + iter_x] + B[start_x + iter_x];
 	}
+
+	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
+
+	if (__bsg_id == 0)
+		bsg_print_stat(1000 + __bsg_tile_group_id);
 
 	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
 

--- a/software/spmd/bsg_cuda_lite_runtime/vec_add_serial_multi_grid/kernel_vec_add_serial_multi_grid.c
+++ b/software/spmd/bsg_cuda_lite_runtime/vec_add_serial_multi_grid/kernel_vec_add_serial_multi_grid.c
@@ -13,7 +13,7 @@ INIT_TILE_GROUP_BARRIER(r_barrier, c_barrier, 0, bsg_tiles_X-1, 0, bsg_tiles_Y-1
 int  __attribute__ ((noinline)) kernel_vec_add_serial_multi_grid(int *A, int *B, int *C, int N, int block_size_x) {
 
 	if (__bsg_id == 0)
-		bsg_print_stat(__bsg_tile_group_id);
+		bsg_print_stat_start(__bsg_tile_group_id);
 
 	int start_x = block_size_x * (__bsg_tile_group_id_y * __bsg_grid_dim_x + __bsg_tile_group_id_x); 
 	for (int iter_x = __bsg_id; iter_x < block_size_x; iter_x += bsg_tiles_X * bsg_tiles_Y) { 
@@ -23,7 +23,7 @@ int  __attribute__ ((noinline)) kernel_vec_add_serial_multi_grid(int *A, int *B,
 	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
 
 	if (__bsg_id == 0)
-		bsg_print_stat(1000 + __bsg_tile_group_id);
+		bsg_print_stat_end(__bsg_tile_group_id);
 
 	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
 

--- a/software/spmd/bsg_cuda_lite_runtime/vec_add_shared_mem/kernel_vec_add_shared_mem.c
+++ b/software/spmd/bsg_cuda_lite_runtime/vec_add_shared_mem/kernel_vec_add_shared_mem.c
@@ -12,6 +12,9 @@ INIT_TILE_GROUP_BARRIER(r_barrier, c_barrier, 0, bsg_tiles_X-1, 0, bsg_tiles_Y-1
 
 int  __attribute__ ((noinline)) kernel_vec_add_shared_mem(int *A, int *B, int *C, int N, int block_size_x) {
 
+	if (__bsg_id == 0)
+		bsg_print_stat(__bsg_tile_group_id);
+
 	// Declare tile-group shared memroy with specific size
 	bsg_tile_group_shared_mem (int, sh_A, block_size_x);
 	bsg_tile_group_shared_mem (int, sh_B, block_size_x); 
@@ -54,6 +57,10 @@ int  __attribute__ ((noinline)) kernel_vec_add_shared_mem(int *A, int *B, int *C
 
 	bsg_tile_group_barrier(&r_barrier, &c_barrier);
 
+	if (__bsg_id == 0)
+		bsg_print_stat(1000 + __bsg_tile_group_id);
+
+	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
 
   return 0;
 }

--- a/software/spmd/bsg_cuda_lite_runtime/vec_add_shared_mem/kernel_vec_add_shared_mem.c
+++ b/software/spmd/bsg_cuda_lite_runtime/vec_add_shared_mem/kernel_vec_add_shared_mem.c
@@ -13,7 +13,7 @@ INIT_TILE_GROUP_BARRIER(r_barrier, c_barrier, 0, bsg_tiles_X-1, 0, bsg_tiles_Y-1
 int  __attribute__ ((noinline)) kernel_vec_add_shared_mem(int *A, int *B, int *C, int N, int block_size_x) {
 
 	if (__bsg_id == 0)
-		bsg_print_stat(__bsg_tile_group_id);
+		bsg_print_stat_start(__bsg_tile_group_id);
 
 	// Declare tile-group shared memroy with specific size
 	bsg_tile_group_shared_mem (int, sh_A, block_size_x);
@@ -58,7 +58,7 @@ int  __attribute__ ((noinline)) kernel_vec_add_shared_mem(int *A, int *B, int *C
 	bsg_tile_group_barrier(&r_barrier, &c_barrier);
 
 	if (__bsg_id == 0)
-		bsg_print_stat(1000 + __bsg_tile_group_id);
+		bsg_print_stat_end(__bsg_tile_group_id);
 
 	bsg_tile_group_barrier(&r_barrier, &c_barrier); 
 


### PR DESCRIPTION
- Added a new symbol, __bsg_tile_group_id which is the flat tile group ID, or (__bsg_tile_group_id_y * __bsg_grid_dim_x + __bsg_tile_group_id_x) to the bsg_set_tile_x_y().
- Added bsg_print_stat() statements to the beginning and end of all cuda lite runtime regression tests. 
