### PR TITLE
Stop kernel_softmax from returning early.

### DIFF
--- a/software/spmd/bsg_cuda_lite_runtime/softmax/kernel_softmax.c
+++ b/software/spmd/bsg_cuda_lite_runtime/softmax/kernel_softmax.c
@@ -100,7 +100,7 @@ int kernel_softmax(const float *A, float *B, int M, int N, int block_size_y, int
                 }
         }
         bsg_tile_group_barrier(&r_barrier, &c_barrier);
-        return 0;
+
         float partial_sum = 0;
         // Compute sum(B) for each element belonging to a tile in the tilegroup
         for(int y = start_y + __bsg_y; y < end_y; y += bsg_tiles_Y)


### PR DESCRIPTION
This was a leftover from debugging. Not super sure how it passed with this line, but it still passes when I remove it. 
Maybe we need to somehow have a smarter way of testing kernels?