### PR TITLE
Adds Vanilla Stats Parser

### DIFF
--- a/software/py/generate_stats.py
+++ b/software/py/generate_stats.py
@@ -20,6 +20,29 @@ import re
 from enum import Enum
 
 
+instructions_list = ['instr','fadd','fsub','fmul','fsgnj','fsgnjn',\
+                     'fsgnjx','fmin','fmax','fcvt_s_w','fcvt_s_wu',\
+                     'fmv_w_x','feq','flt','fle','fcvt_w_s','fcvt_wu_s',\
+                     'fclass','fmv_x_w','local_ld','local_st',\
+                     'remote_ld','remote_st','local_flw','local_fsw',\
+                     'remote_flw','remote_fsw','lr','lr_aq',\
+                     'swap_aq','swap_rl','beq','bne','blt','bge','bltu',\
+                     'bgeu','jalr','jal', 'sll',\
+                     'slli','srl','srli','sra','srai','add','addi','sub',\
+                     'lui','auipc','xor','xori','or','ori','and','andi',\
+                     'slt','slti','sltu','sltiu','mul','mulh','mulhsu',\
+                     'mulhu','div','divu','rem','remu','fence']
+
+unkonwns_list = ['icache_miss', 'beq_miss', 'bne_miss', 'blt_miss',\
+                'bge_miss', 'bltu_miss', 'bgeu_miss', 'jalr_miss']
+
+stalls_list = ['stall_fp_remote_load','stall_fp_local_load',\
+               'stall_depend','stall_depend_remote_load',\
+               'stall_depend_local_load','stall_force_wb',\
+               'stall_ifetch_wait','stall_icache_store',\
+               'stall_lr_aq','stall_md,stall_remote_req','stall_local_flw']
+
+
 
 class Stats:
 
@@ -33,6 +56,7 @@ class Stats:
     self.total_execution_time = 0
     self.execution_stats_file = open("execution_stats.log", "w")
     self.stats_list = []
+    self.max_time = 0 # Used to find the last bsg_print_statement (latest in time)
 
   # Create a list of stat types
   def define_stats_list(self, tokens):
@@ -49,6 +73,17 @@ class Stats:
         self.num_tile_groups += 1
       else: 
         self.timing_end_list[int(tokens[self.stats_list.index('tag')]) - 1000] = int(tokens[self.stats_list.index('time')])
+
+
+  # Generate instruction stats
+#  def generate_instruction_stats(self, tokens): 
+#    if (tokens[self.stats_list.index('time')] < self.max_time):
+#      return
+#    self.max_time = tokens[self.stats_list.index('time')]
+#    for token in tokens:
+#      if token in instruction_list
+
+    
    
 
   # Print execution timing for all tile groups 
@@ -78,7 +113,11 @@ class Stats:
           self.define_stats_list(tokens)
           continue
 
+        # Generate timing stats 
         self.generate_stats_timing(tokens)
+
+        # Generate instruction stats
+        #self.generate_instruction_stats(tokens)
 
 
     self.print_stats_timing()

--- a/software/py/generate_stats.py
+++ b/software/py/generate_stats.py
@@ -63,6 +63,8 @@ class Stats:
     self.timing_end_list = [0] * self.max_tile_groups
     self.total_execution_time = 0
     self.total_instr_cnt = 0
+    self.total_stall_cnt = 0
+    self.total_miss_cnt = 0
     self.stats_list = []
     self.stats_count = []
 
@@ -84,19 +86,10 @@ class Stats:
       else: 
         self.timing_end_list[int(tokens[self.stats_list.index('tag')]) - 1000] = int(tokens[self.stats_list.index('time')])
 
-  # Calculate number of executed instruction by type for all tiles and total
-  def generate_stats_instructions(self, tokens):
+  # Sum up all other stats for all tiles based on the last bsg_print_stat instr
+  def generate_stats_all(self, tokens):
     for idx in range (0, len(self.stats_list)):
-      if self.stats_list[idx] in instructions_list:
-        self.stats_count[idx] += int(tokens[idx])
-    return
-
-   # Calculate number of stall cycles by type for all tiles and total
-  def generate_stats_stalls(self, tokens):
-    return
-
-  # Calculate number of misses by type for all tiles and total
-  def generate_stats_miss(self, tokens):
+      self.stats_count[idx] += int(tokens[idx])
     return
 
 
@@ -117,19 +110,37 @@ class Stats:
                                     "=======================================================\n")
     for idx in range (0, len(self.stats_list)):
       if self.stats_list[idx] in instructions_list:
-        self.execution_stats_file.write("{:14}\t{}\n".format(self.stats_list[idx], self.stats_count[idx]))
+        self.execution_stats_file.write("{:25}\t{}\n".format(self.stats_list[idx], self.stats_count[idx]))
         if self.stats_list[idx] != 'instr':
           self.total_instr_cnt += self.stats_count[idx]
-    self.execution_stats_file.write("{:14}\t{}\n".format("Total", self.total_instr_cnt))
+    self.execution_stats_file.write("{:25}\t{}\n".format("Total", self.total_instr_cnt))
     self.execution_stats_file.write("=======================================================\n\n")
     return
 
+
   # Print instruction stats for all tiles and total
   def print_stats_stalls(self):
+    self.execution_stats_file.write("Stall Stats:\n" + \
+                                    "=======================================================\n")
+    for idx in range (0, len(self.stats_list)):
+      if self.stats_list[idx] in stalls_list:
+        self.execution_stats_file.write("{:25}\t{}\n".format(self.stats_list[idx], self.stats_count[idx]))
+        self.total_stall_cnt += self.stats_count[idx]
+    self.execution_stats_file.write("{:25}\t{}\n".format("Total", self.total_stall_cnt))
+    self.execution_stats_file.write("=======================================================\n\n")
     return
+
 
   # Print miss stats for all tiles and total
   def print_stats_miss(self):
+    self.execution_stats_file.write("Miss Stats:\n" + \
+                                    "=======================================================\n")
+    for idx in range (0, len(self.stats_list)):
+      if self.stats_list[idx] in miss_list:
+        self.execution_stats_file.write("{:25}\t{}\n".format(self.stats_list[idx], self.stats_count[idx]))
+        self.total_miss_cnt += self.stats_count[idx]
+    self.execution_stats_file.write("{:25}\t{}\n".format("Total", self.total_miss_cnt))
+    self.execution_stats_file.write("=======================================================\n\n")
     return
 
 
@@ -155,9 +166,7 @@ class Stats:
       for idx in range(len(self.vanilla_stats_lines) - self.manycore_dim, len(self.vanilla_stats_lines)):
         line = self.vanilla_stats_lines[idx]
         tokens = line.split(",")
-        self.generate_stats_instructions(tokens)
-        self.generate_stats_stalls(tokens)
-        self.generate_stats_miss(tokens)
+        self.generate_stats_all(tokens)
 
 
     self.print_stats_timing()

--- a/software/py/generate_stats.py
+++ b/software/py/generate_stats.py
@@ -37,7 +37,7 @@ instructions_list = ['instr','fadd','fsub','fmul','fsgnj','fsgnjn',\
                      'slt','slti','sltu','sltiu','mul','mulh','mulhsu',\
                      'mulhu','div','divu','rem','remu','fence']
 
