### PR TITLE
Fix LLVM installation

### DIFF
--- a/software/mk/.gitignore
+++ b/software/mk/.gitignore
@@ -1,0 +1,1 @@
+cmake-install.sh

--- a/software/mk/Makefile.builddefs
+++ b/software/mk/Makefile.builddefs
@@ -173,11 +173,10 @@ RISCV_GXX_OPTS += $(RISCV_GXX_EXTRA_OPTS)
 spmd_defs = -DPREALLOCATE=0 -DHOST_DEBUG=0
 
 ifdef CLANG
-LLVM_DIR ?= /opt/llvm
-export LLVM_DIR
-LLVM_CLANG       ?= $(LLVM_DIR)/llvm-install/bin/clang
-LLVM_OPT         ?= $(LLVM_DIR)/llvm-install/bin/opt
-LLVM_LLC         ?= $(LLVM_DIR)/llvm-install/bin/llc
+LLVM_DIR         ?= $(BSG_MANYCORE_DIR)/software/riscv-tools/llvm/llvm-install
+LLVM_CLANG       ?= $(LLVM_DIR)/bin/clang
+LLVM_OPT         ?= $(LLVM_DIR)/bin/opt
+LLVM_LLC         ?= $(LLVM_DIR)/bin/llc
 PASS_DIR         ?= $(BSG_MANYCORE_DIR)/software/manycore-llvm-pass
 PASS_LIB         ?= build/manycore/libManycorePass.so
 RUNTIME_FNS      ?= $(BSG_MANYCORE_DIR)/software/bsg_manycore_lib/bsg_tilegroup.h
@@ -211,7 +210,7 @@ $(LLVM_DIR):
 
 $(PASS_LIB): $(PASS_DIR)/manycore/Manycore.cpp $(LLVM_DIR)
 	mkdir -p build
-	cd build && cmake3 $(PASS_DIR) -Dbsg_group_size:INTEGER=$(bsg_group_size) && make
+	cd build && LLVM_DIR=$(LLVM_DIR) cmake3 $(PASS_DIR) -Dbsg_group_size:INTEGER=$(bsg_group_size) && make
 
 else
 %.o: %.c

--- a/software/mk/Makefile.builddefs
+++ b/software/mk/Makefile.builddefs
@@ -173,10 +173,11 @@ RISCV_GXX_OPTS += $(RISCV_GXX_EXTRA_OPTS)
 spmd_defs = -DPREALLOCATE=0 -DHOST_DEBUG=0
 
 ifdef CLANG
-export LLVM_DIR   = /mnt/bsg/diskbits/neilryan/llvm/llvm-install
-LLVM_CLANG       ?= $(LLVM_DIR)/bin/clang
-LLVM_OPT         ?= $(LLVM_DIR)/bin/opt
-LLVM_LLC         ?= $(LLVM_DIR)/bin/llc
+LLVM_DIR ?= /opt/llvm
+export LLVM_DIR
+LLVM_CLANG       ?= $(LLVM_DIR)/llvm-install/bin/clang
+LLVM_OPT         ?= $(LLVM_DIR)/llvm-install/bin/opt
+LLVM_LLC         ?= $(LLVM_DIR)/llvm-install/bin/llc
 PASS_DIR         ?= $(BSG_MANYCORE_DIR)/software/manycore-llvm-pass
 PASS_LIB         ?= build/manycore/libManycorePass.so
 RUNTIME_FNS      ?= $(BSG_MANYCORE_DIR)/software/bsg_manycore_lib/bsg_tilegroup.h
@@ -210,7 +211,7 @@ $(LLVM_DIR):
 
 $(PASS_LIB): $(PASS_DIR)/manycore/Manycore.cpp $(LLVM_DIR)
 	mkdir -p build
-	cd build && cmake $(PASS_DIR) -Dbsg_group_size:INTEGER=$(bsg_group_size) && make
+	cd build && cmake3 $(PASS_DIR) -Dbsg_group_size:INTEGER=$(bsg_group_size) && make
 
 else
 %.o: %.c

--- a/software/mk/Makefile.llvminstall
+++ b/software/mk/Makefile.llvminstall
@@ -7,10 +7,6 @@ ifndef RISCV_INSTALL_DIR
 endif
 
 llvm-install:
