### PR TITLE
Toolchain updates

### DIFF
--- a/software/mk/Makefile.builddefs
+++ b/software/mk/Makefile.builddefs
@@ -55,11 +55,11 @@ ifeq ($(RISCV_BIN_DIR),)
 $(error RISCV_BIN_DIR not defined)
 endif
 
-RISCV_GCC     ?= $(RISCV_BIN_DIR)/riscv32-unknown-elf-gcc
-RISCV_GXX     ?= $(RISCV_BIN_DIR)/riscv32-unknown-elf-g++
+RISCV_GCC     ?= $(RISCV_BIN_DIR)/riscv32-unknown-elf-dramfs-gcc
+RISCV_GXX     ?= $(RISCV_BIN_DIR)/riscv32-unknown-elf-dramfs-g++
 RISCV_ELF2HEX ?= LD_LIBRARY_PATH=$(RISCV_BIN_DIR)/../lib $(RISCV_BIN_DIR)/elf2hex
-RISCV_OBJCOPY ?= $(RISCV_BIN_DIR)/riscv32-unknown-elf-objcopy
-RISCV_AR      ?= $(RISCV_BIN_DIR)/riscv32-unknown-elf-ar
+RISCV_OBJCOPY ?= $(RISCV_BIN_DIR)/riscv32-unknown-elf-dramfs-objcopy
+RISCV_AR      ?= $(RISCV_BIN_DIR)/riscv32-unknown-elf-dramfs-ar
 RISCV_SIM     ?= $(RISCV_BIN_DIR)/spike
 
 BSG_ROM_GEN     = $(BSG_IP_CORES_DIR)/bsg_mem/bsg_ascii_to_rom.py
@@ -108,7 +108,7 @@ LFS_BLOCK_SIZE ?= 128
 LFS_BLOCK_COUNT ?= 64
 
 lfs.c: $(IN_FILES)
-	$(RISCV_BIN_DIR)/../riscv32-unknown-elf/bin/dramfs_mklfs $(LFS_BLOCK_SIZE) $(LFS_BLOCK_COUNT) $(IN_FILES) > $@
+	$(RISCV_BIN_DIR)/../riscv32-unknown-elf-dramfs/bin/dramfs_mklfs $(LFS_BLOCK_SIZE) $(LFS_BLOCK_COUNT) $(IN_FILES) > $@
 endif
 
 # Manycore C library archiving rule
@@ -262,7 +262,7 @@ $(BSG_MANYCORE_LIB): $(BSG_MANYCORE_LIB_OBJS)
 	python $(HEX2BIN) $< 32 > $@
 
 %.dis: %.riscv
-	$(RISCV_BIN_DIR)/riscv32-unknown-elf-objdump -M numeric --disassemble-all -S $<
+	$(RISCV_BIN_DIR)/riscv32-unknown-elf-dramfs-objdump -M numeric --disassemble-all -S $<
 
 PROG_NAME ?= main
 

--- a/software/py/nbf.py
+++ b/software/py/nbf.py
@@ -94,7 +94,7 @@ class NBF:
     # make sure that you have riscv tool binaries in
     # bsg_manycore/software/riscv-tools/riscv-install/bin
     dirname = os.path.abspath(os.path.dirname(__file__))
-    objcopy_path = os.path.join(dirname, "../riscv-tools/riscv-install/bin/riscv32-unknown-elf-objcopy")
+    objcopy_path = os.path.join(dirname, "../riscv-tools/riscv-install/bin/riscv32-unknown-elf-dramfs-objcopy")
 
     if not os.path.isfile(objcopy_path):
       print("install riscv-tools first...")

--- a/software/riscv-tools/Makefile
+++ b/software/riscv-tools/Makefile
@@ -84,6 +84,9 @@ checkout-repos:
 	git clone $(TOOLCHAIN_URL);
 	cd $(TOOLCHAIN_REPO) && git checkout $(TOOLCHAIN_VERSION);
 	cd $(TOOLCHAIN_REPO) && git submodule update --init --recursive -j 16;
