### PR TITLE
Changed the output of both blocking and non-blocking vcache profiler's

### DIFF
--- a/testbenches/common/v/vcache_non_blocking_profiler.v
+++ b/testbenches/common/v/vcache_non_blocking_profiler.v
@@ -144,7 +144,7 @@ module vcache_non_blocking_profiler
   
   // file logging
   //
-  localparam logfile_lp = "vcache_non_blocking_stats.log";
+  localparam logfile_lp = "vcache_stats.csv";
 
   string my_name;
   integer fd; 

--- a/testbenches/common/v/vcache_profiler.v
+++ b/testbenches/common/v/vcache_profiler.v
@@ -77,7 +77,7 @@ module vcache_profiler
 
   // file logging
   //
-  localparam logfile_lp = "vcache_stats.log";
+  localparam logfile_lp = "vcache_stats.csv";
 
   string my_name;
   integer fd;


### PR DESCRIPTION
Changed the output of both vcache_profiler.v and vcache_non_blocking_profiler.v to the same file, "vcache_stats.csv", for simplicity of parsing in the bladerunner and bsg_replicant, since only one gets generated for every simulation based on the vcache that is used.