### PR TITLE
Add a rule to build link script on a wildcard path

### DIFF
--- a/software/mk/Makefile.builddefs
+++ b/software/mk/Makefile.builddefs
@@ -147,6 +147,9 @@ LINK_SCRIPT ?= bsg_link.ld
 bsg_link.ld: $(LINK_GEN)
 	$(LINK_GEN) $(LINK_GEN_OPTS) > $@
 
+%/bsg_link.ld: $(LINK_GEN)
+	$(LINK_GEN) $(LINK_GEN_OPTS) > $@
+
 RISCV_LINK_OPTS ?= 
 
 ifneq ($(BSG_NEWLIB), 1)


### PR DESCRIPTION
This adds a rule that allows replicant to build link scripts on any path. This allows replicant to do two things: 

* build machine-specific link scripts
* Auto-re-build the RISC-V binary when the machine changes. 

I haven't decided if this is the right way to do this. But it is a way to do things.