+
+	# This patch is necessary if target abi is ilp32f because of the issue
+	# https://github.com/riscv/riscv-gnu-toolchain/issues/530
 	cd $(TOOLCHAIN_REPO)/riscv-gcc && git apply $(CURDIR)/riscv-gcc.patch
 
 replace-newlib:

--- a/software/riscv-tools/Makefile
+++ b/software/riscv-tools/Makefile
@@ -83,12 +83,14 @@ checkout-repos:
 	@rm -rf $(TOOLCHAIN_REPO);
 	git clone $(TOOLCHAIN_URL);
 	cd $(TOOLCHAIN_REPO) && git checkout $(TOOLCHAIN_VERSION);
-	cd $(TOOLCHAIN_REPO) && git submodule update --init --recursive;
+	cd $(TOOLCHAIN_REPO) && git submodule update --init --recursive -j 16;
+	cd $(TOOLCHAIN_REPO)/riscv-gcc && git apply $(CURDIR)/riscv-gcc.patch
 
 replace-newlib:
-	cd $(TOOLCHAIN_REPO) && git apply ../$(NEWLIB_PATCH)
+	cd $(TOOLCHAIN_REPO) && git apply $(CURDIR)/$(NEWLIB_PATCH)
 	cd $(TOOLCHAIN_REPO) && git submodule sync
-	cd $(TOOLCHAIN_REPO) && git submodule update riscv-newlib
+	cd $(TOOLCHAIN_REPO) && git submodule update --remote riscv-newlib
+	cd $(TOOLCHAIN_REPO)/riscv-newlib && git checkout $(NEWLIB_BRANCH)
 	cd $(TOOLCHAIN_REPO)/riscv-newlib && git checkout $(NEWLIB_VERSION)
 
 checkout-spike:

--- a/software/riscv-tools/Makefile
+++ b/software/riscv-tools/Makefile
@@ -28,7 +28,7 @@
 .DEFAULT_GOAL := help
 
 TARGET_ARCH       := rv32imaf
-TARGET_ABI        := ilp32 # TODO: Test ilp32f for potential performance improvement
+TARGET_ABI        := ilp32f # TODO: Test ilp32f for potential performance improvement
 TARGET_CFLAGS     := '-fno-common -ffp-contract=off -mno-fdiv' # Turn off fma, fdiv and fexp instructions
                                                                # as manycore's FPU doesn't support them.
 
@@ -40,7 +40,7 @@ DEPENDS_DIR       := $(CURDIR)/depends
 
 NEWLIB_URL        := https://github.com/bespoke-silicon-group/bsg_newlib_dramfs.git
 NEWLIB_BRANCH     := dramfs
-NEWLIB_VERSION    := 1341d8b68f8eeec01b36de67c27bb2875e70c6f6
+NEWLIB_VERSION    := 7f0037ac3ac5068524d8e34c9b0fb5553bc55be1
 NEWLIB_PATCH      := newlib.patch
 
 SPIKE_REPO        := riscv-isa-sim
@@ -86,11 +86,9 @@ checkout-repos:
 	cd $(TOOLCHAIN_REPO) && git submodule update --init --recursive;
 
 replace-newlib:
-	cd $(TOOLCHAIN_REPO) && git config --file=.gitmodules submodule.riscv-newlib.url $(NEWLIB_URL)
-	cd $(TOOLCHAIN_REPO) && git config --file=.gitmodules submodule.riscv-newlib.branch $(NEWLIB_BRANCH)
 	cd $(TOOLCHAIN_REPO) && git apply ../$(NEWLIB_PATCH)
 	cd $(TOOLCHAIN_REPO) && git submodule sync
-	cd $(TOOLCHAIN_REPO) && git submodule update --remote riscv-newlib
+	cd $(TOOLCHAIN_REPO) && git submodule update riscv-newlib
 	cd $(TOOLCHAIN_REPO)/riscv-newlib && git checkout $(NEWLIB_VERSION)
 
 checkout-spike:
