### PR TITLE
Removed [INFO][VCORE] print statements

### DIFF
--- a/v/vanilla_bean/vanilla_core.v
+++ b/v/vanilla_bean/vanilla_core.v
@@ -1179,14 +1179,14 @@ module vanilla_core
         reserved_r <= 1'b1;
         reserved_addr_r <= dmem_addr_li;
         // synopsys translate_off
-        $display("[INFO][VCORE] making reservation. t=%0t, addr=%x", $time, dmem_addr_li);
+        //$display("[INFO][VCORE] making reservation. t=%0t, addr=%x", $time, dmem_addr_li);
         // synopsys translate_on
       end
       else if ((reserved_r == 1'b1)
         & dmem_v_li & dmem_w_li & (dmem_addr_li == reserved_addr_r)) begin
         reserved_r <= 1'b0;
         // synopsys translate_off
-        $display("[INFO][VCORE] breaking reservation. t=%0t.", $time);
+        //$display("[INFO][VCORE] breaking reservation. t=%0t.", $time);
         // synopsys translate_on
       end
     end


### PR DESCRIPTION
These print statements are constant in CUDA programs. They're annoying to work with because they can interfere with debug messages from the manycore and they're no longer useful (at least, until we need to debug kernel launching again)