-unkonwns_list = ['icache_miss', 'beq_miss', 'bne_miss', 'blt_miss',\
+miss_list = ['icache_miss', 'beq_miss', 'bne_miss', 'blt_miss',\
                 'bge_miss', 'bltu_miss', 'bgeu_miss', 'jalr_miss']
 
 stalls_list = ['stall_fp_remote_load','stall_fp_local_load',\
@@ -62,12 +62,16 @@ class Stats:
     self.timing_start_list = [0] * self.max_tile_groups
     self.timing_end_list = [0] * self.max_tile_groups
     self.total_execution_time = 0
+    self.total_instr_cnt = 0
     self.stats_list = []
+    self.stats_count = []
+
 
   # Create a list of stat types
   def define_stats_list(self, tokens):
     for token in tokens:
       self.stats_list += [token]
+      self.stats_count += [0]
     return
 
 
@@ -82,29 +86,50 @@ class Stats:
 
   # Calculate number of executed instruction by type for all tiles and total
   def generate_stats_instructions(self, tokens):
+    for idx in range (0, len(self.stats_list)):
+      if self.stats_list[idx] in instructions_list:
+        self.stats_count[idx] += int(tokens[idx])
     return
 
    # Calculate number of stall cycles by type for all tiles and total
   def generate_stats_stalls(self, tokens):
     return
- 
+
+  # Calculate number of misses by type for all tiles and total
+  def generate_stats_miss(self, tokens):
+    return
+
 
   # Print execution timing for all tile groups 
   def print_stats_timing(self):
-    self.execution_stats_file.write("Timing Stats ==========================================\n")
+    self.execution_stats_file.write("Timing Stats:\n" + \
+                                    "=======================================================\n")
     for i in range (0, self.num_tile_groups):
-      self.execution_stats_file.write("Tile group {}:\t{}\n".format(i, self.timing_end_list[i] - self.timing_start_list[i]))
+      self.execution_stats_file.write("{:10}{:4}:\t{}\n".format("Tile group", i, self.timing_end_list[i] - self.timing_start_list[i]))
       self.total_execution_time += (self.timing_end_list[i] - self.timing_start_list[i])
-    self.execution_stats_file.write("Total(cycles):\t{}\n".format(self.total_execution_time))
-    self.execution_stats_file.write("=======================================================\n")
+    self.execution_stats_file.write("{:14}:\t{}\n".format("Total (cycles)", self.total_execution_time))
+    self.execution_stats_file.write("=======================================================\n\n")
 
 
   # Print instruction stats for all tiles and total
   def print_stats_instructions(self):
+    self.execution_stats_file.write("Instruction Stats:\n" + \
+                                    "=======================================================\n")
+    for idx in range (0, len(self.stats_list)):
+      if self.stats_list[idx] in instructions_list:
+        self.execution_stats_file.write("{:14}\t{}\n".format(self.stats_list[idx], self.stats_count[idx]))
+        if self.stats_list[idx] != 'instr':
+          self.total_instr_cnt += self.stats_count[idx]
+    self.execution_stats_file.write("{:14}\t{}\n".format("Total", self.total_instr_cnt))
+    self.execution_stats_file.write("=======================================================\n\n")
     return
 
   # Print instruction stats for all tiles and total
   def print_stats_stalls(self):
+    return
+
+  # Print miss stats for all tiles and total
+  def print_stats_miss(self):
     return
 
 
@@ -132,12 +157,14 @@ class Stats:
         tokens = line.split(",")
         self.generate_stats_instructions(tokens)
         self.generate_stats_stalls(tokens)
+        self.generate_stats_miss(tokens)
 
 
     self.print_stats_timing()
     self.print_stats_instructions()
     self.print_stats_stalls()
-   
+    self.print_stats_miss()
+  
 
     # cleanup
     self.vanilla_stats_file.close()

--- a/software/py/generate_stats.py
+++ b/software/py/generate_stats.py
@@ -1,0 +1,85 @@
+#
+#   generate_stats.py
+#
+#   vanilla core stats extractor
+# 
+#   input: vanilla_stats.log
+#   output: execution_stats.log
+#
+#   @author Borna
+#
+#   How to use:
+#   python3 generate_stats.py {vanilla_stats.log}
+#
+#
+
+
+import sys
+import os
+import re
+from enum import Enum
+
+
+
+class Stats:
+
+  # default constructor
+  def __init__(self):
+
+    self.max_tile_groups = 1024
+    self.num_tile_groups = 0
+    self.start_list = [0] * self.max_tile_groups
+    self.end_list = [0] * self.max_tile_groups
+    self.total_execution_time = 0
+    self.execution_stats_file = open("execution_stats.log", "w")
+
+  def define_stats(self, stat_tokens):
+    return
+
+
+  # default stats generator
+  def generate_stats(self, input_file):
+    self.vanilla_stats_file = open (input_file, "r")
+    if (self.vanilla_stats_file.mode == 'r'):
+      self.vanilla_stats_lines = self.vanilla_stats_file.readlines()
+
+      for idx,line in enumerate(self.vanilla_stats_lines):
+        tokens = line.split(",")
+
+        if (idx == 0):
+          self.define_stats(tokens)
+          continue
+
+        self.execution_stats_file.write("Time: {}\tX: {}\tY: {}\tTGID: {}\n".format(tokens[0], tokens[1], tokens[2], tokens[3]))
+        if (tokens[1] == '0' and tokens[2] == '1'):
+          if (int(tokens[3]) < 1000):
+            self.start_list[int(tokens[3])] = int(tokens[0])
+            self.num_tile_groups += 1
+          else: 
+            self.end_list[int(tokens[3]) - 1000] = int(tokens[0])
+
+    self.execution_stats_file.write("Tile groups: {}\n".format(self.num_tile_groups))
+
+    for i in range (0, self.num_tile_groups):
+      self.total_execution_time += self.end_list[i] - self.start_list[i]
+
+    self.execution_stats_file.write("Total Execution cycles: {}".format(self.total_execution_time))
+
+    # cleanup
+    self.vanilla_stats_file.close()
+    self.execution_stats_file.close()
+
+
+# main()
+if __name__ == "__main__":
+
+  if len(sys.argv) != 2:
+    print("wrong number of arguments.")
+    print("python vanilla.log")
+    sys.exit()
+ 
+  input_file = sys.argv[1]
+
+  st = Stats();
+  st.generate_stats(input_file)
+

--- a/software/py/vanilla_stats_parser.py
+++ b/software/py/vanilla_stats_parser.py
@@ -4,14 +4,15 @@
 #   vanilla core stats extractor
 # 
 #   input: vanilla_stats.log
-#   output: execution_stats.log
+#   output: manycore_stats.log
+#   output: tile_stats/tile_#_stats.log for all tiles 
 #
 #   @author Borna
 #
 #   How to use:
-#   python3 generate_stats.py {manycore_dim_y} {manycore_dim_x} {vanilla_stats.log}
+#   python3 generate_stats.py {manycore_dim_y} {manycore_dim_x} {total OR per_tile} {vanilla_stats.log}
 #
-#   ex) python3 generate_stats.py 4 4 vanilla_stats.log
+#   ex) python3 generate_stats.py 4 4 per_tile vanilla_stats.log
 #
 #   {manycore_dim_y}  Mesh Y dimension of manycore
 #   {manycore_dim_x}  Mesh X dimension of manycore
@@ -24,7 +25,6 @@ import re
 from enum import Enum
 import csv
 
-
 # These values are used by the manycore library in bsg_print_stat instructions
 # They are added to the tag value to detremine wether the message is from the 
 # start or the end of the kernel 
@@ -32,7 +32,8 @@ import csv
 # bsg_manycore/software/bsg_manycore_lib/bsg_manycore.h
 bsg_PRINT_STAT_START_VAL = 0x00000000
 bsg_PRINT_STAT_END_VAL   = 0xDEAD0000
-
+bsg_TILE_GROUP_ORG_X = 0
+bsg_TILE_GROUP_ORG_Y = 1
 
 
 # formatting parameters for aligned printing
@@ -84,19 +85,23 @@ stalls_list =       ['stall_fp_remote_load','stall_fp_local_load',
 class VanillaStatsParser:
 
   # default constructor
-  def __init__(self, manycore_dim_y, manycore_dim_x):
+  def __init__(self, manycore_dim_y, manycore_dim_x, per_tile_stat):
 
     self.manycore_dim_y = manycore_dim_y
     self.manycore_dim_x = manycore_dim_x
     self.manycore_dim = manycore_dim_y * manycore_dim_x
+    self.per_tile_stat = per_tile_stat
 
-    self.execution_stats_file = open("execution_stats.log", "w")
+    self.manycore_stats_file = open("manycore_stats.log", "w")
 
     self.max_tile_groups = 1024
     self.num_tile_groups = 0
+#    self.num_tile_groups = [[0] * self.manycore_dim_x] * self.manycore_dim_y
 
-    self.timing_start_list = [0] * self.max_tile_groups
-    self.timing_end_list = [0] * self.max_tile_groups
+    self.timing_start_list = [0] * self.max_tile_groups 
+    self.timing_end_list =   [0] * self.max_tile_groups
+#    self.timing_start_list = [[[0] * self.max_tile_groups] * self.manycore_dim_x] * self.manycore_dim_y
+#    self.timing_end_list =   [[[0] * self.max_tile_groups] * self.manycore_dim_x] * self.manycore_dim_y
 
     self.total_execution_time = 0
     self.total_instr_cnt = 0
@@ -108,12 +113,18 @@ class VanillaStatsParser:
 
 
   def generate_stats_timing(self, trace):
-    if trace["x"] == 0 and trace["y"] == 1:
-      if(trace["tag"] < bsg_PRINT_STAT_END_VAL):
-        self.timing_start_list[trace["tag"]] = trace["time"]
+    y = trace["y"]
+    x = trace["x"]
+    relative_y = y - bsg_TILE_GROUP_ORG_Y
+    relative_x = x - bsg_TILE_GROUP_ORG_X
+    tg_num = trace["tag"]
+    # Only count those coming from the origin tile (0,0)
+    if (relative_x == 0 and relative_y == 0):
+      if(tg_num < bsg_PRINT_STAT_END_VAL):
+        self.timing_start_list[tg_num] = trace["time"]
         self.num_tile_groups += 1
       else:
-        self.timing_end_list[trace["tag"] - bsg_PRINT_STAT_END_VAL] = trace["time"]
+        self.timing_end_list[tg_num - bsg_PRINT_STAT_END_VAL] = trace["time"]
 
 
   # Sum up all other stats for all tiles based on the last bsg_print_stat instr
@@ -140,73 +151,132 @@ class VanillaStatsParser:
             self.tile_stat_dict[y][x][miss] = trace[miss]
 
 
-  # Print execution timing for all tile groups 
-  def print_manycore_stats_timing(self):
-    self.execution_stats_file.write("Timing Stats\n")
-    self.execution_stats_file.write(stats_timing_header_format.format("tile group", "exec time", "share (%)"))
-    self.execution_stats_file.write("{}".format(separating_line))
+  # Print execution timing for the entire manycore 
+  def print_manycore_stats_timing(self, stat_file):
+    # For total execution time, we only sum up the execution time of origin tile in tile groups
+    # The origin tile's relative coordinates is always 0,0 
+    stat_file.write("Timing Stats\n")
+    stat_file.write(stats_timing_header_format.format("tile group", "exec time", "share (%)"))
+    stat_file.write("{}".format(separating_line))
 
+    # Sum up execution time for all tile groups 
     for i in range (0, self.num_tile_groups):
       self.total_execution_time += (self.timing_end_list[i] - self.timing_start_list[i])
 
     for i in range (0, self.num_tile_groups):
       tg_time = self.timing_end_list[i] - self.timing_start_list[i]
-      self.execution_stats_file.write(stats_timing_data_format.format(i,
-                                                                      tg_time,
-                                                                      (tg_time / self.total_execution_time * 100)))
+      stat_file.write(stats_timing_data_format.format(i,
+                                                      tg_time,
+                                                      (tg_time / self.total_execution_time * 100)))
 
-    self.execution_stats_file.write(stats_timing_data_format.format("total",
-                                                                    self.total_execution_time,
-                                                                    (self.total_execution_time / self.total_execution_time * 100)))
-    self.execution_stats_file.write("{}\n".format(separating_line))
+    stat_file.write(stats_timing_data_format.format("total",
+                                                    self.total_execution_time,
+                                                    (self.total_execution_time / self.total_execution_time * 100)))
+    stat_file.write("{}\n".format(separating_line))
     return
 
 
-  # Print instruction stats for all tiles and total
-  def print_manycore_stats_instructions(self):
+  # Print instruction stats for the entire manycore
+  def print_manycore_stats_instructions(self, stat_file):
 
-    self.execution_stats_file.write("Instruction Stats\n")
-    self.execution_stats_file.write(stats_instr_header_format.format("instruction", "count", " share (%)"))
-    self.execution_stats_file.write("{}".format(separating_line))
+    stat_file.write("Instruction Stats\n")
+    stat_file.write(stats_instr_header_format.format("instruction", "count", " share (%)"))
+    stat_file.write("{}".format(separating_line))
 
    
     # Print instruction stats for manycore
     for instr in instr_list:
-       self.execution_stats_file.write(stats_instr_data_format.format(instr,
-                                                                      self.manycore_stat_dict[instr],
-                                                                      (100 * self.manycore_stat_dict[instr] / self.total_instr_cnt)))
+       stat_file.write(stats_instr_data_format.format(instr,
+                                                      self.manycore_stat_dict[instr],
+                                                      (100 * self.manycore_stat_dict[instr] / self.total_instr_cnt)))
 
-    self.execution_stats_file.write(stats_instr_data_format.format("total",
-                                                                   self.total_instr_cnt, 
-                                                                   (100 * self.total_instr_cnt / self.total_instr_cnt)))
-    self.execution_stats_file.write("{}\n".format(separating_line))
+    stat_file.write(stats_instr_data_format.format("total",
+                                                   self.total_instr_cnt, 
+                                                   (100 * self.total_instr_cnt / self.total_instr_cnt)))
+    stat_file.write("{}\n".format(separating_line))
     return
 
 
-  # Print stall stats for all tiles and total
-  def print_manycore_stats_stalls(self):
-    self.execution_stats_file.write("Stall Stats\n")
-    self.execution_stats_file.write(stats_stall_header_format.format("stall", "cycles", "share (%)"))
-    self.execution_stats_file.write("{}".format(separating_line))
+  # Print instruction stats for each tile in a separate file 
+  # y,x are tile coordinates 
+  def print_per_tile_stats_instructions(self, y, x, stat_file):
+
+    stat_file.write("Instruction Stats\n")
+    stat_file.write(stats_instr_header_format.format("instruction", "count", " share (%)"))
+    stat_file.write("{}".format(separating_line))
+
+    # Calculate total instruction count for tile 
+    tile_total_instr_cnt = 0
+    for instr in instr_list:
+      if (instr != "instr"):
+        tile_total_instr_cnt += self.tile_stat_dict[y][x][instr]
+   
+    # Print instruction stats for manycore
+    for instr in instr_list:
+       stat_file.write(stats_instr_data_format.format(instr,
+                                                      self.tile_stat_dict[y][x][instr],
+                                                      (100 * self.tile_stat_dict[y][x][instr] / tile_total_instr_cnt)))
+
+    stat_file.write(stats_instr_data_format.format("total",
+                                                   tile_total_instr_cnt, 
+                                                   (100 * tile_total_instr_cnt / tile_total_instr_cnt)))
+    stat_file.write("{}\n".format(separating_line))
+    return
+
+
+
+
+  # Print stall stats for the entire manycore
+  def print_manycore_stats_stalls(self, stat_file):
+    stat_file.write("Stall Stats\n")
+    stat_file.write(stats_stall_header_format.format("stall", "cycles", "share (%)"))
+    stat_file.write("{}".format(separating_line))
 
     # Print stall stats for manycore
     for stall in stalls_list:
-       self.execution_stats_file.write(stats_stall_data_format.format(stall,
-                                                                      self.manycore_stat_dict[stall],
-                                                                      (100 * self.manycore_stat_dict[stall] / self.total_stall_cnt)))
+       stat_file.write(stats_stall_data_format.format(stall,
+                                                      self.manycore_stat_dict[stall],
+                                                      (100 * self.manycore_stat_dict[stall] / self.total_stall_cnt)))
 
-    self.execution_stats_file.write(stats_stall_data_format.format("total",
-                                                                    self.total_stall_cnt,
-                                                                    (100 * self.total_stall_cnt / self.total_stall_cnt)))
-    self.execution_stats_file.write("{}\n".format(separating_line))
+    stat_file.write(stats_stall_data_format.format("total",
+                                                   self.total_stall_cnt,
+                                                   (100 * self.total_stall_cnt / self.total_stall_cnt)))
+    stat_file.write("{}\n".format(separating_line))
     return
 
 
-  # Print miss stats for all tiles and total
-  def print_manycore_stats_miss(self):
-    self.execution_stats_file.write("Miss Stats\n")
-    self.execution_stats_file.write(stats_miss_header_format.format("unit", "miss", "total", "hit rate"))
-    self.execution_stats_file.write("{}".format(separating_line))
+  # Print stall stats for each tile in a separate file
+  # y,x are tile coordinates 
+  def print_per_tile_stats_stalls(self, y, x, stat_file):
+    stat_file.write("Stall Stats\n")
+    stat_file.write(stats_stall_header_format.format("stall", "cycles", "share (%)"))
+    stat_file.write("{}".format(separating_line))
+
+    # Calculate total stall count for tile
+    tile_total_stall_cnt = 0
+    for stall in stalls_list:
+      tile_total_stall_cnt += self.tile_stat_dict[y][x][stall]
+
+    # Print stall stats for manycore
+    for stall in stalls_list:
+       stat_file.write(stats_stall_data_format.format(stall,
+                                                      self.tile_stat_dict[y][x][stall],
+                                                      (100 * self.tile_stat_dict[y][x][stall] / tile_total_stall_cnt)))
+
+    stat_file.write(stats_stall_data_format.format("total",
+                                                   tile_total_stall_cnt,
+                                                   (100 * tile_total_stall_cnt / tile_total_stall_cnt)))
+    stat_file.write("{}\n".format(separating_line))
+    return
+
+
+
+
+  # Print miss stats for the entire manycore
+  def print_manycore_stats_miss(self, stat_file):
+    stat_file.write("Miss Stats\n")
+    stat_file.write(stats_miss_header_format.format("unit", "miss", "total", "hit rate"))
+    stat_file.write("{}".format(separating_line))
 
     for miss in miss_list:
        # Find total number of operations for that miss
@@ -221,9 +291,35 @@ class VanillaStatsParser:
        miss_cnt = self.manycore_stat_dict[miss]
        hit_rate = 1 if operation_cnt == 0 else (1 - miss_cnt/operation_cnt)
          
-       self.execution_stats_file.write(stats_miss_data_format.format(operation, miss_cnt, operation_cnt, hit_rate ))
-    self.execution_stats_file.write("{}\n".format(separating_line))
+       stat_file.write(stats_miss_data_format.format(operation, miss_cnt, operation_cnt, hit_rate ))
+    stat_file.write("{}\n".format(separating_line))
     return
+
+
+  # Print miss stats for each tile in a separate file
+  # y,x are tile coordinates 
+  def print_per_tile_stats_miss(self, y, x, stat_file):
+    stat_file.write("Miss Stats\n")
+    stat_file.write(stats_miss_header_format.format("unit", "miss", "total", "hit rate"))
+    stat_file.write("{}".format(separating_line))
+
+    for miss in miss_list:
+       # Find total number of operations for that miss
+       # If operation is icache, the total is total # of instruction
+       # otherwise, search for the specific instruction
+       if (miss == "icache_miss"):
+         operation = "icache"
+         operation_cnt = self.tile_stat_dict[y][x]["instr"]
+       else:
+         operation = miss.replace("_miss", '')
+         operation_cnt = self.tile_stat_dict[y][x][operation]
+       miss_cnt = self.tile_stat_dict[y][x][miss]
+       hit_rate = 1 if operation_cnt == 0 else (1 - miss_cnt/operation_cnt)
+         
+       stat_file.write(stats_miss_data_format.format(operation, miss_cnt, operation_cnt, hit_rate ))
+    stat_file.write("{}\n".format(separating_line))
+    return
+
 
 
 
@@ -263,10 +359,22 @@ class VanillaStatsParser:
 
   def print_manycore_stats_all(self):
     self.calculate_manycore_stats_all()
-    self.print_manycore_stats_timing()
-    self.print_manycore_stats_miss()
-    self.print_manycore_stats_stalls()
-    self.print_manycore_stats_instructions()
+    self.print_manycore_stats_timing(self.manycore_stats_file)
+    self.print_manycore_stats_miss(self.manycore_stats_file)
+    self.print_manycore_stats_stalls(self.manycore_stats_file)
+    self.print_manycore_stats_instructions(self.manycore_stats_file)
+
+  def print_per_tile_stats_all(self):
+    stats_path = os.getcwd() + "/tile_stats/"
+    if not os.path.exists(stats_path):
+      os.mkdir(stats_path)
+    for y in range(self.manycore_dim_y):
+      for x in range(self.manycore_dim_x):
+        stat_file = open( (stats_path + "tile_" + str(y) + "_" + str(x) + "_stats.log"), "w")
+#        self.print_per_tile_stats_timing(y, x, stat_file)
+        self.print_per_tile_stats_miss(y, x, stat_file)
+        self.print_per_tile_stats_stalls(y, x, stat_file)
+        self.print_per_tile_stats_instructions(y, x, stat_file)
 
 
 
@@ -290,26 +398,41 @@ class VanillaStatsParser:
     # generate all other stats
     self.generate_stats_all()
 
-    # print all stats
+    # print all manycore stats 
     self.print_manycore_stats_all()
-  
+
+    # If requested, print all per tile stats
+    if(per_tile_stat):
+      self.print_per_tile_stats_all()
 
     # cleanup
-    self.execution_stats_file.close()
+    self.manycore_stats_file.close()
 
 
 # main()
 if __name__ == "__main__":
 
-  if len(sys.argv) != 4:
-    print("wrong number of arguments.")
-    print("python vanilla.log")
+  if len(sys.argv) != 5:
+    print("Error: wrong number of arguments.")
+    print("python3 vanilla_stats_parser.py {manycore_dim_x} {manycore_dim_y} {total/per_tile} {vanilla_stats.log} ")
     sys.exit()
  
   manycore_dim_y = int(sys.argv[1])
   manycore_dim_x = int(sys.argv[2])
-  input_file = sys.argv[3]
 
-  st = VanillaStatsParser(manycore_dim_y, manycore_dim_x)
+  stat_type = sys.argv[3]
+  if stat_type == "total":
+    per_tile_stat = False
+  elif stat_type == "per_tile":
+    per_tile_stat = True
+  else:
+    print("Error: invalid stat type " + stat_type + ". Can be total or per_tile.")
+    print("python3 vanilla_stats_parser.py {manycore_dim_x} {manycore_dim_y} {vanilla_stats.log} {total/per_tile}")
+    sys.exit()
+
+  input_file = sys.argv[4]
+
+
+  st = VanillaStatsParser(manycore_dim_y, manycore_dim_x, per_tile_stat)
   st.generate_stats(input_file)
 

--- a/software/py/vanilla_stats_parser.py
+++ b/software/py/vanilla_stats_parser.py
@@ -32,6 +32,28 @@ from enum import Enum
 bsg_PRINT_STAT_START_VAL = 0x00000000
 bsg_PRINT_STAT_END_VAL   = 0xDEAD0000
 
+
+
+# formatting parameters for aligned printing
+name_length = 25
+type_length = 15
+int_length = 15
+float_length=15.4
+percent_length=15.2
+
+stats_timing_header_format = ("{:<"+str(name_length)+"}{:>"+str(type_length)+"}{:>"+str(type_length)+"}\n")
+stats_timing_data_format   = ("{:<"+str(name_length)+"}{:>"+str(int_length)+"}{:>"+str(percent_length)+"f}\n") 
+stats_instr_header_format  = ("{:<"+str(name_length)+"}{:>"+str(int_length)+"}{:>"+str(type_length)+"}\n")
+stats_instr_data_format    = ("{:<"+str(name_length)+"}{:>"+str(int_length)+"}{:>"+str(percent_length)+"f}\n")
+stats_stall_header_format  = ("{:<"+str(name_length)+"}{:>"+str(type_length)+"}{:>"+str(type_length)+"}\n")
+stats_stall_data_format    = ("{:<"+str(name_length)+"}{:>"+str(int_length)+"}{:>"+str(percent_length)+"f}\n")
+stats_miss_header_format   = ("{:<"+str(name_length)+"}{:>"+str(type_length)+"}{:>"+str(type_length)+"}{:>"+str(type_length)+"}\n")
+stats_miss_data_format     = ("{:<"+str(name_length)+"}{:>"+str(int_length)+"}{:>"+str(int_length)+"}{:>"+str(float_length)+"f}\n")
+separating_line = ('=' * 80 + '\n')
+
+
+
+# List of instructions, operations and events parsed from vanilla_stats.log
 instructions_list = ['instr','fadd','fsub','fmul','fsgnj','fsgnjn',\
                      'fsgnjx','fmin','fmax','fcvt_s_w','fcvt_s_wu',\
                      'fmv_w_x','feq','flt','fle','fcvt_w_s','fcvt_wu_s',\
@@ -54,7 +76,6 @@ stalls_list =       ['stall_fp_remote_load','stall_fp_local_load',\
                      'stall_ifetch_wait','stall_icache_store',\
                      'stall_lr_aq','stall_md,stall_remote_req','stall_local_flw']
 
-separating_line = ('=' * 80 + '\n')
 
 
 class VanillaStatsParser:
@@ -110,6 +131,17 @@ class VanillaStatsParser:
 
   # Sum up all other stats for all tiles based on the last bsg_print_stat instr
   def generate_stats_all(self):
+
+      # Generate timing stats
+      for idx,line in enumerate(self.vanilla_stats_lines):
+        tokens = line.split(",")
+        # first line is list of stats types
+        if (idx == 0):
+          self.define_stats_list(tokens)
+          continue
+        # Generate timing stats 
+        self.generate_stats_timing(tokens)
+
       #other stats are only read once per tile from the end of file
       #i.e. if mesh dimensions are 4x4, only last 16 lines are needed 
       for idx in range(len(self.vanilla_stats_lines) - self.manycore_dim, len(self.vanilla_stats_lines)):
@@ -123,20 +155,24 @@ class VanillaStatsParser:
             self.stats_stall_dict[self.stats_list[idx]] += int(token)
           elif self.stats_list[idx] in miss_list:
             self.stats_miss_dict[self.stats_list[idx]] += int(token)
-
+      return
 
 
   # Print execution timing for all tile groups 
   def print_stats_timing(self):
     self.execution_stats_file.write("Timing Stats\n")
-    self.execution_stats_file.write("{:<30}{:<10}\n".format("tile group", "exec time"))
+    self.execution_stats_file.write(stats_timing_header_format.format("tile group", "exec time", "share (%)"))
     self.execution_stats_file.write("{}".format(separating_line))
 
     for i in range (0, self.num_tile_groups):
-      self.execution_stats_file.write("{:<30}{:<10}\n".format( i, self.timing_end_list[i] - self.timing_start_list[i]))
       self.total_execution_time += (self.timing_end_list[i] - self.timing_start_list[i])
-    self.execution_stats_file.write("{:<30}{:<10}\n".format("total", self.total_execution_time))
 
+
+    for i in range (0, self.num_tile_groups):
+      tg_time = self.timing_end_list[i] - self.timing_start_list[i]
+      self.execution_stats_file.write(stats_timing_data_format.format( i, tg_time, (tg_time / self.total_execution_time * 100)))
+
+    self.execution_stats_file.write(stats_timing_data_format.format("total", self.total_execution_time, (self.total_execution_time / self.total_execution_time * 100)))
     self.execution_stats_file.write("{}\n".format(separating_line))
     return
 
@@ -145,20 +181,17 @@ class VanillaStatsParser:
   def print_stats_instructions(self):
 
     self.execution_stats_file.write("Instruction Stats\n")
-    self.execution_stats_file.write("{:<30}{:<10}{:<10}\n".format("instruction", "count", "% of total"))
+    self.execution_stats_file.write(stats_instr_header_format.format("instruction", "count", " share (%)"))
     self.execution_stats_file.write("{}".format(separating_line))
-
 
     for instr, cnt in self.stats_instr_dict.items():
        if instr != 'instr':
          self.total_instr_cnt += cnt
      
     for instr, cnt in self.stats_instr_dict.items():
-       self.execution_stats_file.write("{:<30}{:<10}{:<5.2f}\n".format(instr, cnt, (100 * cnt / self.total_instr_cnt)))
+       self.execution_stats_file.write(stats_instr_data_format.format(instr, cnt, (100 * cnt / self.total_instr_cnt)))
 
-
-    self.execution_stats_file.write("{:<30}{:<10}{:<5.2f}\n".format("total", self.total_instr_cnt, (100 * self.total_instr_cnt / self.total_instr_cnt)))
-
+    self.execution_stats_file.write(stats_instr_data_format.format("total", self.total_instr_cnt, (100 * self.total_instr_cnt / self.total_instr_cnt)))
     self.execution_stats_file.write("{}\n".format(separating_line))
     return
 
@@ -166,18 +199,16 @@ class VanillaStatsParser:
   # Print stall stats for all tiles and total
   def print_stats_stalls(self):
     self.execution_stats_file.write("Stall Stats\n")
-    self.execution_stats_file.write("{:<30}{:<10}{:<10}\n".format("stall", "cycles", "% of total"))
+    self.execution_stats_file.write(stats_stall_header_format.format("stall", "cycles", "share (%)"))
     self.execution_stats_file.write("{}".format(separating_line))
-
 
     for stall, cnt in self.stats_stall_dict.items():
          self.total_stall_cnt += cnt
      
     for stall, cnt in self.stats_stall_dict.items():
-       self.execution_stats_file.write("{:<30}{:<10}{:<5.2f}\n".format(stall, cnt, (100 * cnt / self.total_stall_cnt)))
+       self.execution_stats_file.write(stats_stall_data_format.format(stall, cnt, (100 * cnt / self.total_stall_cnt)))
 
-    self.execution_stats_file.write("{:<30}{:<10}{:<5.2f}\n".format("total", self.total_stall_cnt, (100 * self.total_stall_cnt / self.total_stall_cnt)))
-
+    self.execution_stats_file.write(stats_stall_data_format.format("total", self.total_stall_cnt, (100 * self.total_stall_cnt / self.total_stall_cnt)))
     self.execution_stats_file.write("{}\n".format(separating_line))
     return
 
@@ -185,9 +216,8 @@ class VanillaStatsParser:
   # Print miss stats for all tiles and total
   def print_stats_miss(self):
     self.execution_stats_file.write("Miss Stats\n")
-    self.execution_stats_file.write("{:<20}{:>15}{:>15}{:>15}\n".format("unit", "miss", "total", "hit rate"))
+    self.execution_stats_file.write(stats_miss_header_format.format("unit", "miss", "total", "hit rate"))
     self.execution_stats_file.write("{}".format(separating_line))
-
 
     for miss, cnt in self.stats_miss_dict.items():
          self.total_miss_cnt += cnt
@@ -199,16 +229,13 @@ class VanillaStatsParser:
        if (miss == "icache_miss"):
          operation = "icache"
          operation_cnt = self.stats_instr_dict["instr"]
-
        else:
          operation = miss.replace("_miss", '')
-         operation_cnt = self.stats_instr_dict["instr"]
+         operation_cnt = self.stats_instr_dict[operation]
 
        hit_rate = 1 if operation_cnt == 0 else (1 - miss_cnt/operation_cnt)
          
-       self.execution_stats_file.write("{:<20}{:>15}{:>15}{:>13.4f}\n".format(operation, miss_cnt, operation_cnt, hit_rate ))
-
-
+       self.execution_stats_file.write(stats_miss_data_format.format(operation, miss_cnt, operation_cnt, hit_rate ))
     self.execution_stats_file.write("{}\n".format(separating_line))
     return
 
@@ -227,15 +254,6 @@ class VanillaStatsParser:
     self.vanilla_stats_file = open (input_file, "r")
     if (self.vanilla_stats_file.mode == 'r'):
       self.vanilla_stats_lines = self.vanilla_stats_file.readlines()
-
-      for idx,line in enumerate(self.vanilla_stats_lines):
-        tokens = line.split(",")
-        # first line is list of stats types
-        if (idx == 0):
-          self.define_stats_list(tokens)
-          continue
-        # Generate timing stats 
-        self.generate_stats_timing(tokens)
 
     # generate all other stats
     self.generate_stats_all()

--- a/software/py/vanilla_stats_parser.py
+++ b/software/py/vanilla_stats_parser.py
@@ -46,6 +46,7 @@ stalls_list =       ['stall_fp_remote_load','stall_fp_local_load',\
                      'stall_ifetch_wait','stall_icache_store',\
                      'stall_lr_aq','stall_md,stall_remote_req','stall_local_flw']
 
+separating_line = ('=' * 60 + '\n')
 
 
 class VanillaStatsParser:
@@ -119,58 +120,86 @@ class VanillaStatsParser:
 
   # Print execution timing for all tile groups 
   def print_stats_timing(self):
-    self.execution_stats_file.write("Timing Stats:\n" + \
-                                    "=======================================================\n")
+    self.execution_stats_file.write("Timing Stats\n")
+    self.execution_stats_file.write("{:<30}{:<10}\n".format("tile group", "exec time"))
+    self.execution_stats_file.write("{}".format(separating_line))
+
     for i in range (0, self.num_tile_groups):
-      self.execution_stats_file.write("{:10}{:5}{:25}{}\n".format("Tile group", i, ":", self.timing_end_list[i] - self.timing_start_list[i]))
+      self.execution_stats_file.write("{:<30}{:<10}\n".format( i, self.timing_end_list[i] - self.timing_start_list[i]))
       self.total_execution_time += (self.timing_end_list[i] - self.timing_start_list[i])
-    self.execution_stats_file.write("{:40}{}\n".format("Total (cycles):", self.total_execution_time))
-    self.execution_stats_file.write("=======================================================\n\n")
+    self.execution_stats_file.write("{:<30}{:<10}\n".format("total", self.total_execution_time))
+
+    self.execution_stats_file.write("{}\n".format(separating_line))
+    return
 
 
   # Print instruction stats for all tiles and total
   def print_stats_instructions(self):
-    self.execution_stats_file.write("Instruction Stats:\n" + \
-                                    "=======================================================\n")
+
+    self.execution_stats_file.write("Instruction Stats\n")
+    self.execution_stats_file.write("{:<30}{:<10}{:<10}\n".format("instruction", "count", "% of total"))
+    self.execution_stats_file.write("{}".format(separating_line))
+
+
     for instr, cnt in self.stats_instr_dict.items():
        if instr != 'instr':
          self.total_instr_cnt += cnt
      
     for instr, cnt in self.stats_instr_dict.items():
-       self.execution_stats_file.write("{:35}%{:0>5.2f}{:10}\n".format(instr, (100 * cnt / self.total_instr_cnt), cnt))
+       self.execution_stats_file.write("{:<30}{:<10}{:<5.2f}\n".format(instr, cnt, (100 * cnt / self.total_instr_cnt)))
 
-    self.execution_stats_file.write("{:41}{:10}\n".format("Total", self.total_instr_cnt))
-    self.execution_stats_file.write("=======================================================\n\n")
+
+    self.execution_stats_file.write("{:<30}{:<10}{:<5.2f}\n".format("total", self.total_instr_cnt, (100 * self.total_instr_cnt / self.total_instr_cnt)))
+
+    self.execution_stats_file.write("{}\n".format(separating_line))
     return
 
 
   # Print stall stats for all tiles and total
   def print_stats_stalls(self):
-    self.execution_stats_file.write("Stalls Stats:\n" + \
-                                    "=======================================================\n")
+    self.execution_stats_file.write("Stall Stats\n")
+    self.execution_stats_file.write("{:<30}{:<10}{:<10}\n".format("stall", "cycles", "% of total"))
+    self.execution_stats_file.write("{}".format(separating_line))
+
+
     for stall, cnt in self.stats_stall_dict.items():
          self.total_stall_cnt += cnt
      
     for stall, cnt in self.stats_stall_dict.items():
-       self.execution_stats_file.write("{:35}%{:0>5.2f}{:10}\n".format(stall, (100 * cnt / self.total_stall_cnt), cnt))
+       self.execution_stats_file.write("{:<30}{:<10}{:<5.2f}\n".format(stall, cnt, (100 * cnt / self.total_stall_cnt)))
 
-    self.execution_stats_file.write("{:41}{:10}\n".format("Total", self.total_stall_cnt))
-    self.execution_stats_file.write("=======================================================\n\n")
+    self.execution_stats_file.write("{:<30}{:<10}{:<5.2f}\n".format("total", self.total_stall_cnt, (100 * self.total_stall_cnt / self.total_stall_cnt)))
+
+    self.execution_stats_file.write("{}\n".format(separating_line))
     return
 
 
   # Print miss stats for all tiles and total
   def print_stats_miss(self):
-    self.execution_stats_file.write("Miss Stats:\n" + \
-                                    "=======================================================\n")
+    self.execution_stats_file.write("Miss Stats\n")
+    self.execution_stats_file.write("{:<30}{:<10}{:<10}{:<10}\n".format("unit", "miss", "total", "hit rate"))
+    self.execution_stats_file.write("{}".format(separating_line))
+
+
     for miss, cnt in self.stats_miss_dict.items():
          self.total_miss_cnt += cnt
      
-    for miss, cnt in self.stats_miss_dict.items():
-       self.execution_stats_file.write("{:35}%{:0>5.2f}{:10}\n".format(miss, (100 * cnt / self.total_miss_cnt), cnt))
+    for miss, miss_cnt in self.stats_miss_dict.items():
+       # Find total number of operations for that miss
+       # If operation is icache, the total is total # of instruction
+       # otherwise, search for the specific instruction
+       if (miss == "icache_miss"):
+         instr = "instr"
+       else:
+         instr = miss.replace("_miss", '')
 
-    self.execution_stats_file.write("{:41}{:10}\n".format("Total", self.total_miss_cnt))
-    self.execution_stats_file.write("=======================================================\n\n")
+       instr_cnt = self.stats_instr_dict[instr]
+       hit_rate = 1 if instr_cnt == 0 else (1 - miss_cnt/instr_cnt)
+         
+       self.execution_stats_file.write("{:<30}{:<10}{:<10}{:<5.2f}\n".format(instr, miss_cnt, instr_cnt, hit_rate ))
+
+
+    self.execution_stats_file.write("{}\n".format(separating_line))
     return
 
 

--- a/software/py/vanilla_stats_parser.py
+++ b/software/py/vanilla_stats_parser.py
@@ -48,7 +48,7 @@ DEFAULT_INPUT_FILE = "vanilla_stats.log"
 
 
 # formatting parameters for aligned printing
-name_length = 25
+name_length = 35
 type_length = 15
 int_length = 15
 float_length=15.4
@@ -62,34 +62,38 @@ stats_stall_header_format  = ("{:<"+str(name_length)+"}{:>"+str(type_length)+"}{
 stats_stall_data_format    = ("{:<"+str(name_length)+"}{:>"+str(int_length)+"}{:>"+str(percent_length)+"f}\n")
 stats_miss_header_format   = ("{:<"+str(name_length)+"}{:>"+str(type_length)+"}{:>"+str(type_length)+"}{:>"+str(type_length)+"}\n")
 stats_miss_data_format     = ("{:<"+str(name_length)+"}{:>"+str(int_length)+"}{:>"+str(int_length)+"}{:>"+str(float_length)+"f}\n")
-separating_line = ('=' * 80 + '\n')
+separating_line = ('=' * 90 + '\n')
 
 
 
 # List of instructions, operations and events parsed from vanilla_stats.log
-stats_list  = {"time", "x", "y", "tag", "global_ctr", "cycle"}
+stats_list  = ["time", "x", "y", "tag", "global_ctr", "cycle"]
 
-instr_list  = {'instr','fadd','fsub','fmul','fsgnj','fsgnjn',
+instr_list  = ['instr','fadd','fsub','fmul','fsgnj','fsgnjn',
                'fsgnjx','fmin','fmax','fcvt_s_w','fcvt_s_wu',
                'fmv_w_x','feq','flt','fle','fcvt_w_s','fcvt_wu_s',
                'fclass','fmv_x_w','local_ld','local_st',
-               'remote_ld','remote_st','local_flw','local_fsw',
-               'remote_flw','remote_fsw','lr','lr_aq',
-               'swap_aq','swap_rl','beq','bne','blt','bge','bltu',
-               'bgeu','jalr','jal', 'sll',
+               'remote_ld_dram','remote_ld_global','remote_ld_group',
+               'remote_st_dram','remote_st_global','remote_st_group',
+               'local_flw','local_fsw','remote_flw','remote_fsw',
+               'lr','lr_aq','swap_aq','swap_rl','beq','bne',
+               'blt','bge','bltu','bgeu','jalr','jal', 'sll',
                'slli','srl','srli','sra','srai','add','addi','sub',
                'lui','auipc','xor','xori','or','ori','and','andi',
                'slt','slti','sltu','sltiu','mul','mulh','mulhsu',
-               'mulhu','div','divu','rem','remu','fence'}
+               'mulhu','div','divu','rem','remu','fence']
 
-miss_list   = {'icache_miss', 'beq_miss', 'bne_miss', 'blt_miss',
-               'bge_miss', 'bltu_miss', 'bgeu_miss', 'jalr_miss'}
+miss_list   = ['icache_miss', 'beq_miss', 'bne_miss', 'blt_miss',
+               'bge_miss', 'bltu_miss', 'bgeu_miss', 'jalr_miss']
 
-stalls_list = {'stall_fp_remote_load','stall_fp_local_load',
-               'stall_depend','stall_depend_remote_load',
+stalls_list = ['stall_fp_remote_load','stall_fp_local_load',
+               'stall_depend',
+               'stall_depend_remote_load_dram',
+               'stall_depend_remote_load_global',
+               'stall_depend_remote_load_group',
                'stall_depend_local_load','stall_force_wb',
                'stall_ifetch_wait','stall_icache_store',
-               'stall_lr_aq','stall_md','stall_remote_req','stall_local_flw'}
+               'stall_lr_aq','stall_md','stall_remote_req','stall_local_flw']
 
 
 

--- a/software/py/vanilla_stats_parser.py
+++ b/software/py/vanilla_stats_parser.py
@@ -22,6 +22,7 @@ import sys
 import os
 import re
 from enum import Enum
+import csv
 
 
 # These values are used by the manycore library in bsg_print_stat instructions
@@ -54,27 +55,29 @@ separating_line = ('=' * 80 + '\n')
 
 
 # List of instructions, operations and events parsed from vanilla_stats.log
-instructions_list = ['instr','fadd','fsub','fmul','fsgnj','fsgnjn',\
-                     'fsgnjx','fmin','fmax','fcvt_s_w','fcvt_s_wu',\
-                     'fmv_w_x','feq','flt','fle','fcvt_w_s','fcvt_wu_s',\
-                     'fclass','fmv_x_w','local_ld','local_st',\
-                     'remote_ld','remote_st','local_flw','local_fsw',\
-                     'remote_flw','remote_fsw','lr','lr_aq',\
-                     'swap_aq','swap_rl','beq','bne','blt','bge','bltu',\
-                     'bgeu','jalr','jal', 'sll',\
-                     'slli','srl','srli','sra','srai','add','addi','sub',\
-                     'lui','auipc','xor','xori','or','ori','and','andi',\
-                     'slt','slti','sltu','sltiu','mul','mulh','mulhsu',\
+stats_list = ["time", "x", "y", "tag", "global_ctr", "cycle"]
+
+instr_list = ['instr','fadd','fsub','fmul','fsgnj','fsgnjn',
+                     'fsgnjx','fmin','fmax','fcvt_s_w','fcvt_s_wu',
+                     'fmv_w_x','feq','flt','fle','fcvt_w_s','fcvt_wu_s',
+                     'fclass','fmv_x_w','local_ld','local_st',
+                     'remote_ld','remote_st','local_flw','local_fsw',
+                     'remote_flw','remote_fsw','lr','lr_aq',
+                     'swap_aq','swap_rl','beq','bne','blt','bge','bltu',
+                     'bgeu','jalr','jal', 'sll',
+                     'slli','srl','srli','sra','srai','add','addi','sub',
+                     'lui','auipc','xor','xori','or','ori','and','andi',
+                     'slt','slti','sltu','sltiu','mul','mulh','mulhsu',
                      'mulhu','div','divu','rem','remu','fence']
 
-miss_list =         ['icache_miss', 'beq_miss', 'bne_miss', 'blt_miss',\
+miss_list =         ['icache_miss', 'beq_miss', 'bne_miss', 'blt_miss',
                      'bge_miss', 'bltu_miss', 'bgeu_miss', 'jalr_miss']
 
-stalls_list =       ['stall_fp_remote_load','stall_fp_local_load',\
-                     'stall_depend','stall_depend_remote_load',\
-                     'stall_depend_local_load','stall_force_wb',\
-                     'stall_ifetch_wait','stall_icache_store',\
-                     'stall_lr_aq','stall_md,stall_remote_req','stall_local_flw']
+stalls_list =       ['stall_fp_remote_load','stall_fp_local_load',
+                     'stall_depend','stall_depend_remote_load',
+                     'stall_depend_local_load','stall_force_wb',
+                     'stall_ifetch_wait','stall_icache_store',
+                     'stall_lr_aq','stall_md','stall_remote_req','stall_local_flw']
 
 
 
@@ -100,66 +103,45 @@ class VanillaStatsParser:
     self.total_stall_cnt = 0
     self.total_miss_cnt = 0
 
-    self.stats_list = []
-
-    self.stats_instr_dict = {}
-    self.stats_stall_dict = {}
-    self.stats_miss_dict = {}
+    self.tile_stat_dict = [[dict() for x in range(self.manycore_dim_x)] for y in range(self.manycore_dim_y)]
+    self.manycore_stat_dict = dict()
 
 
-  # Create a list of stat types
-  def define_stats_list(self, tokens):
-    for token in tokens:
-      self.stats_list += [token]
-      if token in instructions_list:
-        self.stats_instr_dict.update ({token: 0})
-      elif token in stalls_list:
-        self.stats_stall_dict.update ({token: 0})
-      elif token in miss_list:
-        self.stats_miss_dict.update ({token: 0})
-    return
-
-
-  # Calculate execution time for tile groups and total
-  def generate_stats_timing(self, tokens):
-    if (tokens[self.stats_list.index('x')] == '0' and tokens[self.stats_list.index('y')] == '1'):
-      if (int(tokens[self.stats_list.index('tag')]) < bsg_PRINT_STAT_END_VAL):
-        self.timing_start_list[int(tokens[self.stats_list.index('tag')])] = int(tokens[self.stats_list.index('time')])
+  def generate_stats_timing(self, trace):
+    if trace["x"] == 0 and trace["y"] == 1:
+      if(trace["tag"] < bsg_PRINT_STAT_END_VAL):
+        self.timing_start_list[trace["tag"]] = trace["time"]
         self.num_tile_groups += 1
-      else: 
-        self.timing_end_list[int(tokens[self.stats_list.index('tag')]) - bsg_PRINT_STAT_END_VAL] = int(tokens[self.stats_list.index('time')])
+      else:
+        self.timing_end_list[trace["tag"] - bsg_PRINT_STAT_END_VAL] = trace["time"]
+
 
   # Sum up all other stats for all tiles based on the last bsg_print_stat instr
   def generate_stats_all(self):
+      # Generate timing stats 
+      for trace in self.traces:
+        self.generate_stats_timing(trace)
 
-      # Generate timing stats
-      for idx,line in enumerate(self.vanilla_stats_lines):
-        tokens = line.split(",")
-        # first line is list of stats types
-        if (idx == 0):
-          self.define_stats_list(tokens)
-          continue
-        # Generate timing stats 
-        self.generate_stats_timing(tokens)
 
       #other stats are only read once per tile from the end of file
       #i.e. if mesh dimensions are 4x4, only last 16 lines are needed 
-      for idx in range(len(self.vanilla_stats_lines) - self.manycore_dim, len(self.vanilla_stats_lines)):
-        line = self.vanilla_stats_lines[idx]
-        tokens = line.split(",")
-
-        for idx, token in enumerate(tokens):
-          if self.stats_list[idx] in instructions_list:
-            self.stats_instr_dict[self.stats_list[idx]] += int(token)
-          elif self.stats_list[idx] in stalls_list:
-            self.stats_stall_dict[self.stats_list[idx]] += int(token)
-          elif self.stats_list[idx] in miss_list:
-            self.stats_miss_dict[self.stats_list[idx]] += int(token)
-      return
+      trace_idx = len(self.traces)
+      for y in range(self.manycore_dim_y):
+        for x in range(self.manycore_dim_x):
+          trace_idx -= 1
+          trace = self.traces[trace_idx]
+          for stat in stats_list:
+            self.tile_stat_dict[y][x][stat] = trace[stat]
+          for instr in instr_list:
+            self.tile_stat_dict[y][x][instr] = trace[instr]
+          for stall in stalls_list:
+            self.tile_stat_dict[y][x][stall] = trace[stall]
+          for miss in miss_list:
+            self.tile_stat_dict[y][x][miss] = trace[miss]
 
 
   # Print execution timing for all tile groups 
-  def print_stats_timing(self):
+  def print_manycore_stats_timing(self):
     self.execution_stats_file.write("Timing Stats\n")
     self.execution_stats_file.write(stats_timing_header_format.format("tile group", "exec time", "share (%)"))
     self.execution_stats_file.write("{}".format(separating_line))
@@ -167,72 +149,76 @@ class VanillaStatsParser:
     for i in range (0, self.num_tile_groups):
       self.total_execution_time += (self.timing_end_list[i] - self.timing_start_list[i])
 
-
     for i in range (0, self.num_tile_groups):
       tg_time = self.timing_end_list[i] - self.timing_start_list[i]
-      self.execution_stats_file.write(stats_timing_data_format.format( i, tg_time, (tg_time / self.total_execution_time * 100)))
+      self.execution_stats_file.write(stats_timing_data_format.format(i,
+                                                                      tg_time,
+                                                                      (tg_time / self.total_execution_time * 100)))
 
-    self.execution_stats_file.write(stats_timing_data_format.format("total", self.total_execution_time, (self.total_execution_time / self.total_execution_time * 100)))
+    self.execution_stats_file.write(stats_timing_data_format.format("total",
+                                                                    self.total_execution_time,
+                                                                    (self.total_execution_time / self.total_execution_time * 100)))
     self.execution_stats_file.write("{}\n".format(separating_line))
     return
 
 
   # Print instruction stats for all tiles and total
-  def print_stats_instructions(self):
+  def print_manycore_stats_instructions(self):
 
     self.execution_stats_file.write("Instruction Stats\n")
     self.execution_stats_file.write(stats_instr_header_format.format("instruction", "count", " share (%)"))
     self.execution_stats_file.write("{}".format(separating_line))
 
-    for instr, cnt in self.stats_instr_dict.items():
-       if instr != 'instr':
-         self.total_instr_cnt += cnt
-     
-    for instr, cnt in self.stats_instr_dict.items():
-       self.execution_stats_file.write(stats_instr_data_format.format(instr, cnt, (100 * cnt / self.total_instr_cnt)))
+   
+    # Print instruction stats for manycore
+    for instr in instr_list:
+       self.execution_stats_file.write(stats_instr_data_format.format(instr,
+                                                                      self.manycore_stat_dict[instr],
+                                                                      (100 * self.manycore_stat_dict[instr] / self.total_instr_cnt)))
 
-    self.execution_stats_file.write(stats_instr_data_format.format("total", self.total_instr_cnt, (100 * self.total_instr_cnt / self.total_instr_cnt)))
+    self.execution_stats_file.write(stats_instr_data_format.format("total",
+                                                                   self.total_instr_cnt, 
+                                                                   (100 * self.total_instr_cnt / self.total_instr_cnt)))
     self.execution_stats_file.write("{}\n".format(separating_line))
     return
 
 
   # Print stall stats for all tiles and total
-  def print_stats_stalls(self):
+  def print_manycore_stats_stalls(self):
     self.execution_stats_file.write("Stall Stats\n")
     self.execution_stats_file.write(stats_stall_header_format.format("stall", "cycles", "share (%)"))
     self.execution_stats_file.write("{}".format(separating_line))
 
-    for stall, cnt in self.stats_stall_dict.items():
-         self.total_stall_cnt += cnt
-     
-    for stall, cnt in self.stats_stall_dict.items():
-       self.execution_stats_file.write(stats_stall_data_format.format(stall, cnt, (100 * cnt / self.total_stall_cnt)))
+    # Print stall stats for manycore
+    for stall in stalls_list:
+       self.execution_stats_file.write(stats_stall_data_format.format(stall,
+                                                                      self.manycore_stat_dict[stall],
+                                                                      (100 * self.manycore_stat_dict[stall] / self.total_stall_cnt)))
 
-    self.execution_stats_file.write(stats_stall_data_format.format("total", self.total_stall_cnt, (100 * self.total_stall_cnt / self.total_stall_cnt)))
+    self.execution_stats_file.write(stats_stall_data_format.format("total",
+                                                                    self.total_stall_cnt,
+                                                                    (100 * self.total_stall_cnt / self.total_stall_cnt)))
     self.execution_stats_file.write("{}\n".format(separating_line))
     return
 
 
   # Print miss stats for all tiles and total
-  def print_stats_miss(self):
+  def print_manycore_stats_miss(self):
     self.execution_stats_file.write("Miss Stats\n")
     self.execution_stats_file.write(stats_miss_header_format.format("unit", "miss", "total", "hit rate"))
     self.execution_stats_file.write("{}".format(separating_line))
 
-    for miss, cnt in self.stats_miss_dict.items():
-         self.total_miss_cnt += cnt
-     
-    for miss, miss_cnt in self.stats_miss_dict.items():
+    for miss in miss_list:
        # Find total number of operations for that miss
        # If operation is icache, the total is total # of instruction
        # otherwise, search for the specific instruction
        if (miss == "icache_miss"):
          operation = "icache"
-         operation_cnt = self.stats_instr_dict["instr"]
+         operation_cnt = self.manycore_stat_dict["instr"]
        else:
          operation = miss.replace("_miss", '')
-         operation_cnt = self.stats_instr_dict[operation]
-
+         operation_cnt = self.manycore_stat_dict[operation]
+       miss_cnt = self.manycore_stat_dict[miss]
        hit_rate = 1 if operation_cnt == 0 else (1 - miss_cnt/operation_cnt)
          
        self.execution_stats_file.write(stats_miss_data_format.format(operation, miss_cnt, operation_cnt, hit_rate ))
@@ -240,30 +226,75 @@ class VanillaStatsParser:
     return
 
 
-  def print_stats_all(self):
-    self.print_stats_timing()
-    self.print_stats_miss()
-    self.print_stats_stalls()
-    self.print_stats_instructions()
 
+
+  # Sums up all stats from all tiles to generate manycore stats 
+  def calculate_manycore_stats_all(self):
+
+    # Initialize counts to zero
+    for instr in instr_list:
+      self.manycore_stat_dict[instr] = 0
+    for stall in stalls_list:
+      self.manycore_stat_dict[stall] = 0
+    for miss in miss_list:
+      self.manycore_stat_dict[miss] = 0
+
+    for y in range(self.manycore_dim_y):
+      for x in range(self.manycore_dim_x):
+
+        # Calculate total instruction count for each tile and for manycore
+        for instr in instr_list: 
+          self.manycore_stat_dict[instr] += self.tile_stat_dict[y][x][instr]
+          if (instr != "instr"):
+            self.total_instr_cnt += self.tile_stat_dict[y][x][instr]
+
+        # Calculate total stall count for each tile and for manycore
+        for stall in stalls_list: 
+          self.manycore_stat_dict[stall] += self.tile_stat_dict[y][x][stall]
+          self.total_stall_cnt += self.tile_stat_dict[y][x][stall]
+
+        # Calculate total miss count for each tile and for manycore
+        for miss in miss_list: 
+          self.manycore_stat_dict[miss] += self.tile_stat_dict[y][x][miss]
+          self.total_miss_cnt += self.tile_stat_dict[y][x][miss]
+    return 
+ 
+
+
+  def print_manycore_stats_all(self):
+    self.calculate_manycore_stats_all()
+    self.print_manycore_stats_timing()
+    self.print_manycore_stats_miss()
+    self.print_manycore_stats_stalls()
+    self.print_manycore_stats_instructions()
 
 
 
   # default stats generator
   def generate_stats(self, input_file):
-    self.vanilla_stats_file = open (input_file, "r")
-    if (self.vanilla_stats_file.mode == 'r'):
-      self.vanilla_stats_lines = self.vanilla_stats_file.readlines()
+    self.traces = []
+    with open(input_file) as f:
+      csv_reader = csv.DictReader (f, delimiter=",")
+      for row in csv_reader:
+        trace = {}
+        for stat in stats_list:
+          trace[stat] = int(row[stat])
+        for instr in instr_list:
+          trace[instr] = int(row[instr])
+        for stall in stalls_list:
+          trace[stall] = int(row[stall])
+        for miss in miss_list:
+          trace[miss] = int(row[miss])
+        self.traces.append(trace)
 
     # generate all other stats
     self.generate_stats_all()
 
     # print all stats
-    self.print_stats_all()
+    self.print_manycore_stats_all()
   
 
     # cleanup
-    self.vanilla_stats_file.close()
     self.execution_stats_file.close()
 
 

--- a/software/py/vanilla_stats_parser.py
+++ b/software/py/vanilla_stats_parser.py
@@ -1,5 +1,5 @@
 #
-#   generate_stats.py
+#   vanilla_stats_parser.py
 #
 #   vanilla core stats extractor
 # 
@@ -37,18 +37,18 @@ instructions_list = ['instr','fadd','fsub','fmul','fsgnj','fsgnjn',\
                      'slt','slti','sltu','sltiu','mul','mulh','mulhsu',\
                      'mulhu','div','divu','rem','remu','fence']
 
-miss_list = ['icache_miss', 'beq_miss', 'bne_miss', 'blt_miss',\
-                'bge_miss', 'bltu_miss', 'bgeu_miss', 'jalr_miss']
+miss_list =         ['icache_miss', 'beq_miss', 'bne_miss', 'blt_miss',\
+                     'bge_miss', 'bltu_miss', 'bgeu_miss', 'jalr_miss']
 
-stalls_list = ['stall_fp_remote_load','stall_fp_local_load',\
-               'stall_depend','stall_depend_remote_load',\
-               'stall_depend_local_load','stall_force_wb',\
-               'stall_ifetch_wait','stall_icache_store',\
-               'stall_lr_aq','stall_md,stall_remote_req','stall_local_flw']
+stalls_list =       ['stall_fp_remote_load','stall_fp_local_load',\
+                     'stall_depend','stall_depend_remote_load',\
+                     'stall_depend_local_load','stall_force_wb',\
+                     'stall_ifetch_wait','stall_icache_store',\
+                     'stall_lr_aq','stall_md,stall_remote_req','stall_local_flw']
 
 
 
-class Stats:
+class VanillaStatsParser:
 
   # default constructor
   def __init__(self, manycore_dim_y, manycore_dim_x):
@@ -222,6 +222,6 @@ if __name__ == "__main__":
   manycore_dim_x = int(sys.argv[2])
   input_file = sys.argv[3]
 
-  st = Stats(manycore_dim_y, manycore_dim_x)
+  st = VanillaStatsParser(manycore_dim_y, manycore_dim_x)
   st.generate_stats(input_file)
 


### PR DESCRIPTION
The vanilla stats parser takes the vanilla_stats.log file as input and prints out per tile and total statistics in separate files. 
Stats include:
- Execution time, for each tile group and aggregated total
- Instruction count and ratio for each tile and total for all types of instructions
- Stall cycle count and ratio for each tile and total for all types of stalls
- Miss count and ratio for each tile and total for all types of miss
Useful when precise numbers and ratios are needed, compared to bloodgraph's high-level view.