### PR TITLE
Vanilla bean hash function fix

### DIFF
--- a/software/spmd/bsg_cuda_lite_runtime/eva_range/Makefile
+++ b/software/spmd/bsg_cuda_lite_runtime/eva_range/Makefile
@@ -1,0 +1,34 @@
+#########################################################
+# Network Configutaion
+# If not configured, Will use default Values
+	bsg_global_X ?= $(bsg_tiles_X)
+	bsg_global_Y ?= $(bsg_tiles_Y)+1
+
+#########################################################
+#Tile group configuration
+# If not configured, Will use default Values
+	bsg_tiles_org_X ?= 0
+	bsg_tiles_org_Y ?= 1
+
+# If not configured, Will use default Values
+	bsg_tiles_X ?= 2
+	bsg_tiles_Y ?= 2
+
+
+all: main.run
+
+
+KERNEL_NAME ?=kernel_hammer_cache
+
+OBJECT_FILES=main.o kernel_eva_range.o
+
+include ../../Makefile.include
+
+
+main.riscv: $(OBJECT_FILES) $(SPMD_COMMON_OBJECTS) $(BSG_MANYCORE_LIB) ../../common/crt.o
+	$(RISCV_LINK) $(OBJECT_FILES) $(SPMD_COMMON_OBJECTS) -L. "-l:$(BSG_MANYCORE_LIB)" -o $@ $(RISCV_LINK_OPTS)
+
+
+main.o: Makefile
+
+include ../../../mk/Makefile.tail_rules

--- a/software/spmd/bsg_cuda_lite_runtime/eva_range/kernel_eva_range.cpp
+++ b/software/spmd/bsg_cuda_lite_runtime/eva_range/kernel_eva_range.cpp
@@ -1,0 +1,21 @@
+/////////////////////////////////////////////////////////////////////////
+// This kernel copies a single word from one memory address to another //
+/////////////////////////////////////////////////////////////////////////
+
+#include "bsg_manycore.h"
+#include "bsg_set_tile_x_y.h"
+
+#define bsg_n (bsg_tiles_X * bsg_tiles_Y)
+
+extern "C"
+int kernel_eva_range(
+    // in
+    const unsigned * ptr,
+    // out
+    unsigned * value_read_ptr
+    ) {
+    bsg_print_hexadecimal(reinterpret_cast<unsigned>(ptr));
+    bsg_print_hexadecimal(reinterpret_cast<unsigned>(value_read_ptr));
+    *value_read_ptr = *ptr;
+    return 0;
+}

--- a/software/spmd/bsg_cuda_lite_runtime/eva_range/main.c
+++ b/software/spmd/bsg_cuda_lite_runtime/eva_range/main.c
@@ -1,0 +1,1 @@
+../main/main.c

--- a/v/vanilla_bean/hash_function.v
+++ b/v/vanilla_bean/hash_function.v
@@ -37,9 +37,8 @@ module hash_function
   end
   else if (`BSG_IS_POW2(banks_p)) begin: p2
 
-    assign bank_o = i[0+:lg_banks_lp];
-    assign index_o = i[index_width_lp-1:lg_banks_lp];
-
+    assign bank_o  = i[0+:lg_banks_lp];
+    assign index_o = i[lg_banks_lp+:index_width_lp];
   end
   else begin: unhandled
     initial assert("banks_p" == "unhandled") else $error("unhandled case for %m");


### PR DESCRIPTION
Fixes a bug in EVA => NPA translation for DRAM addresses on designs with power of 2 columns.