### PR TITLE
Fix Python Origin Bug

### DIFF
--- a/software/py/vanilla_pc_histogram.py
+++ b/software/py/vanilla_pc_histogram.py
@@ -33,7 +33,7 @@ class PCHistogram:
 
     # Default coordinates of origin tile
     _BSG_ORIGIN_X = 0
-    _BSG_ORIGIN_Y = 1
+    _BSG_ORIGIN_Y = 2
 
     _BSG_PC_MIN = 0x0000
     _BSG_PC_MAX = 0x2000
@@ -120,7 +120,7 @@ class PCHistogram:
 
             # Only add to pc count if at this cycle the processor is not stalled
             if(not (trace["operation"].startswith('stall_') or trace["operation"].endswith('_miss') or trace["operation"] == 'bubble')):
-                tile_pc_cnt[relative_y][relative_x][trace["pc"]] += 1
+                    tile_pc_cnt[relative_y][relative_x][trace["pc"]] += 1
         return tile_pc_cnt
 
 

--- a/software/py/vanilla_pc_histogram.py
+++ b/software/py/vanilla_pc_histogram.py
@@ -70,6 +70,10 @@ class PCHistogram:
         self.min_pc_val = self._BSG_PC_MIN
         self.max_pc_val = self._BSG_PC_MAX
 
+        # The origin is parsed from the upper-left tile of the active
+        # tiles. This assumption only works if that tile executes. If
+        # it does not, caveat emptor. We initialize to a non-sensical
+        # tile.
         self.origin_x = manycore_dim_x + 1
         self.origin_y = manycore_dim_y + 1
 

--- a/software/py/vanilla_pc_histogram.py
+++ b/software/py/vanilla_pc_histogram.py
@@ -120,7 +120,7 @@ class PCHistogram:
 
             # Only add to pc count if at this cycle the processor is not stalled
             if(not (trace["operation"].startswith('stall_') or trace["operation"].endswith('_miss') or trace["operation"] == 'bubble')):
-                    tile_pc_cnt[relative_y][relative_x][trace["pc"]] += 1
+                tile_pc_cnt[relative_y][relative_x][trace["pc"]] += 1
         return tile_pc_cnt
 
 

--- a/software/py/vanilla_pc_histogram.py
+++ b/software/py/vanilla_pc_histogram.py
@@ -57,11 +57,8 @@ class PCHistogram:
 
 
     # default constructor
-    def __init__(self, manycore_dim_y, manycore_dim_x, per_tile_stat, input_file):
+    def __init__(self, per_tile_stat, input_file):
 
-        self.manycore_dim_y = manycore_dim_y
-        self.manycore_dim_x = manycore_dim_x
-        self.manycore_dim = manycore_dim_y * manycore_dim_x
         self.per_tile_stat = per_tile_stat
 
         self.traces = []
@@ -70,25 +67,19 @@ class PCHistogram:
         self.min_pc_val = self._BSG_PC_MIN
         self.max_pc_val = self._BSG_PC_MAX
 
-        # The origin is parsed from the upper-left tile of the active
-        # tiles. This assumption only works if that tile executes. If
-        # it does not, caveat emptor. We initialize to a non-sensical
-        # tile.
-        self.origin_x = manycore_dim_x + 1
-        self.origin_y = manycore_dim_y + 1
+        unorigin = (0,0)
 
-       # parse vanilla_operation_trace.log
+        # parse vanilla_operation_trace.log
         with open(input_file) as f:
             csv_reader = csv.DictReader(f, delimiter=",")
             for row in csv_reader:
                 trace = {}
                 trace["x"] = int(row["x"])
-                self.origin_x = min(trace["x"], self.origin_x)
                 trace["y"] = int(row["y"])  
-                self.origin_y = min(trace["y"], self.origin_y)
                 trace["operation"] = row["operation"]
                 trace["cycle"] = int(row["cycle"])
                 trace["pc"] = int(row["pc"], 16)
+                unorigin = max((trace['y'], trace['x']), unorigin)
 
                 # update min and max pc read from traces 
                 #self.max_pc_val = max(self.max_pc_val, trace["pc"])
@@ -96,6 +87,9 @@ class PCHistogram:
 
                 if (trace["pc"] >= self._BSG_PC_MIN and trace["pc"] <= self._BSG_PC_MAX):
                     self.traces.append(trace)