@@ -151,6 +149,7 @@ build-all:
 	$(MAKE) build-spike
 	$(MAKE) build-llvm
 
+rebuild-newlib: PATH:=$(RISCV)/bin:$(PATH)
 rebuild-newlib:
 	$(MAKE) -C $(TOOLCHAIN_REPO)/build-newlib
 	$(MAKE) -C $(TOOLCHAIN_REPO)/build-newlib install

--- a/software/riscv-tools/Makefile
+++ b/software/riscv-tools/Makefile
@@ -28,7 +28,7 @@
 .DEFAULT_GOAL := help
 
 TARGET_ARCH       := rv32imaf
-TARGET_ABI        := ilp32f # TODO: Test ilp32f for potential performance improvement
+TARGET_ABI        := ilp32f
 TARGET_CFLAGS     := '-fno-common -ffp-contract=off -mno-fdiv' # Turn off fma, fdiv and fexp instructions
                                                                # as manycore's FPU doesn't support them.
 

--- a/software/riscv-tools/newlib.patch
+++ b/software/riscv-tools/newlib.patch
@@ -1,7 +1,30 @@
+diff --git a/.gitmodules b/.gitmodules
+index bfc0f7b..2dd2803 100644
+--- a/.gitmodules
++++ b/.gitmodules
+@@ -12,7 +12,8 @@
+ 	url = ../riscv-dejagnu.git
+ [submodule "riscv-newlib"]
+ 	path = riscv-newlib
+-	url = ../riscv-newlib.git
++	url = https://github.com/bespoke-silicon-group/bsg_newlib_dramfs.git
++	branch = dramfs
+ [submodule "riscv-gdb"]
+ 	path = riscv-gdb
+ 	url = ../riscv-binutils-gdb.git
 diff --git a/Makefile.in b/Makefile.in
-index a006b0a..c6fbdca 100644
+index a006b0a..098d2fd 100644
 --- a/Makefile.in
 +++ b/Makefile.in
+@@ -53,7 +53,7 @@ endif
+ 
+ make_tuple = riscv$(1)-unknown-$(2)
+ LINUX_TUPLE  ?= $(call make_tuple,$(XLEN),linux-gnu)
+-NEWLIB_TUPLE ?= $(call make_tuple,$(XLEN),elf)
++NEWLIB_TUPLE ?= $(call make_tuple,$(XLEN),elf-dramfs)
+ MUSL_TUPLE ?= $(call make_tuple,$(XLEN),linux-musl)
+ 
+ CFLAGS_FOR_TARGET := $(CFLAGS_FOR_TARGET_EXTRA) @cmodel@
 @@ -520,8 +520,6 @@ stamps/merge-newlib-nano: stamps/build-newlib-nano stamps/build-newlib
  		$(INSTALL_DIR)/$(NEWLIB_TUPLE)/lib/$${mld}/libg_nano.a; \
  	    cp $(builddir)/install-newlib-nano/$(NEWLIB_TUPLE)/lib/$${mld}/libgloss.a\

--- a/software/riscv-tools/riscv-gcc.patch
+++ b/software/riscv-tools/riscv-gcc.patch
@@ -1,0 +1,14 @@
+diff --git a/libgcc/config/riscv/t-softfp32 b/libgcc/config/riscv/t-softfp32
+index 1bd51e803d1..c52337ae605 100644
+--- a/libgcc/config/riscv/t-softfp32
++++ b/libgcc/config/riscv/t-softfp32
+@@ -18,9 +18,7 @@ softfp_float_modes := df tf
+ softfp_extensions := sfdf sftf dftf
+ softfp_truncations := dfsf tfsf tfdf
+ 
+-ifndef ABI_SINGLE
+ softfp_float_modes += sf
+-endif
+ 
+ endif
+ endif


### PR DESCRIPTION
- Added a configure option to Newlib for installing our dramfs bsp.
- Updated the compiler ABI to ilp32f with a patch to riscv-gcc
- All RTL regression tests except nbody are passing; failure is debugged and is being fixed in https://github.com/bespoke-silicon-group/bsg_manycore/pull/183