-	# Install cmake
-	wget https://github.com/Kitware/CMake/releases/download/v3.14.0-rc4/cmake-3.14.0-rc4-Linux-x86_64.sh -O cmake-install.sh
-	chmod +x cmake-install.sh && sudo ./cmake-install.sh --skip-license --prefix=/usr/local
-	rm cmake-install.sh
 	mkdir -p $(LLVM_DIR)/llvm-build && mkdir -p $(LLVM_DIR)/llvm-install
 	# Clone LLVM sources
 	cd $(LLVM_DIR) && wget http://releases.llvm.org/7.0.1/llvm-7.0.1.src.tar.xz && \
@@ -22,7 +18,7 @@ llvm-install:
 	# aren't strictly necessary, but otherwise there'd be more options to
 	# pass on the command line for clang. We Only need X86 and RISCV targets.
 	cd $(LLVM_DIR)/llvm-build \
-	    && cmake -DCMAKE_BUILD_TYPE="Debug" \
+	    && cmake3 -DCMAKE_BUILD_TYPE="Debug" \
 	    -DLLVM_TARGETS_TO_BUILD="X86" \
 	    -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD="RISCV" \
 	    -DBUILD_SHARED_LIBS=True \
@@ -33,5 +29,5 @@ llvm-install:
 	    -DDEFAULT_SYSROOT="$(RISCV_INSTALL_DIR)/riscv32-unknown-elf" \
 	    -DLLVM_DEFAULT_TARGET_TRIPLE="riscv32-unknown-elf" \
 	    ../llvm-src
-	cd  $(LLVM_DIR)/llvm-build && cmake --build . -- -j12 && make install
+	cd  $(LLVM_DIR)/llvm-build && cmake3 --build . -- -j12 && make install
 	rm -rf $(LLVM_DIR)/llvm-build $(LLVM_DIR)/llvm-src

--- a/software/riscv-tools/.gitignore
+++ b/software/riscv-tools/.gitignore
@@ -2,3 +2,4 @@ depends/
 riscv-gnu-toolchain/
 riscv-isa-sim/
 riscv-install/
+llvm

--- a/software/riscv-tools/Makefile
+++ b/software/riscv-tools/Makefile
@@ -48,6 +48,7 @@ SPIKE_URL         := https://github.com/riscv/riscv-isa-sim.git
 SPIKE_PATCH       := spike.patch
 SPIKE_TAG         := v1.0.0
 
+LLVM_DIR          := $(CURDIR)/llvm
 export PATH:=$(DEPENDS_DIR)/bin:$(PATH)
 
 DEPENDS_LIST=autoconf-2.69 automake-1.14
@@ -138,10 +139,17 @@ build-spike:
 	cd $(SPIKE_REPO) && ./configure --prefix=$(RISCV) --enable-commitlog
 	cd $(SPIKE_REPO) && $(MAKE) && $(MAKE) install
 
+build-llvm:
+	@echo "====================================="
+	@echo "Building $(LLVM_DIR)..."
+	@echo "====================================="
+	$(MAKE) -C ../mk/ -f Makefile.llvminstall LLVM_DIR=$(LLVM_DIR) RISCV_INSTALL_DIR=$(RISCV)
+
 build-all: 
 	$(MAKE) build-deps 
 	$(MAKE) build-riscv-gnu-tools 
 	$(MAKE) build-spike
+	$(MAKE) build-llvm
 
 rebuild-newlib:
 	$(MAKE) -C $(TOOLCHAIN_REPO)/build-newlib
@@ -160,9 +168,10 @@ clean-builds:
 
 clean-install:
 	rm -rf riscv-install
+	rm -rf $(LLVM_DIR)
 
 clean-all:
-	rm -rf $(DEPENDS_DIR) $(TOOLCHAIN_REPO) $(SPIKE_REPO) riscv-install
+	rm -rf $(DEPENDS_DIR) $(TOOLCHAIN_REPO) $(SPIKE_REPO) riscv-install $(LLVM_DIR)
 
 installs:
 	sudo apt-get install autoconf automake libtool curl gawk bison flex texinfo gperf \


### PR DESCRIPTION
I've removed the dependence that LLVM_DIR be a globally accessible directory. Now, it is built with the RISC-V tools on a clean installation. 

This makes bsg_manycore immediately portable to kk9, and simplifies the aws build process (a bit)

This also updates to cmake3 (instead of cmake) which means we no longer need to download and build cmake.