+
+        self.manycore_dim_y = unorigin[0] + 1
+        self.manycore_dim_x = unorigin[1] + 1
 
         self.tile_pc_cnt = self.__generate_tile_pc_cnt(self.traces)
         self.manycore_pc_cnt = self.__generate_manycore_pc_cnt(self.tile_pc_cnt)
@@ -119,12 +113,12 @@ class PCHistogram:
    
         tile_pc_cnt = [[Counter() for x in range(self.manycore_dim_x)] for y in range(self.manycore_dim_y)]
         for trace in traces:
-            relative_x = trace["x"] - self.origin_x
-            relative_y = trace["y"] - self.origin_y
+            x = trace["x"]
+            y = trace["y"]
 
             # Only add to pc count if at this cycle the processor is not stalled
             if(not (trace["operation"].startswith('stall_') or trace["operation"].endswith('_miss') or trace["operation"] == 'bubble')):
-                tile_pc_cnt[relative_y][relative_x][trace["pc"]] += 1
+                tile_pc_cnt[y][x][trace["pc"]] += 1
         return tile_pc_cnt
 
 
@@ -272,10 +266,6 @@ def parse_args():
                         help="Vanilla operation log file")
     parser.add_argument("--tile", default=False, action='store_true',
                         help="Also generate separate pc histogram files for each tile.")
-    parser.add_argument("--dim-y", required=1, type=int,
-                        help="Manycore Y dimension")
-    parser.add_argument("--dim-x", required=1, type=int,
-                        help="Manycore X dimension")
 
     args = parser.parse_args()
     return args
@@ -284,4 +274,4 @@ def parse_args():
 # main()
 if __name__ == "__main__":
     args = parse_args()
-    pch = PCHistogram(args.dim_y, args.dim_x, args.tile, args.input)
+    pch = PCHistogram(args.tile, args.input)

--- a/software/py/vanilla_pc_histogram.py
+++ b/software/py/vanilla_pc_histogram.py
@@ -31,10 +31,6 @@ class PCHistogram:
     _DEFAULT_START_CYCLE = 0 
     _DEFAULT_END_CYCLE   = 500000
 
-    # Default coordinates of origin tile
-    _BSG_ORIGIN_X = 0
-    _BSG_ORIGIN_Y = 2
-
     _BSG_PC_MIN = 0x0000
     _BSG_PC_MAX = 0x2000
 
@@ -74,14 +70,18 @@ class PCHistogram:
         self.min_pc_val = self._BSG_PC_MIN
         self.max_pc_val = self._BSG_PC_MAX
 
+        self.origin_x = manycore_dim_x + 1
+        self.origin_y = manycore_dim_y + 1
 
        # parse vanilla_operation_trace.log
         with open(input_file) as f:
             csv_reader = csv.DictReader(f, delimiter=",")
             for row in csv_reader:
                 trace = {}
-                trace["x"] = int(row["x"])  
+                trace["x"] = int(row["x"])
+                self.origin_x = min(trace["x"], self.origin_x)
                 trace["y"] = int(row["y"])  
+                self.origin_y = min(trace["y"], self.origin_y)
                 trace["operation"] = row["operation"]
                 trace["cycle"] = int(row["cycle"])
                 trace["pc"] = int(row["pc"], 16)
@@ -115,8 +115,8 @@ class PCHistogram:
    
         tile_pc_cnt = [[Counter() for x in range(self.manycore_dim_x)] for y in range(self.manycore_dim_y)]
         for trace in traces:
-            relative_x = trace["x"] - self._BSG_ORIGIN_X
-            relative_y = trace["y"] - self._BSG_ORIGIN_Y
+            relative_x = trace["x"] - self.origin_x
+            relative_y = trace["y"] - self.origin_y
 
             # Only add to pc count if at this cycle the processor is not stalled
             if(not (trace["operation"].startswith('stall_') or trace["operation"].endswith('_miss') or trace["operation"] == 'bubble')):

--- a/software/py/vanilla_stats_parser.py
+++ b/software/py/vanilla_stats_parser.py
@@ -138,8 +138,6 @@ class CudaStatTag:
 
  
 class VanillaStatsParser:
