### PR TITLE
Adding CI script for manycore regression

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,74 @@
+variables:
+  GIT_STRATEGY: none
+  GIT_SUBMODULE_STRATEGY: none
+
+stages:
+  - prereq
+  - check
+  - test-short
+  - test-long
+
+build-toolchain:
+  when: manual
+  stage: prereq
+  tags:
+    - bsg
+  before_script:
+    - rm -rf *
+    - echo "Cloning Manycore"
+    - git clone -b $CI_COMMIT_REF_NAME https://github.com/bespoke-silicon-group/bsg_manycore.git
+    - echo "Copying cadenv from local directory"
+    - cp -r $BSG_CADENV_DIR bsg_cadenv
+  script:
+    - echo "Building Manycore Toolchain."
+    - cd bsg_manycore
+    - make checkout_submodules
+    - make -C software/riscv-tools clean-all install-clean
+  cache:
+    key: $CI_COMMIT_REF_SLUG
+    paths:
+      - $CI_PROJECT_DIR/bsg_manycore/imports/
+      - $CI_PROJECT_DIR/bsg_manycore/software/riscv-tools/
+    policy: push
+
+
+test-regress:
+  stage: test-long
+  tags:
+    - bsg
+    - vcs
+  before_script:
+    - echo "This before_script is a HACK.  The cache automatically restores to bsg_manycore/*"
+    - echo "So we copy the cached tools, delete the dependencies, then restore the cache..."
+    - echo "Pulling cache"
+    - rm -rf imports/
+    - rm -rf riscv-tools/
+    - cp -r $CI_PROJECT_DIR/bsg_manycore/imports/ imports/
+    - cp -r $CI_PROJECT_DIR/bsg_manycore/software/riscv-tools/ riscv-tools/
+    - rm -rf bsg_manycore
+    - rm -rf bsg_cadenv
+    - rm -rf basejump_stl
+    - echo "Cloning Manycore"
+    - git clone -b $CI_COMMIT_REF_NAME https://github.com/bespoke-silicon-group/bsg_manycore.git
+    - echo "Copying cadenv from local directory"
+    - cp -r $BSG_CADENV_DIR bsg_cadenv
+    - echo "Restoring cache"
+    - cp -r imports/* $CI_PROJECT_DIR/bsg_manycore/imports/
+    - cp -r riscv-tools/* $CI_PROJECT_DIR/bsg_manycore/software/riscv-tools/
+    - echo "Cloning basejump_stl"
+    - git clone https://github.com/bespoke-silicon-group/basejump_stl.git
+  script:
+    - echo "Running Manycore regression."
+    - cd bsg_manycore
+    - ./ci/regress.sh
+  artifacts:
+    when: always
+    paths:
+      - ./software/spmd/recurse-results
+  cache:
+    key: $CI_COMMIT_REF_SLUG
+    paths:
+      - $CI_PROJECT_DIR/bsg_manycore/imports/
+      - $CI_PROJECT_DIR/bsg_manycore/software/riscv-tools/
+    policy: pull
+  

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,7 +16,6 @@ build-repos:
     - cp -r $BSG_CADENV_DIR bsg_cadenv
     - git clone https://github.com/bespoke-silicon-group/basejump_stl.git
     - git clone --recursive -b $CI_COMMIT_REF_NAME https://github.com/bespoke-silicon-group/bsg_manycore.git
-    - git clone https://github.com/bespoke-silicon-group/bsg_f1.git 
     - echo "Building toolchain"
     - cd bsg_manycore/software/riscv-tools
     - make clean-all install-clean
@@ -26,10 +25,10 @@ build-repos:
       - $CI_PROJECT_DIR/bsg_cadenv
       - $CI_PROJECT_DIR/basejump_stl
       - $CI_PROJECT_DIR/bsg_manycore
-      - $CI_PROJECT_DIR/bsg_f1
+      - $CI_PROJECT_DIR/bsg_bladerunner
     policy: push
 
-test-manycore:
+test-spmd:
   stage: test
   tags:
     - bsg
@@ -43,7 +42,7 @@ test-manycore:
       - $CI_PROJECT_DIR/bsg_cadenv
       - $CI_PROJECT_DIR/basejump_stl
       - $CI_PROJECT_DIR/bsg_manycore
-      - $CI_PROJECT_DIR/bsg_f1
+      - $CI_PROJECT_DIR/bsg_bladerunner
     policy: pull
   only:
     - merge_requests
@@ -56,13 +55,24 @@ test-cosim:
     - bsg
     - vcs
   script:
+    - echo "Configuring bsg_bladerunner..."
+    - git clone https://github.com/bespoke-silicon-group/bsg_bladerunner.git 
+    - cd bsg_bladerunner
+    - cp -r $BSG_CADENV_DIR bsg_cadenv
+    - make -f amibuild.mk setup-aws-fpga AWS_FPGA_REPO_DIR=$CI_PROJECT_DIR/bsg_bladerunner/aws-fpga
+    - git submodule update --init --recursive
+    - cd bsg_f1; git checkout master; cd ..
+    - cd bsg_manycore; git checkout $CI_COMMIT_REF_NAME
+    - cd software/riscv-tools
+    - ln -s ../../../../bsg_manycore/software/riscv-tools/riscv-install .
+    - ln -s ../../../../bsg_manycore/software/riscv-tools/llvm .
     - echo "Running COSIM..."
-    - cd bsg_f1/testbenches
-    - make
+    - cd bsg_bladerunner/bsg_f1/testbenches
+    - make regression
   cache:
     paths:
       - $CI_PROJECT_DIR/bsg_cadenv
       - $CI_PROJECT_DIR/basejump_stl
       - $CI_PROJECT_DIR/bsg_manycore
-      - $CI_PROJECT_DIR/bsg_f1
+      - $CI_PROJECT_DIR/bsg_bladerunner
     policy: pull

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,72 +3,66 @@ variables:
   GIT_SUBMODULE_STRATEGY: none
 
 stages:
-  - prereq
-  - check
-  - test-short
-  - test-long
+  - build
+  - test
 
-build-toolchain:
-  when: manual
-  stage: prereq
+build-repos:
+  stage: build
   tags:
     - bsg
-  before_script:
-    - rm -rf *
-    - echo "Cloning Manycore"
-    - git clone -b $CI_COMMIT_REF_NAME https://github.com/bespoke-silicon-group/bsg_manycore.git
-    - echo "Copying cadenv from local directory"
-    - cp -r $BSG_CADENV_DIR bsg_cadenv
   script:
-    - echo "Building Manycore Toolchain."
-    - cd bsg_manycore
-    - make checkout_submodules
-    - make -C software/riscv-tools clean-all install-clean
+    - echo "Cloning repos..."
+    - rm -rf *
+    - cp -r $BSG_CADENV_DIR bsg_cadenv
+    - git clone https://github.com/bespoke-silicon-group/basejump_stl.git
+    - git clone --recursive -b $CI_COMMIT_REF_NAME https://github.com/bespoke-silicon-group/bsg_manycore.git
+    - git clone https://github.com/bespoke-silicon-group/bsg_f1.git 
+    - echo "Building toolchain"
+    - cd bsg_manycore/software/riscv-tools
+    - make clean-all install-clean
   cache:
     key: $CI_COMMIT_REF_SLUG
     paths:
-      - $CI_PROJECT_DIR/bsg_manycore/imports/
-      - $CI_PROJECT_DIR/bsg_manycore/software/riscv-tools/
+      - $CI_PROJECT_DIR/bsg_cadenv
+      - $CI_PROJECT_DIR/basejump_stl
+      - $CI_PROJECT_DIR/bsg_manycore
+      - $CI_PROJECT_DIR/bsg_f1
     policy: push
 
-
-test-regress:
-  stage: test-long
+test-manycore:
+  stage: test
   tags:
     - bsg
     - vcs
-  before_script:
-    - echo "This before_script is a HACK.  The cache automatically restores to bsg_manycore/*"
-    - echo "So we copy the cached tools, delete the dependencies, then restore the cache..."
-    - echo "Pulling cache"
-    - rm -rf imports/
-    - rm -rf riscv-tools/
-    - cp -r $CI_PROJECT_DIR/bsg_manycore/imports/ imports/
-    - cp -r $CI_PROJECT_DIR/bsg_manycore/software/riscv-tools/ riscv-tools/
-    - rm -rf bsg_manycore
-    - rm -rf bsg_cadenv
-    - rm -rf basejump_stl
-    - echo "Cloning Manycore"
-    - git clone -b $CI_COMMIT_REF_NAME https://github.com/bespoke-silicon-group/bsg_manycore.git
-    - echo "Copying cadenv from local directory"
-    - cp -r $BSG_CADENV_DIR bsg_cadenv
-    - echo "Restoring cache"
-    - cp -r imports/* $CI_PROJECT_DIR/bsg_manycore/imports/
-    - cp -r riscv-tools/* $CI_PROJECT_DIR/bsg_manycore/software/riscv-tools/
-    - echo "Cloning basejump_stl"
-    - git clone https://github.com/bespoke-silicon-group/basejump_stl.git
   script:
-    - echo "Running Manycore regression."
+    - echo "Running Manycore regression..."
     - cd bsg_manycore
     - ./ci/regress.sh
-  artifacts:
-    when: always
-    paths:
-      - ./software/spmd/recurse-results
   cache:
-    key: $CI_COMMIT_REF_SLUG
     paths:
-      - $CI_PROJECT_DIR/bsg_manycore/imports/
-      - $CI_PROJECT_DIR/bsg_manycore/software/riscv-tools/
+      - $CI_PROJECT_DIR/bsg_cadenv
+      - $CI_PROJECT_DIR/basejump_stl
+      - $CI_PROJECT_DIR/bsg_manycore
+      - $CI_PROJECT_DIR/bsg_f1
     policy: pull
-  
+  only:
+    - merge_requests
+    - master
+
+test-cosim:
+  when: manual
+  stage: test
+  tags:
+    - bsg
+    - vcs
+  script:
+    - echo "Running COSIM..."
+    - cd bsg_f1/testbenches
+    - make
+  cache:
+    paths:
+      - $CI_PROJECT_DIR/bsg_cadenv
+      - $CI_PROJECT_DIR/basejump_stl
+      - $CI_PROJECT_DIR/bsg_manycore
+      - $CI_PROJECT_DIR/bsg_f1
+    policy: pull

--- a/ci/regress.sh
+++ b/ci/regress.sh
@@ -1,0 +1,19 @@
+#~/bin/bash
+
+NUM_CORES=${CI_NUM_CORES:-16}
+
+cd software/spmd
+make -j $NUM_CORES recurse-clean 
+make -j $NUM_CORES recurse-all
+for file in recurse-results/*.log; do
+  if grep --quiet BSG_FAIL $file; then
+    echo $file failed!
+    exit 1
+  fi
+
+  if grep --quiet BSG_TIMEOUT $file; then
+    echo $file timedout!
+    exit 1
+  fi
+done
+exit `(grep --quiet BSG_PASS recurse-results/*.log)`

--- a/ci/regress.sh
+++ b/ci/regress.sh
@@ -3,8 +3,8 @@
 NUM_CORES=${CI_NUM_CORES:-16}
 
 cd software/spmd
-make -j $NUM_CORES recurse-clean 
-make -j $NUM_CORES recurse-all
+make -j $NUM_CORES recurse-clean > /dev/null 2>&1
+make -j $NUM_CORES recurse-all > /dev/null 2>&1
 for file in recurse-results/*.log; do
   if grep --quiet BSG_FAIL $file; then
     echo $file failed!
@@ -16,5 +16,5 @@ for file in recurse-results/*.log; do
     exit 1
   fi
 done
-exit `(grep --quiet BSG_PASS recurse-results/*.log)`
 make BSG_FINISH.scrape BSG_FAIL.scrape BSG_TIMEOUT.scrape
+exit `(grep --quiet BSG_PASS recurse-results/*.log)`

--- a/ci/regress.sh
+++ b/ci/regress.sh
@@ -17,3 +17,4 @@ for file in recurse-results/*.log; do
   fi
 done
 exit `(grep --quiet BSG_PASS recurse-results/*.log)`
+make BSG_FINISH.scrape BSG_FAIL.scrape BSG_TIMEOUT.scrape


### PR DESCRIPTION
This CI setup builds the toolchain manually and runs the manycore regression.

Things missing (may or may not be important before merging):
- Checking success of toolchain build (One can manually trigger the build, but it will not fail, even if tools are not present)
- Add Badge to project README (to check status of builds, the CI status should still show up in PRs)

I've also only run this on a sucessful run.  I don't know now to easily force a CI fail, but it theoretically should fail if any test has BSG_FAIL or BSG_TIMEOUT and _no_ test has BSG_PASS (to detect build failures)

Before merging, we should restrict this to run on certain branches only.  This depends on the manycore development model.  Obviously we want to run on master, but probably not on all development branches, if they are frequently pushed.  If the model is people work in their own fork and then PR when ready, then running on all branches should be fine.  Since this is dependent on the manycore team, I'll leave it up to y'all to decide.