### PR TITLE
Fix linker script to force sections to be word-aligned

### DIFF
--- a/software/spmd/common/link_dmem.ld
+++ b/software/spmd/common/link_dmem.ld
@@ -183,6 +183,7 @@ SECTIONS
 
     _dram_dram = .;
     *(.dram)
+    . = ALIGN(4);
   } >DRAM_D_VMA 
 
   _bsg_dram_d_end_addr = . ;


### PR DESCRIPTION
One of my kernels had a `.data.dram` section size of 97 bytes, which caused it to fail to load program onto manycore. 