-    # Default coordinates of origin tile in the manycore array.
-
     # formatting parameters for aligned printing
     type_fmt = {"name"      : "{:<35}",
                 "name-short": "{:<20}",
@@ -233,6 +231,9 @@ class VanillaStatsParser:
                 self.traces.append(trace)
                 active_tiles.add((trace['y'], trace['x']))
 
+        # The origin is parsed from the upper-left tile of the active
+        # tiles. This assumption only works if that tile executes. If
+        # it does not, caveat emptor.
         self.origin = min(active_tiles)
 
         # Raise exception and exit if there are no traces 

--- a/software/py/vanilla_stats_parser.py
+++ b/software/py/vanilla_stats_parser.py
@@ -140,7 +140,7 @@ class CudaStatTag:
 class VanillaStatsParser:
     # Default coordinates of origin tile in the manycore array.
     _BSG_ORIGIN_X = 0
-    _BSG_ORIGIN_Y = 1
+    _BSG_ORIGIN_Y = 2
 
     # formatting parameters for aligned printing
     type_fmt = {"name"      : "{:<35}",

--- a/software/py/vanilla_stats_parser.py
+++ b/software/py/vanilla_stats_parser.py
@@ -139,8 +139,6 @@ class CudaStatTag:
  
 class VanillaStatsParser:
     # Default coordinates of origin tile in the manycore array.
-    _BSG_ORIGIN_X = 0
-    _BSG_ORIGIN_Y = 2
 
     # formatting parameters for aligned printing
     type_fmt = {"name"      : "{:<35}",
@@ -235,13 +233,14 @@ class VanillaStatsParser:
                 self.traces.append(trace)
                 active_tiles.add((trace['y'], trace['x']))
 
+        self.origin = min(active_tiles)
 
         # Raise exception and exit if there are no traces 
         assert (self.traces), "vanilla_stats_parser: no stats found, nothing to do - use bsg_cuda_print_stat_kerenl_start/end macros to generate vanilla stats."
 
 
         # Save the active tiles in a list
-        self.active = [(y - self._BSG_ORIGIN_Y, x - self._BSG_ORIGIN_X) for (y,x) in active_tiles]
+        self.active = [(y - self.origin[0], x - self.origin[1]) for (y,x) in active_tiles]
         self.active.sort()
 
         # generate timing stats for each tile and tile group 
@@ -984,8 +983,8 @@ class VanillaStatsParser:
         for trace in traces:
             y = trace["y"]
             x = trace["x"]
-            relative_y = y - self._BSG_ORIGIN_Y
-            relative_x = x - self._BSG_ORIGIN_X
+            relative_y = y - self.origin[0]
+            relative_x = x - self.origin[1]
             cur_tile = (relative_y, relative_x)
 
             # instantiate a CudaStatTag object with the tag value

--- a/software/py/vanilla_stats_parser.py
+++ b/software/py/vanilla_stats_parser.py
@@ -231,14 +231,14 @@ class VanillaStatsParser:
                 self.traces.append(trace)
                 active_tiles.add((trace['y'], trace['x']))
 
+        # Raise exception and exit if there are no traces 
+        if not self.traces:
+            raise IOError("No Stats Found: Use bsg_cuda_print_stat_kernel_start/end to generate runtime statistics")
+
         # The origin is parsed from the upper-left tile of the active
         # tiles. This assumption only works if that tile executes. If
         # it does not, caveat emptor.
         self.origin = min(active_tiles)
-
-        # Raise exception and exit if there are no traces 
-        assert (self.traces), "vanilla_stats_parser: no stats found, nothing to do - use bsg_cuda_print_stat_kerenl_start/end macros to generate vanilla stats."
-
 
         # Save the active tiles in a list
         self.active = [(y - self.origin[0], x - self.origin[1]) for (y,x) in active_tiles]

--- a/software/py/vanilla_stats_parser.py
+++ b/software/py/vanilla_stats_parser.py
@@ -225,23 +225,16 @@ class VanillaStatsParser:
         with open(input_file) as f:
             csv_reader = csv.DictReader (f, delimiter=",")
             for row in csv_reader:
-                trace = {}
-                for op in self.all_ops:
-                    trace[op] = int(row[op])
-                self.traces.append(trace)
+                trace = {op:int(row[op]) for op in self.all_ops}
                 active_tiles.add((trace['y'], trace['x']))
+                self.traces.append(trace)
 
         # Raise exception and exit if there are no traces 
         if not self.traces:
             raise IOError("No Stats Found: Use bsg_cuda_print_stat_kernel_start/end to generate runtime statistics")
 
-        # The origin is parsed from the upper-left tile of the active
-        # tiles. This assumption only works if that tile executes. If
-        # it does not, caveat emptor.
-        self.origin = min(active_tiles)
-
         # Save the active tiles in a list
-        self.active = [(y - self.origin[0], x - self.origin[1]) for (y,x) in active_tiles]
+        self.active = list(active_tiles)
         self.active.sort()
 
         # generate timing stats for each tile and tile group 
@@ -982,11 +975,7 @@ class VanillaStatsParser:
 
 
         for trace in traces:
-            y = trace["y"]
-            x = trace["x"]
-            relative_y = y - self.origin[0]
-            relative_x = x - self.origin[1]
-            cur_tile = (relative_y, relative_x)
+            cur_tile = (trace['y'], trace['x'])
 
             # instantiate a CudaStatTag object with the tag value
             cst = CudaStatTag(trace["tag"])

--- a/testbenches/common/v/spmd_testbench.v
+++ b/testbenches/common/v/spmd_testbench.v
@@ -989,8 +989,8 @@ module spmd_testbench;
     ,.icache_entries_p(icache_entries_p)
     ,.data_width_p(data_width_p)
     ,.dmem_size_p(dmem_size_p)
-    ,.header_print_x_cord_p(0)
-    ,.header_print_y_cord_p(2)
+    ,.origin_x_cord_p(0)
+    ,.origin_y_cord_p(2)
   ) vcore_prof (
     .*
     ,.global_ctr_i($root.spmd_testbench.global_ctr)

--- a/testbenches/common/v/vanilla_core_profiler.v
+++ b/testbenches/common/v/vanilla_core_profiler.v
@@ -28,8 +28,8 @@ module vanilla_core_profiler
     , parameter reg_els_lp = RV32_reg_els_gp
 
     // determines who prints the csv header.
-    , parameter header_print_x_cord_p="inv"
-    , parameter header_print_y_cord_p="inv"
+    , parameter origin_x_cord_p="inv"
+    , parameter origin_y_cord_p="inv"
   )
   (
     input clk_i
@@ -105,7 +105,7 @@ module vanilla_core_profiler
 
   // task to print a line of operation trace
   task print_operation_trace(integer fd, string op);
-    $fwrite(fd, "%0t,%0d,%0d,%0h,%s", global_ctr_i, my_x_i, my_y_i, (exe_r.pc_plus4 - 'd4), op);
+    $fwrite(fd, "%0t,%0d,%0d,%0h,%s", global_ctr_i, my_x_i - origin_x_cord_p, my_y_i - origin_y_cord_p, (exe_r.pc_plus4 - 'd4), op);
   endtask
 
   // event signals
@@ -812,8 +812,8 @@ module vanilla_core_profiler
 
     #1; // we need to wait for one time unit so that my_x_i and my_y_i becomes a known value.
 
-    // the first tile opens the logfile and writes the csv header.
-    if ((my_x_i == x_cord_width_p'(header_print_x_cord_p)) & (my_y_i == y_cord_width_p'(header_print_y_cord_p))) begin
+    // the origin tile opens the logfile and writes the csv header.
+    if ((my_x_i == x_cord_width_p'(origin_x_cord_p)) & (my_y_i == y_cord_width_p'(origin_y_cord_p))) begin
       fd = $fopen(logfile_lp, "w");
       $fwrite(fd, "time,x,y,pc_r,pc_n,tag,global_ctr,cycle,");
       $fwrite(fd, "instr_total,instr_fadd,instr_fsub,instr_fmul,");
@@ -1131,8 +1131,8 @@ module vanilla_core_profiler
 
           $fwrite(fd, "%0d,%0d,%0d,%0d,%0d,%0d,%0d,%0d,",
             $time,
-            my_x_i,
-            my_y_i,
+            my_x_i - origin_x_cord_p,
+            my_y_i - origin_y_cord_p,
             pc_r,
             pc_n,
             print_stat_tag_i,


### PR DESCRIPTION
This supersedes #266. I changed verilog files so I want CI to run.

* Renamed header_print_cord_x/y to origin_cord_x/y
* Switched to printing manycore relative x/y coordinates instead of global coordinates for parsers