### PR TITLE
Adds Blocking Vcache stall graph

### DIFF
--- a/software/py/vcache_stall_graph.py
+++ b/software/py/vcache_stall_graph.py
@@ -1,0 +1,328 @@
+#
+#   vcache_stall_graph.py
+#
+#   victim cache execution visualizer.
+# 
+#   input: vcache_operation_trace.csv.log
+#          vcache_stats.csv (for timing)
+#   output: stall graph file (vcache_stall_abstrat/detailed.png)
+#           stall graph key  (vcache_key_abstract/detailed.png)
+#
+#   @author Borna Tommy
+#
+#   How to use:
+#   python vcache_stallgraph.py --input {vcache_operation_trace.csv}
+#                               --timing-stat {vcache_stats.csv}
+#                               --abstract {optional}
+#                               --generate-key {optional}
+#
+#   ex) python vcache_stall_graph.py --input vcache_operation_trace.csv
+#                                    --timing-stat vcache_stats.csv
+#                                    --abstract --generate-key
+#
+#   {timing-stat}  used for extracting the timing window for stall graph
+#   {abstract}     used for abstract simplifed stall graph
+#   {generate-key} also generates a color key for the stall graph
+
+
+import sys
+import csv
+import argparse
+from PIL import Image, ImageDraw, ImageFont
+from itertools import chain
+
+
+
+
+class VCacheStallGraph:
+    # for generating the key
+    _KEY_WIDTH  = 512
+    _KEY_HEIGHT = 512
+    _DEFAULT_START_CYCLE = 0 
+    _DEFAULT_END_CYCLE   = 200000
+
+    # default constructor
+    def __init__(self, timing_stats_file, abstract):
+
+        self.timing_stats_file = timing_stats_file
+        self.abstract = abstract
+
+        # List of operations performed
+        self.operation_list = ["ld",     
+                               "st",     
+                               "mask",   
+                               "sigext", 
+                               "tagst",  
+                               "tagfl",  
+                               "taglv",  
+                               "tagla",  
+                               "afl",    
+                               "aflinv", 
+                               "ainv",   
+                               "alock",  
+                               "aunlock",
+                               "tag_read",
+                               "atomic", 
+                               "amoswap",
+                               "amoor",  
+                               "miss_ld",
+                               "miss_st",
+                               "dma_read_req",
+                               "dma_write_req",
+                               "idle",
+                               "miss"]
+
+
+
+        # coloring scheme for different types of operations
+        # For abstract mode
+        self.abstract_operation_color = {"ld"              : (0x00, 0xff, 0x00) , ## green
+                                         "st"              : (0x00, 0x00, 0xff) , ## blue
+                                         "mask"            : (0x00, 0x00, 0x00) , ## white 
+                                         "sigext"          : (0x00, 0x00, 0x00) , ## white 
+                                         "tagst"           : (0x00, 0x00, 0x00) , ## white 
+                                         "tagfl"           : (0x00, 0x00, 0x00) , ## white 
+                                         "taglv"           : (0x00, 0x00, 0x00) , ## white 
+                                         "tagla"           : (0x00, 0x00, 0x00) , ## white 
+                                         "afl"             : (0x00, 0x00, 0x00) , ## white 
+                                         "aflinv"          : (0x00, 0x00, 0x00) , ## white 
+                                         "ainv"            : (0x00, 0x00, 0x00) , ## white 
+                                         "alock"           : (0x00, 0x00, 0x00) , ## white 
+                                         "aunlock"         : (0x00, 0x00, 0x00) , ## white 
+                                         "tag_read"        : (0x00, 0x00, 0x00) , ## white 
+                                         "atomic"          : (0x00, 0x00, 0x00) , ## white 
+                                         "amoswap"         : (0x00, 0x00, 0x00) , ## white 
+                                         "amoor"           : (0x00, 0x00, 0x00) , ## white 
+                                         "miss_ld"         : (0x00, 0xff, 0x00) , ## green
+                                         "miss_st"         : (0x00, 0x00, 0xff) , ## blue 
+                                         "dma_read_req"    : (0xff, 0xff, 0xff) , ## white 
+                                         "dma_write_req"   : (0xff, 0xff, 0xff) , ## white 
+                                         "idle"            : (0x40, 0x40, 0x40) , ## gray
+                                         "miss"            : (0xff, 0x00, 0x00) , ## red
+                                         } 
+
+
+        # coloring scheme for different types of operations
+        # For detailed mode
+        self.detailed_operation_color = {"ld"              : (0x00, 0xff, 0x00) , ## green
+                                         "st"              : (0x00, 0x00, 0xff) , ## blue
+                                         "mask"            : (0x00, 0x00, 0x00) , ## white 
+                                         "sigext"          : (0x00, 0x00, 0x00) , ## white 
+                                         "tagst"           : (0x00, 0x00, 0x00) , ## white 
+                                         "tagfl"           : (0x00, 0x00, 0x00) , ## white 
+                                         "taglv"           : (0x00, 0x00, 0x00) , ## white 
+                                         "tagla"           : (0x00, 0x00, 0x00) , ## white 
+                                         "afl"             : (0x00, 0x00, 0x00) , ## white 
+                                         "aflinv"          : (0x00, 0x00, 0x00) , ## white 
+                                         "ainv"            : (0x00, 0x00, 0x00) , ## white 
+                                         "alock"           : (0x00, 0x00, 0x00) , ## white 
+                                         "aunlock"         : (0x00, 0x00, 0x00) , ## white 
+                                         "tag_read"        : (0x00, 0x00, 0x00) , ## white 
+                                         "atomic"          : (0x00, 0x00, 0x00) , ## white 
+                                         "amoswap"         : (0x00, 0x00, 0x00) , ## white 
+                                         "amoor"           : (0x00, 0x00, 0x00) , ## white 
+                                         "miss_ld"         : (0x00, 0xff, 0x00) , ## green
+                                         "miss_st"         : (0x00, 0x00, 0xff) , ## blue 
+                                         "dma_read_req"    : (0xff, 0xff, 0xff) , ## white 
+                                         "dma_write_req"   : (0xff, 0xff, 0xff) , ## white 
+                                         "idle"            : (0x40, 0x40, 0x40) , ## gray
+                                         "miss"            : (0xff, 0x00, 0x00) , ## red
+                                         } 
+
+
+
+
+        # Determine coloring rules based on mode {abstract / detailed}
+        if (self.abstract):
+            self.operation_color     = self.abstract_operation_color
+        else:
+            self.operation_color     = self.detailed_operation_color
+
+
+        # Parse timing stat file vcache_stats.csv
+        # to gather start and end cycle of entire graph
+        self.timing_stats = []
+        try:
+            with open(self.timing_stats_file) as f:
+                csv_reader = csv.DictReader(f, delimiter=",")
+                for row in csv_reader:
+                    timing_stat = {}
+                    timing_stat["global_ctr"] = int(row["global_ctr"])
+                    self.timing_stats.append(timing_stat)
+
+            # If there are at least two stats recovered from vcache_stats.csv for start and end cycle
+            if (len(self.timing_stats) >= 2):
+                self.start_cycle = self.timing_stats[0]["global_ctr"]
+                self.end_cycle = self.timing_stats[-1]["global_ctr"]
+            else:
+                self.start_cycle = self._DEFAULT_START_CYCLE
+                self.end_cycle = self._DEFAULT_END_CYCLE
+            return
+
+        # If the vcache_stats.csv file has not been given as input
+        # Use the default values for start and end cycles
+        except IOError as e:
+            self.start_cycle = self._DEFAULT_START_CYCLE
+            self.end_cycle = self._DEFAULT_END_CYCLE
+
+        return
+
+
+
+  
+    # main public method
+    def generate(self, input_file):
+        # parse vcache_operation_trace.csv
+        traces = []
+        with open(input_file) as f:
+            csv_reader = csv.DictReader(f, delimiter=",")
+            for row in csv_reader:
+                trace = {}
+                vcache = row["vcache"]
+                trace["vcache"] = int (vcache[vcache.find("[")+1 : vcache.find("]")])
+                trace["operation"] = row["operation"]
+                trace["cycle"] = int(row["cycle"])
+                traces.append(trace)
+  
+        # get number of victim cache banks
+        self.__get_vcache_dim(traces)
+
+        # init image
+        self.__init_image()
+
+        # create image
+        for trace in traces:
+            self.__mark_trace(trace)
+
+        #self.img.show()
+        mode = "abstract" if self.abstract else "detailed"
+        self.img.save(("vcache_stall_" + mode + ".png"))
+        return
+
+    # public method to generate key for vcache stall graph
+    # called if --generate-key argument is true
+    def generate_key(self, key_image_fname = "key"):
+        img  = Image.new("RGB", (self._KEY_WIDTH, self._KEY_HEIGHT), "black")
+        draw = ImageDraw.Draw(img)
+        font = ImageFont.load_default()
+        # the current row position of our key
+        yt = 0
+
+        # for each color in stalls...
+        for operation in self.operation_color.keys():
+            # get the font size
+            (font_height,font_width) = font.getsize(operation)
+            # draw a rectangle with color fill
+            yb = yt + font_width
+            # [0, yt, 64, yb] is [top left x, top left y, bottom right x, bottom left y]
+            draw.rectangle([0, yt, 64, yb], self.operation_color[operation])
+            # write the label for this color in white
+            # (68, yt) = (top left x, top left y)
+            # (255, 255, 255) = white
+            draw.text((68, yt), operation, (255,255,255))
+            # create the new row's y-coord
+            yt += font_width
+
+        # save the key
+        mode = "abstract" if self.abstract else "detailed"
+        img.save("{}.png".format(key_image_fname + "_" + mode))
+        return
+
+    # look through the input file to get the number of vcache banks
+    def __get_vcache_dim(self, traces):
+        vcaches = list(map(lambda t: t["vcache"], traces))
+        self.vcache_max = max(vcaches)
+        self.vcache_min = min(vcaches)
+        self.vcache_dim = self.vcache_max - self.vcache_min +1
+        return
+
+
+    # initialize image
+    def __init_image(self):
+        self.img_width = 2048   # default
+        self.img_height = (((self.end_cycle-self.start_cycle)+self.img_width)//self.img_width)*(2+(self.vcache_dim))
+        self.img = Image.new("RGB", (self.img_width, self.img_height), "black")
+        self.pixel = self.img.load()
+        return  
+  
+    # mark the trace on output image
+    def __mark_trace(self, trace):
+
+        # ignore trace outside the cycle range
+        if trace["cycle"] < self.start_cycle or trace["cycle"] >= self.end_cycle:
+            return
+
+        # determine pixel location
+        cycle = (trace["cycle"] - self.start_cycle)
+        col = cycle % self.img_width
+        floor = cycle // self.img_width
+        vcache = trace["vcache"]
+        row = floor*(2+(self.vcache_dim)) + (vcache)
+
+
+        # determine color
+        if trace["operation"] in self.operation_color.keys():
+            self.pixel[col,row] = self.operation_color[trace["operation"]]
+        else:
+            raise Exception('Invalid operation in vcache operation trace log {}'.format(trace["operation"]))
+        return
+
+
+# Deprecated: We no longer pass in the cycles by hand 
+# The appliation parses the start/end cycles from vcache_stats.csv file
+# The action to take in two input arguments for start and 
+# end cycle of execution in the form of start_cycle@end_cycle
+class CycleAction(argparse.Action):
+    def __call__(self, parser, namespace, cycle, option_string=None):
+        start_str,end_str = cycle.split("@")
+
+        # Check if start cycle is given as input
+        if(not start_str):
+            start_cycle = BloodGraph._DEFAULT_START_CYCLE
+        else:
+            start_cycle = int(start_str)
+
+        # Check if end cycle is given as input
+        if(not end_str):
+            end_cycle = BloodGraph._DEFAULT_END_CYCLE
+        else:
+            end_cycle = int(end_str)
+
+        # check if start cycle is before end cycle
+        if(start_cycle > end_cycle):
+            raise ValueError("start cycle {} cannot be larger than end cycle {}.".format(start_cycle, end_cycle))
+
+        setattr(namespace, "start", start_cycle)
+        setattr(namespace, "end", end_cycle)
+ 
+# Parse input arguments and options 
+def parse_args():  
+    parser = argparse.ArgumentParser(description="Argument parser for vcache_stall_graph.py")
+    parser.add_argument("--input", default="vcache_operation_trace.csv", type=str,
+                        help="VCache operation log file")
+    parser.add_argument("--timing-stats", default="vcache_stats.csv", type=str,
+                        help="VCache stats log file")
+    parser.add_argument("--cycle", nargs='?', required=0, action=CycleAction, 
+                        const = (str(VCacheStallGraph._DEFAULT_START_CYCLE)+"@"+str(VCacheStallGraph._DEFAULT_END_CYCLE)),
+                        help="Cycle window of stall graph as start_cycle@end_cycle.")
+    parser.add_argument("--abstract", default=False, action='store_true',
+                        help="Type of stall graph - abstract / detailed")
+    parser.add_argument("--generate-key", default=False, action='store_true',
+                        help="Generate a key image")
+    parser.add_argument("--no-stall-graph", default=False, action='store_true',
+                        help="Skip stall graph generation")
+
+    args = parser.parse_args()
+    return args
+
+
+# main()
+if __name__ == "__main__":
+    args = parse_args()
+  
+    bg = VCacheStallGraph(args.timing_stats, args.abstract)
+    if not args.no_stall_graph:
+        bg.generate(args.input)
+    if args.generate_key:
+        bg.generate_key()
+

--- a/software/py/vcache_stall_graph.py
+++ b/software/py/vcache_stall_graph.py
@@ -48,8 +48,22 @@ class VCacheStallGraph:
         self.abstract = abstract
 
         # List of operations performed
-        self.operation_list = ["ld",     
+        self.operation_list = ["ld",
+                               "ld_ld",
+                               "ld_ldu",
+                               "ld_lw",
+                               "ld_lwu",
+                               "ld_lh",
+                               "ld_lhu",
+                               "ld_lb",
+                               "ld_lbu",
+
                                "st",     
+                               "st_sd",
+                               "st_sw",
+                               "st_sh",
+                               "st_sb",
+
                                "mask",   
                                "sigext", 
                                "tagst",  
@@ -77,7 +91,19 @@ class VCacheStallGraph:
         # coloring scheme for different types of operations
         # For abstract mode
         self.abstract_operation_color = {"ld"              : (0x00, 0xff, 0x00) , ## green
+                                         "ld_ld"           : (0x00, 0xff, 0x00) , ## green
+                                         "ld_ldu"          : (0x00, 0xff, 0x00) , ## green
+                                         "ld_lw"           : (0x00, 0xff, 0x00) , ## green
+                                         "ld_lwu"          : (0x00, 0xff, 0x00) , ## green
+                                         "ld_lh"           : (0x00, 0xff, 0x00) , ## green
+                                         "ld_lhu"          : (0x00, 0xff, 0x00) , ## green
+                                         "ld_lb"           : (0x00, 0xff, 0x00) , ## green
+                                         "ld_lbu"          : (0x00, 0xff, 0x00) , ## green
                                          "st"              : (0x00, 0x00, 0xff) , ## blue
+                                         "st_sd"           : (0x00, 0x00, 0xff) , ## blue
+                                         "st_sw"           : (0x00, 0x00, 0xff) , ## blue
+                                         "st_sh"           : (0x00, 0x00, 0xff) , ## blue
+                                         "st_sb"           : (0x00, 0x00, 0xff) , ## blue
                                          "mask"            : (0x00, 0x00, 0x00) , ## white 
                                          "sigext"          : (0x00, 0x00, 0x00) , ## white 
                                          "tagst"           : (0x00, 0x00, 0x00) , ## white 
@@ -105,7 +131,19 @@ class VCacheStallGraph:
         # coloring scheme for different types of operations
         # For detailed mode
         self.detailed_operation_color = {"ld"              : (0x00, 0xff, 0x00) , ## green
+                                         "ld_ld"           : (0x00, 0xff, 0x00) , ## green
+                                         "ld_ldu"          : (0x00, 0xff, 0x00) , ## green
+                                         "ld_lw"           : (0x00, 0xff, 0x00) , ## green
+                                         "ld_lwu"          : (0x00, 0xff, 0x00) , ## green
+                                         "ld_lh"           : (0x00, 0xff, 0x00) , ## green
+                                         "ld_lhu"          : (0x00, 0xff, 0x00) , ## green
+                                         "ld_lb"           : (0x00, 0xff, 0x00) , ## green
+                                         "ld_lbu"          : (0x00, 0xff, 0x00) , ## green
                                          "st"              : (0x00, 0x00, 0xff) , ## blue
+                                         "st_sd"           : (0x00, 0x00, 0xff) , ## blue
+                                         "st_sw"           : (0x00, 0x00, 0xff) , ## blue
+                                         "st_sh"           : (0x00, 0x00, 0xff) , ## blue
+                                         "st_sb"           : (0x00, 0x00, 0xff) , ## blue
                                          "mask"            : (0x00, 0x00, 0x00) , ## white 
                                          "sigext"          : (0x00, 0x00, 0x00) , ## white 
                                          "tagst"           : (0x00, 0x00, 0x00) , ## white 
@@ -201,7 +239,7 @@ class VCacheStallGraph:
 
     # public method to generate key for vcache stall graph
     # called if --generate-key argument is true
-    def generate_key(self, key_image_fname = "key"):
+    def generate_key(self, key_image_fname = "vcache_key"):
         img  = Image.new("RGB", (self._KEY_WIDTH, self._KEY_HEIGHT), "black")
         draw = ImageDraw.Draw(img)
         font = ImageFont.load_default()

--- a/testbenches/common/v/spmd_testbench.v
+++ b/testbenches/common/v/spmd_testbench.v
@@ -294,6 +294,7 @@ module spmd_testbench;
       ,.global_ctr_i($root.spmd_testbench.global_ctr)
       ,.print_stat_v_i($root.spmd_testbench.print_stat_v)
       ,.print_stat_tag_i($root.spmd_testbench.print_stat_tag)
+      ,.trace_en_i($root.spmd_testbench.trace_en)
     );
 
   end

--- a/testbenches/common/v/vcache_profiler.v
+++ b/testbenches/common/v/vcache_profiler.v
@@ -217,18 +217,18 @@ module vcache_profiler
       $fwrite(log_fd, "time,vcache,global_ctr,tag,");
       $fwrite(log_fd, "instr_ld,instr_ld_ld,instr_ld_ldu,instr_ld_lw,instr_ld_lwu,");
       $fwrite(log_fd, "instr_ld_lh,instr_ld_lhu,instr_ld_lb,instr_ld_lbu,");
-      $fwrite(log_fd, "instr_st,instr_st_sd,instr_st_sw,instr_st_sh,instr_st_sb");
-      $fwrite(log_fd, "instr_mask,instr_sigext,instr_tagst,instr_tagfl,instr_taglv,");
+      $fwrite(log_fd, "instr_st,instr_st_sd,instr_st_sw,instr_st_sh,instr_st_sb,");
+      $fwrite(log_fd, "instr_mask,instr_sigext,instr_tagst,instr_tagfl,instr_taglv,instr_tagla");
       $fwrite(log_fd, "instr_afl,instr_aflinv,instr_ainv,instr_alock,instr_aunlock,");
       $fwrite(log_fd, "instr_tag_read,instr_atomic,instr_amoswap,instr_amoor,");
       $fwrite(log_fd, "miss_ld,miss_st,stall_miss,stall_idle,dma_read_req,dma_write_req\n");
       $fclose(log_fd);
 
-      if (trace_en_i) begin
+      //if (trace_en_i) begin
         trace_fd = $fopen(tracefile_lp, "w");
         $fwrite(trace_fd, "cycle,vcache,operation\n");
         $fclose(trace_fd);
-      end
+      //end
     end
 
 
@@ -294,7 +294,7 @@ module vcache_profiler
             stat_r.miss_count,
             stat_r.idle_count,
             stat_r.dma_read_req,
-            stat_r.dma_write_req,
+            stat_r.dma_write_req
           );
 
           $fclose(log_fd);

--- a/testbenches/common/v/vcache_profiler.v
+++ b/testbenches/common/v/vcache_profiler.v
@@ -46,10 +46,27 @@ module vcache_profiler
   // event signals
   //
 
-  wire inc_ld = v_o & yumi_i & decode_v_r.ld_op;
-  wire inc_st = v_o & yumi_i & decode_v_r.st_op;
-  wire inc_ld_miss = v_o & yumi_i & decode_v_r.ld_op & miss_v;
-  wire inc_st_miss = v_o & yumi_i & decode_v_r.st_op & miss_v;
+  wire inc_ld       = v_o & yumi_i & decode_v_r.ld_op;
+  wire inc_st       = v_o & yumi_i & decode_v_r.st_op;
+  wire inc_mask     = v_o & yumi_i & decode_v_r.mask_op;
+  wire inc_sigext   = v_o & yumi_i & decode_v_r.sigext_op;
+  wire inc_tagst    = v_o & yumi_i & decode_v_r.tagst_op;
+  wire inc_tagfl    = v_o & yumi_i & decode_v_r.tagfl_op;
+  wire inc_taglv    = v_o & yumi_i & decode_v_r.taglv_op;
+  wire inc_tagla    = v_o & yumi_i & decode_v_r.tagla_op;
+  wire inc_afl      = v_o & yumi_i & decode_v_r.afl_op;
+  wire inc_aflinv   = v_o & yumi_i & decode_v_r.aflinv_op;
+  wire inc_ainv     = v_o & yumi_i & decode_v_r.ainv_op;
+  wire inc_alock    = v_o & yumi_i & decode_v_r.alock_op;
+  wire inc_aunlock  = v_o & yumi_i & decode_v_r.aunlock_op;
+  wire inc_tag_read = v_o & yumi_i & decode_v_r.tag_read_op;
+  wire inc_atomic   = v_o & yumi_i & decode_v_r.atomic_op;
+  wire inc_amoswap  = v_o & yumi_i & decode_v_r.amoswap_op;
+  wire inc_amoor    = v_o & yumi_i & decode_v_r.amoor_op;
+
+  wire inc_ld_miss  = v_o & yumi_i & decode_v_r.ld_op & miss_v;
+  wire inc_st_miss  = v_o & yumi_i & decode_v_r.st_op & miss_v;
+
   wire inc_dma_read_req = dma_pkt_v_o & dma_pkt_yumi_i & ~dma_pkt.write_not_read;
   wire inc_dma_write_req = dma_pkt_v_o & dma_pkt_yumi_i & dma_pkt.write_not_read;
 
@@ -59,8 +76,25 @@ module vcache_profiler
   typedef struct packed {
     integer ld_count;
     integer st_count;
+    integer mask_count; 
+    integer sigext_count; 
+    integer tagst_count;   
+    integer tagfl_count;   
+    integer taglv_count;   
+    integer tagla_count;   
+    integer afl_count;     
+    integer aflinv_count;  
+    integer ainv_count;    
+    integer alock_count;   
+    integer aunlock_count; 
+    integer tag_read_count;
+    integer atomic_count;  
+    integer amoswap_count; 
+    integer amoor_count;   
+
     integer ld_miss_count;
     integer st_miss_count;
+
     integer dma_read_req;
     integer dma_write_req;
   } vcache_stat_s;
@@ -73,11 +107,28 @@ module vcache_profiler
       stat_r <= '0;
     end
     else begin
-      if (inc_ld) stat_r.ld_count++;
-      if (inc_st) stat_r.st_count++;
-      if (inc_ld_miss) stat_r.ld_miss_count++;
-      if (inc_st_miss) stat_r.st_miss_count++;
-      if (inc_dma_read_req) stat_r.dma_read_req++;
+      if (inc_ld)            stat_r.ld_count++;
+      if (inc_st)            stat_r.st_count++;
+      if (inc_mask)          stat_r.mask_count++;      
+      if (inc_sigext)        stat_r.sigext_count++; 
+      if (inc_tagst)         stat_r.tagst_count++;   
+      if (inc_tagfl)         stat_r.tagfl_count++;   
+      if (inc_taglv)         stat_r.taglv_count++;   
+      if (inc_tagla)         stat_r.tagla_count++;   
+      if (inc_afl)           stat_r.afl_count++;     
+      if (inc_aflinv)        stat_r.aflinv_count++;  
+      if (inc_ainv)          stat_r.ainv_count++;    
+      if (inc_alock)         stat_r.alock_count++;   
+      if (inc_aunlock)       stat_r.aunlock_count++; 
+      if (inc_tag_read)      stat_r.tag_read_count++;
+      if (inc_atomic)        stat_r.atomic_count++;  
+      if (inc_amoswap)       stat_r.amoswap_count++; 
+      if (inc_amoor)         stat_r.amoor_count++;   
+
+      if (inc_ld_miss)       stat_r.ld_miss_count++;
+      if (inc_st_miss)       stat_r.st_miss_count++;
+
+      if (inc_dma_read_req)  stat_r.dma_read_req++;
       if (inc_dma_write_req) stat_r.dma_write_req++;
     end
 
@@ -97,7 +148,9 @@ module vcache_profiler
     my_name = $sformatf("%m");
     if (str_match(my_name, header_print_p)) begin
       log_fd = $fopen(logfile_lp, "w");
-      $fwrite(log_fd, "instance,global_ctr,tag,ld,st,ld_miss,st_miss,dma_read_req,dma_write_req\n");
+      $fwrite(log_fd, "instance,global_ctr,tag,ld,st,mask,sigext,tagst,tagfl,taglv,");
+      $fwrite(log_fd, "afl,aflinv,ainv,alock,aunlock,tag_read,atomic,amoswap,amoor,");
+      $fwrite(log_fd, "miss_ld,miss_st,dma_read_req,dma_write_req\n");
       $fclose(log_fd);
 
       trace_fd = $fopen(tracefile_lp, "w");
@@ -114,30 +167,100 @@ module vcache_profiler
           $display("[BSG_INFO][VCACHE_PROFILER] %s t=%0t printing stats.", my_name, $time);
 
           log_fd = $fopen(logfile_lp, "a");
-          $fwrite(log_fd, "%s,%0d,%0d,%0d,%0d,%0d,%0d,%0d,%0d\n",
-            my_name, global_ctr_i, print_stat_tag_i,
-            stat_r.ld_count, stat_r.st_count,
-            stat_r.ld_miss_count, stat_r.st_miss_count,
-            stat_r.dma_read_req, stat_r.dma_write_req 
-          );   
+          $fwrite(log_fd, "%s,%0d,%0d,",
+            my_name,
+            global_ctr_i,
+            print_stat_tag_i
+          );
+
+          $fwrite(log_fd, "%0d,%0d,%0d,%0d,%0d,%0d,%0d,%0d,",
+            stat_r.ld_count,
+            stat_r.st_count,
+            stat_r.mask_count,
+            stat_r.sigext_count,
+            stat_r.tagst_count,
+            stat_r.tagfl_count,
+            stat_r.taglv_count,
+            stat_r.tagla_count
+          );
+
+          $fwrite(log_fd, "%0d,%0d,%0d,%0d,%0d,%0d,%0d,%0d,%0d,",
+            stat_r.afl_count,
+            stat_r.aflinv_count,
+            stat_r.ainv_count,
+            stat_r.alock_count,
+            stat_r.aunlock_count,
+            stat_r.tag_read_count,
+            stat_r.atomic_count,
+            stat_r.amoswap_count,
+            stat_r.amoor_count
+          );
+
+          $fwrite(log_fd, "%0d,%0d,%0d,%0d\n",
+            stat_r.ld_miss_count,
+            stat_r.st_miss_count,
+            stat_r.dma_read_req,
+            stat_r.dma_write_req
+          );
+
           $fclose(log_fd);
         end
 
 
+
         if (~reset_i) begin
           trace_fd = $fopen(tracefile_lp, "a");
-          if (miss_v) begin
-            if (inc_ld_miss)
-              print_operation_trace(trace_fd, my_name, "miss_ld");
-            else if (inc_st_miss)
-              print_operation_trace(trace_fd, my_name, "miss_st");
+
+          // If miss handler has finished the dma request and result is ready
+          // for a missed request
+          if (inc_ld_miss)
+            print_operation_trace(trace_fd, my_name, "miss_ld");
+          else if (inc_st_miss)
+            print_operation_trace(trace_fd, my_name, "miss_st");
+
+
+          // If miss handler is still busy on a request
+          else if (miss_v) begin
+            print_operation_trace(trace_fd, my_name, "miss");
           end 
+
         
+          // If response is ready for a hit request
           else begin
             if (inc_ld)
               print_operation_trace(trace_fd, my_name, "ld");
             else if (inc_st)
               print_operation_trace(trace_fd, my_name, "st");
+            else if (inc_mask)
+              print_operation_trace(trace_fd, my_name, "mask");
+            else if (inc_sigext)
+              print_operation_trace(trace_fd, my_name, "sigext");
+            else if (inc_tagst)
+              print_operation_trace(trace_fd, my_name, "tagst");
+            else if (inc_tagfl)
+              print_operation_trace(trace_fd, my_name, "tagfl");
+            else if (inc_taglv)
+              print_operation_trace(trace_fd, my_name, "taglv");
+            else if (inc_tagla)
+              print_operation_trace(trace_fd, my_name, "tagla");
+            else if (inc_afl)
+              print_operation_trace(trace_fd, my_name, "afl");
+            else if (inc_aflinv)
+              print_operation_trace(trace_fd, my_name, "aflinv");
+            else if (inc_ainv)
+              print_operation_trace(trace_fd, my_name, "ainv");
+            else if (inc_alock)
+              print_operation_trace(trace_fd, my_name, "alock");
+            else if (inc_aunlock)
+              print_operation_trace(trace_fd, my_name, "aunlock");
+            else if (inc_tag_read)
+              print_operation_trace(trace_fd, my_name, "tag_read");
+            else if (inc_atomic)
+              print_operation_trace(trace_fd, my_name, "atomic");
+            else if (inc_amoswap)
+              print_operation_trace(trace_fd, my_name, "amoswap");
+            else if (inc_amoor)
+              print_operation_trace(trace_fd, my_name, "amoor");
             else
               print_operation_trace(trace_fd, my_name, "idle");
           end


### PR DESCRIPTION
- Generates blocking vcache trace file as vcache_operation_trace.csv
- Generates vcache stall graph as vcache_stall_abstract/detailed.png
- At the moment abstract and detailed versions are identical, will change in the future
- TODO: need @drichmond 's makefile magic to append test_name and call vcache_stall_graph.py on the generated trace.

node: at the moment, the vcache_operation_trace.csv file is generated inside `.<test_name>/vcache_operation_trace.csv` , and vcache_stall_graph.py should be called manually. 

**merge with PR # 543 on bsg_replicant.**