### PR TITLE
Added a new enum value, e_mem_cfg_f1_dram

### DIFF
--- a/testbenches/common/v/bsg_mem_cfg_pkg.v
+++ b/testbenches/common/v/bsg_mem_cfg_pkg.v
@@ -12,6 +12,7 @@ package bsg_mem_cfg_pkg;
   typedef enum bit [lg_max_cfgs-1:0] {
     e_mem_cfg_default    = 0
     , e_mem_cfg_infinite = 1
+    , e_mem_cfg_f1_dram  = 2
   } bsg_mem_cfg_e;
 
 endpackage

--- a/testbenches/common/v/memory_system.v
+++ b/testbenches/common/v/memory_system.v
@@ -84,7 +84,7 @@ module memory_system
     ,output logic axi_rready_o
   );
 
-  if (mem_cfg_p == e_mem_cfg_default) begin: mem_default
+  if (mem_cfg_p == e_mem_cfg_default || mem_cfg_p == e_mem_cfg_f1_dram) begin: mem_default
 
     bsg_cache_wrapper_axi #(
       .bsg_global_x_p(bsg_global_x_p)


### PR DESCRIPTION
In F1 this enumeration value switches between the default memory model
(e_mem_cfg_default), with an AXI memory model, and the DRAM IP (with
more accurate timing)