### PR TITLE
Added extern c to bsg_manycore.h

### DIFF
--- a/software/bsg_manycore_lib/bsg_manycore.h
+++ b/software/bsg_manycore_lib/bsg_manycore.h
@@ -3,6 +3,10 @@
 
 #include "bsg_manycore_arch.h"
 
+#ifdef __cplusplus
+extern "C"{
+#endif
+
 int bsg_printf(const char *fmt, ...);
 
 typedef volatile int   *bsg_remote_int_ptr;
@@ -181,5 +185,8 @@ inline void bsg_fence()      { __asm__ __volatile__("fence" :::); }
 #define bsg_cuda_print_stat_kernel_start() bsg_cuda_print_stat_type(BSG_CUDA_PRINT_STAT_TAG_TOTAL,BSG_CUDA_PRINT_STAT_ID_KERNEL_START)
 #define bsg_cuda_print_stat_kernel_end()   bsg_cuda_print_stat_type(BSG_CUDA_PRINT_STAT_TAG_TOTAL,BSG_CUDA_PRINT_STAT_ID_KERNEL_END)
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/software/bsg_manycore_lib/bsg_manycore.h
+++ b/software/bsg_manycore_lib/bsg_manycore.h
@@ -9,6 +9,10 @@ extern "C"{
 
 int bsg_printf(const char *fmt, ...);
 
+#ifdef __cplusplus
+}
+#endif
+
 typedef volatile int   *bsg_remote_int_ptr;
 typedef volatile float   *bsg_remote_float_ptr;
 typedef volatile unsigned char  *bsg_remote_uint8_ptr;
@@ -184,9 +188,5 @@ inline void bsg_fence()      { __asm__ __volatile__("fence" :::); }
 #define bsg_cuda_print_stat_end(tag)      bsg_cuda_print_stat_type(tag,BSG_CUDA_PRINT_STAT_ID_END)
 #define bsg_cuda_print_stat_kernel_start() bsg_cuda_print_stat_type(BSG_CUDA_PRINT_STAT_TAG_TOTAL,BSG_CUDA_PRINT_STAT_ID_KERNEL_START)
 #define bsg_cuda_print_stat_kernel_end()   bsg_cuda_print_stat_type(BSG_CUDA_PRINT_STAT_TAG_TOTAL,BSG_CUDA_PRINT_STAT_ID_KERNEL_END)
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif


### PR DESCRIPTION
Currently we can't call bsg_printf from c++ code. Adding this declaration solves the problem, BUT I'm not sure if it's too heavy handed. I included the whole file which is probably unnecessary. 