### PR TITLE
Extending blood graph timing window options

### DIFF
--- a/software/py/blood_graph.py
+++ b/software/py/blood_graph.py
@@ -29,6 +29,8 @@
 import sys
 import csv
 import argparse
+import warnings
+import os.path
 from PIL import Image, ImageDraw, ImageFont
 from itertools import chain
 
@@ -290,20 +292,23 @@ class BloodGraph:
     def __parse_stats(self, stats_file):
         stats = []
         if(stats_file):
-            with open(stats_file) as f:
-                csv_reader = csv.DictReader(f, delimiter=",")
-                for row in csv_reader:
-                    stat = {}
-                    stat["global_ctr"] = int(row["global_ctr"])
-                    stat["time"] = int(row["time"])
-                    stats.append(stat)
+            if (os.path.isfile(stats_file)):
+                with open(stats_file) as f:
+                    csv_reader = csv.DictReader(f, delimiter=",")
+                    for row in csv_reader:
+                        stat = {}
+                        stat["global_ctr"] = int(row["global_ctr"])
+                        stat["time"] = int(row["time"])
+                        stats.append(stat)
+            else:
+                warnings.warn("Stats file not found, overriding blood graph's start/end cycle with traces.")
         return stats
 
 
     # look through the input file to get the tile group dimension (x,y)
     def __get_tile_group_dim(self, traces):
-        xs = list(map(lambda t: t["x"], traces))
-        ys = list(map(lambda t: t["y"], traces))
+        xs = [t["x"] for t in traces]
+        ys = [t["y"] for t in traces]
         self.xmin = min(xs)
         self.xmax = max(xs)
         self.ymin = min(ys)

--- a/software/py/blood_graph.py
+++ b/software/py/blood_graph.py
@@ -37,265 +37,245 @@ class BloodGraph:
     # for generating the key
     _KEY_WIDTH  = 512
     _KEY_HEIGHT = 512
-    _DEFAULT_START_CYCLE = 50000 
-    _DEFAULT_END_CYCLE   = 250000
+
+
+    # List of types of stalls incurred by the core 
+    _STALLS_LIST   = ["stall_depend_remote_load_dram",
+                      "stall_depend_local_remote_load_dram",
+                      "stall_depend_remote_load_global",
+                      "stall_depend_remote_load_group",
+                      "stall_depend_local_remote_load_global",
+                      "stall_depend_local_remote_load_group",
+                      "stall_lr_aq",
+                      "stall_depend",
+                      "stall_depend_local_load",
+                      "stall_fp_local_load",
+                      "stall_fp_remote_load",
+                      "stall_force_wb",
+                      "stall_icache_store",
+                      "stall_remote_req",
+                      "stall_local_flw",
+                      "stall_amo_aq",
+                      "stall_amo_rl",
+                      "icache_miss",
+                      "stall_ifetch_wait",
+                      "bubble_icache",
+                      "bubble_branch_mispredict",
+                      "bubble_jalr_mispredict",
+                      "bubble_fp_op",
+                      "bubble",
+                      "stall_md" ]
+
+
+
+    # List of types of integer instructions executed by the core 
+    _INSTRS_LIST    = ["local_ld",
+                       "local_st",
+                       "remote_ld_dram",
+                       "remote_ld_global",
+                       "remote_ld_group",
+                       "remote_st_dram",
+                       "remote_st_global",
+                       "remote_st_group",
+                       "local_flw",
+                       "local_fsw",
+                       "remote_flw",
+                       "remote_fsw",
+                       # icache_miss is no longer treated as an instruction
+                       # but treated the same as stall_ifetch_wait
+                       #"icache_miss",
+                       "lr",
+                       "lr_aq",
+                       "swap_aq",
+                       "swap_rl",
+                       "beq",
+                       "bne",
+                       "blt",
+                       "bge",
+                       "bltu",
+                       "bgeu",
+                       "jalr",
+                       "jal",
+                       "beq_miss",
+                       "bne_miss",
+                       "blt_miss",
+                       "bge_miss",
+                       "bltu_miss",
+                       "bgeu_miss",
+                       "jalr_miss",
+                       "sll",
+                       "slli",
+                       "srl",
+                       "srli",
+                       "sra",
+                       "srai",
+                       "add",
+                       "addi",
+                       "sub",
+                       "lui",
+                       "auipc",
+                       "xor",
+                       "xori",
+                       "or",
+                       "ori",
+                       "and",
+                       "andi",
+                       "slt",
+                       "slti",
+                       "sltu",
+                       "sltiu",
+                       "mul",
+                       "mulh",
+                       "mulhsu",
+                       "mulhu",
+                       "div",
+                       "divu",
+                       "rem",
+                       "remu",
+                       "fence",
+                       "amoswap",
+                       "amoor",
+                       "unknown" ]
+
+    # List of types of floating point instructions executed by the core
+    _FP_INSTRS_LIST = ["fadd",
+                      "fsub",
+                      "fmul",
+                      "fsgnj",
+                      "fsgnjn",
+                      "fsgnjx",
+                      "fmin",
+                      "fmax",
+                      "fcvt_s_w",
+                      "fcvt_s_wu",
+                      "fmv_w_x",
+                      "feq",
+                      "flt",
+                      "fle",
+                      "fcvt_w_s",
+                      "fcvt_wu_s",
+                      "fclass",
+                      "fmv_x_w" ]
+
+
+    # Coloring scheme for different types of operations
+    # For detailed mode 
+    # i_cache miss is treated the same is stall_ifetch_wait
+    _DETAILED_STALL_BUBBLE_COLOR = {
+                                     "stall_depend_remote_load_dram"          : (0xff, 0x00, 0x00), ## red 
+                                     "stall_depend_local_remote_load_dram"    : (0xaa, 0x00, 0x00), ## dark red 
+ 
+                                     "stall_depend_remote_load_global"        : (0x00, 0xff, 0x00), ## green 
+                                     "stall_depend_remote_load_group"         : (0x00, 0xff, 0x00), ## green 
+                                     "stall_depend_local_remote_load_global"  : (0x00, 0x55, 0x00), ## dark green 
+                                     "stall_depend_local_remote_load_group"   : (0x00, 0x55, 0x00), ## dark green 
+ 
+                                     "stall_lr_aq"                            : (0x40, 0x40, 0x40), ## dark gray 
+ 
+                                     "stall_depend"                           : (0x00, 0x00, 0x80), ## navy blue 
+                                     "stall_depend_local_load"                : (0x00, 0xff, 0xff), ## cyan 
+ 
+                                     "stall_fp_local_load"                    : (0x00, 0xaa, 0xff), ## dark cyan
+                                     "stall_fp_remote_load"                   : (0x00, 0xaa, 0xff), ## dark cyan
+ 
+                                     "stall_force_wb"                         : (0xff, 0x00, 0xff), ## pink
+                                     "stall_icache_store"                     : (0x00, 0x55, 0xff), ## dark blue
+                                     "stall_remote_req"                       : (0xff, 0xff, 0x00), ## yellow
+                                     "stall_local_flw"                        : (0xff, 0xff, 0x80), ## light yellow
+                                     "stall_amo_aq"                           : (0x8b, 0x45, 0x13), ## brown
+                                     "stall_amo_rl"                           : (0x8b, 0x45, 0x13), ## brown
+ 
+                                     "icache_miss"                            : (0x00, 0x00, 0xff), ## blue
+                                     "stall_ifetch_wait"                      : (0x00, 0x00, 0xff), ## blue
+                                     "bubble_icache"                          : (0x00, 0x00, 0xff), ## blue
+ 
+                                     "bubble_branch_mispredict"               : (0x80, 0x00, 0x80), ## purple
+                                     "bubble_jalr_mispredict"                 : (0xff, 0xa5, 0x00), ## orange
+                                     "bubble_fp_op"                           : (0x00, 0x00, 0x00), ## black
+                                     "bubble"                                 : (0x80, 0x00, 0x00), ## maroon
+ 
+                                     "stall_md"                               : (0xff, 0xf0, 0xa0), ## light orange
+                                  }
+    _DETAILED_UNIFIED_INSTR_COLOR        =                                      (0xff, 0xff, 0xff)  ## white
+    _DETAILED_UNIFIED_FP_INSTR_COLOR     =                                      (0xff, 0xaa, 0xff)  ## light pink
+
+
+    # Coloring scheme for different types of operations
+    # For abstract mode 
+    # i_cache miss is treated the same is stall_ifetch_wait
+    _ABSTRACT_STALL_BUBBLE_COLOR = {   
+                                         "stall_depend_remote_load_dram"          : (0xff, 0x00, 0x00), ## red
+                                         "stall_depend_local_remote_load_dram"    : (0xff, 0x00, 0x00), ## red
+      
+                                         "stall_depend_remote_load_global"        : (0x00, 0xff, 0x00), ## green
+                                         "stall_depend_remote_load_group"         : (0x00, 0xff, 0x00), ## green
+                                         "stall_depend_local_remote_load_global"  : (0x00, 0xff, 0x00), ## green
+                                         "stall_depend_local_remote_load_group"   : (0x00, 0xff, 0x00), ## green
+      
+                                         "stall_lr_aq"                            : (0x40, 0x40, 0x40), ## dark gray
+      
+                                         "stall_depend"                           : (0x00, 0x00, 0x00), ## black
+                                         "stall_depend_local_load"                : (0x00, 0x00, 0x00), ## black
+                                         "stall_fp_local_load"                    : (0x00, 0x00, 0x00), ## black
+                                         "stall_fp_remote_load"                   : (0x00, 0x00, 0x00), ## black
+                                         "stall_force_wb"                         : (0x00, 0x00, 0x00), ## black
+                                         "stall_icache_store"                     : (0x00, 0x00, 0x00), ## black
+                                         "stall_remote_req"                       : (0x00, 0x00, 0x00), ## black
+                                         "stall_local_flw"                        : (0x00, 0x00, 0x00), ## black
+                                         "stall_amo_aq"                           : (0x00, 0x00, 0x00), ## black
+                                         "stall_amo_rl"                           : (0x00, 0x00, 0x00), ## black
+      
+                                         "icache_miss"                            : (0x00, 0x00, 0xff), ## blue
+                                         "stall_ifetch_wait"                      : (0x00, 0x00, 0xff), ## blue
+                                         "bubble_icache"                          : (0x00, 0x00, 0xff), ## blue
+      
+                                         "bubble_branch_mispredict"               : (0x00, 0x00, 0x00), ## black
+                                         "bubble_jalr_mispredict"                 : (0x00, 0x00, 0x00), ## black
+                                         "bubble_fp_op"                           : (0x00, 0x00, 0x00), ## black
+                                         "bubble"                                 : (0x00, 0x00, 0x00), ## black
+      
+                                         "stall_md"                               : (0xff, 0xff, 0xff), ## white
+                                   }
+    _ABSTRACT_UNIFIED_INSTR_COLOR        =                                          (0xff, 0xff, 0xff)  ## white
+    _ABSTRACT_UNIFIED_FP_INSTR_COLOR     =                                          (0xff, 0xff, 0xff)  ## white
+
+
 
     # default constructor
-    def __init__(self, timing_stats_file, abstract):
+    def __init__(self, trace_file, stats_file, start_cycle, end_cycle, abstract):
 
-        self.timing_stats_file = timing_stats_file
         self.abstract = abstract
-
-        # List of types of stalls incurred by the core 
-        self.stalls_list   = ["stall_depend_remote_load_dram",
-                              "stall_depend_local_remote_load_dram",
-                              "stall_depend_remote_load_global",
-                              "stall_depend_remote_load_group",
-                              "stall_depend_local_remote_load_global",
-                              "stall_depend_local_remote_load_group",
-                              "stall_lr_aq",
-                              "stall_depend",
-                              "stall_depend_local_load",
-                              "stall_fp_local_load",
-                              "stall_fp_remote_load",
-                              "stall_force_wb",
-                              "stall_icache_store",
-                              "stall_remote_req",
-                              "stall_local_flw",
-                              "stall_amo_aq",
-                              "stall_amo_rl",
-                              "icache_miss",
-                              "stall_ifetch_wait",
-                              "bubble_icache",
-                              "bubble_branch_mispredict",
-                              "bubble_jalr_mispredict",
-                              "bubble_fp_op",
-                              "bubble",
-                              "stall_md" ]
- 
-
-
-        # List of types of integer instructions executed by the core 
-        self.instr_list    = ["local_ld",
-                              "local_st",
-                              "remote_ld_dram",
-                              "remote_ld_global",
-                              "remote_ld_group",
-                              "remote_st_dram",
-                              "remote_st_global",
-                              "remote_st_group",
-                              "local_flw",
-                              "local_fsw",
-                              "remote_flw",
-                              "remote_fsw",
-                              # icache_miss is no longer treated as an instruction
-                              # but treated the same as stall_ifetch_wait
-                              #"icache_miss",
-                              "lr",
-                              "lr_aq",
-                              "swap_aq",
-                              "swap_rl",
-                              "beq",
-                              "bne",
-                              "blt",
-                              "bge",
-                              "bltu",
-                              "bgeu",
-                              "jalr",
-                              "jal",
-                              "beq_miss",
-                              "bne_miss",
-                              "blt_miss",
-                              "bge_miss",
-                              "bltu_miss",
-                              "bgeu_miss",
-                              "jalr_miss",
-                              "sll",
-                              "slli",
-                              "srl",
-                              "srli",
-                              "sra",
-                              "srai",
-                              "add",
-                              "addi",
-                              "sub",
-                              "lui",
-                              "auipc",
-                              "xor",
-                              "xori",
-                              "or",
-                              "ori",
-                              "and",
-                              "andi",
-                              "slt",
-                              "slti",
-                              "sltu",
-                              "sltiu",
-                              "mul",
-                              "mulh",
-                              "mulhsu",
-                              "mulhu",
-                              "div",
-                              "divu",
-                              "rem",
-                              "remu",
-                              "fence",
-                              "amoswap",
-                              "amoor",
-                              "unknown" ]
-
-        # List of types of floating point instructions executed by the core
-        self.fp_instr_list = ["fadd",
-                              "fsub",
-                              "fmul",
-                              "fsgnj",
-                              "fsgnjn",
-                              "fsgnjx",
-                              "fmin",
-                              "fmax",
-                              "fcvt_s_w",
-                              "fcvt_s_wu",
-                              "fmv_w_x",
-                              "feq",
-                              "flt",
-                              "fle",
-                              "fcvt_w_s",
-                              "fcvt_wu_s",
-                              "fclass",
-                              "fmv_x_w" ]
-
-
-        # Coloring scheme for different types of operations
-        # For detailed mode 
-        # i_cache miss is treated the same is stall_ifetch_wait
-        self.detailed_stall_bubble_color = {
-                                             "stall_depend_remote_load_dram"          : (0xff, 0x00, 0x00), ## red 
-                                             "stall_depend_local_remote_load_dram"    : (0xaa, 0x00, 0x00), ## dark red 
-
-                                             "stall_depend_remote_load_global"        : (0x00, 0xff, 0x00), ## green 
-                                             "stall_depend_remote_load_group"         : (0x00, 0xff, 0x00), ## green 
-                                             "stall_depend_local_remote_load_global"  : (0x00, 0x55, 0x00), ## dark green 
-                                             "stall_depend_local_remote_load_group"   : (0x00, 0x55, 0x00), ## dark green 
- 
-                                             "stall_lr_aq"                            : (0x40, 0x40, 0x40), ## dark gray 
-
-                                             "stall_depend"                           : (0x00, 0x00, 0x80), ## navy blue 
-                                             "stall_depend_local_load"                : (0x00, 0xff, 0xff), ## cyan 
-
-                                             "stall_fp_local_load"                    : (0x00, 0xaa, 0xff), ## dark cyan
-                                             "stall_fp_remote_load"                   : (0x00, 0xaa, 0xff), ## dark cyan
-
-                                             "stall_force_wb"                         : (0xff, 0x00, 0xff), ## pink
-                                             "stall_icache_store"                     : (0x00, 0x55, 0xff), ## dark blue
-                                             "stall_remote_req"                       : (0xff, 0xff, 0x00), ## yellow
-                                             "stall_local_flw"                        : (0xff, 0xff, 0x80), ## light yellow
-                                             "stall_amo_aq"                           : (0x8b, 0x45, 0x13), ## brown
-                                             "stall_amo_rl"                           : (0x8b, 0x45, 0x13), ## brown
-
-                                             "icache_miss"                            : (0x00, 0x00, 0xff), ## blue
-                                             "stall_ifetch_wait"                      : (0x00, 0x00, 0xff), ## blue
-                                             "bubble_icache"                          : (0x00, 0x00, 0xff), ## blue
-
-                                             "bubble_branch_mispredict"               : (0x80, 0x00, 0x80), ## purple
-                                             "bubble_jalr_mispredict"                 : (0xff, 0xa5, 0x00), ## orange
-                                             "bubble_fp_op"                           : (0x00, 0x00, 0x00), ## black
-                                             "bubble"                                 : (0x80, 0x00, 0x00), ## maroon
-
-                                             "stall_md"                               : (0xff, 0xf0, 0xa0), ## light orange
-                                           }
-        self.detailed_unified_instr_color    =                                          (0xff, 0xff, 0xff)  ## white
-        self.detailed_unified_fp_instr_color =                                          (0xff, 0xaa, 0xff)  ## light pink
-
-
-        # Coloring scheme for different types of operations
-        # For abstract mode 
-        # i_cache miss is treated the same is stall_ifetch_wait
-        self.abstract_stall_bubble_color = { 
-                                             "stall_depend_remote_load_dram"          : (0xff, 0x00, 0x00), ## red
-                                             "stall_depend_local_remote_load_dram"    : (0xff, 0x00, 0x00), ## red
-
-                                             "stall_depend_remote_load_global"        : (0x00, 0xff, 0x00), ## green
-                                             "stall_depend_remote_load_group"         : (0x00, 0xff, 0x00), ## green
-                                             "stall_depend_local_remote_load_global"  : (0x00, 0xff, 0x00), ## green
-                                             "stall_depend_local_remote_load_group"   : (0x00, 0xff, 0x00), ## green
-
-                                             "stall_lr_aq"                            : (0x40, 0x40, 0x40), ## dark gray
-
-                                             "stall_depend"                           : (0x00, 0x00, 0x00), ## black
-                                             "stall_depend_local_load"                : (0x00, 0x00, 0x00), ## black
-                                             "stall_fp_local_load"                    : (0x00, 0x00, 0x00), ## black
-                                             "stall_fp_remote_load"                   : (0x00, 0x00, 0x00), ## black
-                                             "stall_force_wb"                         : (0x00, 0x00, 0x00), ## black
-                                             "stall_icache_store"                     : (0x00, 0x00, 0x00), ## black
-                                             "stall_remote_req"                       : (0x00, 0x00, 0x00), ## black
-                                             "stall_local_flw"                        : (0x00, 0x00, 0x00), ## black
-                                             "stall_amo_aq"                           : (0x00, 0x00, 0x00), ## black
-                                             "stall_amo_rl"                           : (0x00, 0x00, 0x00), ## black
-
-                                             "icache_miss"                            : (0x00, 0x00, 0xff), ## blue
-                                             "stall_ifetch_wait"                      : (0x00, 0x00, 0xff), ## blue
-                                             "bubble_icache"                          : (0x00, 0x00, 0xff), ## blue
-
-                                             "bubble_branch_mispredict"               : (0x00, 0x00, 0x00), ## black
-                                             "bubble_jalr_mispredict"                 : (0x00, 0x00, 0x00), ## black
-                                             "bubble_fp_op"                           : (0x00, 0x00, 0x00), ## black
-                                             "bubble"                                 : (0x00, 0x00, 0x00), ## black
-
-                                             "stall_md"                               : (0xff, 0xff, 0xff), ## white
-                                           }
-        self.abstract_unified_instr_color    =                                          (0xff, 0xff, 0xff)  ## white
-        self.abstract_unified_fp_instr_color =                                          (0xff, 0xff, 0xff)  ## white
-
-
 
         # Determine coloring rules based on mode {abstract / detailed}
         if (self.abstract):
-            self.stall_bubble_color     = self.abstract_stall_bubble_color
-            self.unified_instr_color    = self.abstract_unified_instr_color
-            self.unified_fp_instr_color = self.abstract_unified_instr_color
+            self.stall_bubble_color     = self._ABSTRACT_STALL_BUBBLE_COLOR
+            self.unified_instr_color    = self._ABSTRACT_UNIFIED_INSTR_COLOR
+            self.unified_fp_instr_color = self._ABSTRACT_UNIFIED_INSTR_COLOR
         else:
-            self.stall_bubble_color     = self.detailed_stall_bubble_color
-            self.unified_instr_color    = self.detailed_unified_instr_color
-            self.unified_fp_instr_color = self.detailed_unified_instr_color
+            self.stall_bubble_color     = self._DETAILED_STALL_BUBBLE_COLOR
+            self.unified_instr_color    = self._DETAILED_UNIFIED_INSTR_COLOR
+            self.unified_fp_instr_color = self._DETAILED_UNIFIED_INSTR_COLOR
 
 
-        # Parse timing stat file vanilla_stats.csv
-        # to gather start and end cycle of entire graph
-        self.timing_stats = []
-        try:
-            with open(self.timing_stats_file) as f:
-                csv_reader = csv.DictReader(f, delimiter=",")
-                for row in csv_reader:
-                    timing_stat = {}
-                    timing_stat["global_ctr"] = int(row["global_ctr"])
-                    timing_stat["time"] = int(row["time"])
-                    self.timing_stats.append(timing_stat)
+        # Parse vanilla operation trace file to generate traces
+        self.traces = self.__parse_traces(trace_file)
 
-            # If there are at least two stats recovered from vanilla_stats.csv for start and end cycle
-            if (len(self.timing_stats) >= 2):
-                self.start_cycle = self.timing_stats[0]["global_ctr"]
-                self.end_cycle = self.timing_stats[-1]["global_ctr"]
-            else:
-                self.start_cycle = self._DEFAULT_START_CYCLE
-                self.end_cycle = self._DEFAULT_END_CYCLE
-            return
+        # Parse vanilla stats file to generate timing stats 
+        self.stats = self.__parse_stats(stats_file)
+       
+        # get tile group diemsnions
+        self.__get_tile_group_dim(self.traces)
 
-        # If the vanilla_stats.csv file has not been given as input
-        # Use the default values for start and end cycles
-        except IOError as e:
-            self.start_cycle = self._DEFAULT_START_CYCLE
-            self.end_cycle = self._DEFAULT_END_CYCLE
-
-        return
+        # get the timing window (start and end cycle) for blood graph
+        self.start_cycle, self.end_cycle = self.__get_timing_window(self.traces, self.stats, start_cycle, end_cycle)
+        print(self.start_cycle)
+        print(self.end_cycle)
 
 
-
-  
-    # main public method
-    def generate(self, input_file):
-        # parse vanilla_operation_trace.csv
+    # parses vanilla_operation_trace.csv to generate operation traces
+    def __parse_traces(self, trace_file):
         traces = []
-        with open(input_file) as f:
+        with open(trace_file) as f:
             csv_reader = csv.DictReader(f, delimiter=",")
             for row in csv_reader:
                 trace = {}
@@ -304,15 +284,71 @@ class BloodGraph:
                 trace["operation"] = row["operation"]
                 trace["cycle"] = int(row["cycle"])
                 traces.append(trace)
+        return traces
+
+
+    # Parses vanilla_stats.csv to generate timing stats 
+    # to gather start and end cycle of entire graph
+    def __parse_stats(self, stats_file):
+        stats = []
+        if(stats_file):
+            with open(stats_file) as f:
+                csv_reader = csv.DictReader(f, delimiter=",")
+                for row in csv_reader:
+                    stat = {}
+                    stat["global_ctr"] = int(row["global_ctr"])
+                    stat["time"] = int(row["time"])
+                    stats.append(stat)
+        return stats
+
+
+    # look through the input file to get the tile group dimension (x,y)
+    def __get_tile_group_dim(self, traces):
+        xs = list(map(lambda t: t["x"], traces))
+        ys = list(map(lambda t: t["y"], traces))
+        self.xmin = min(xs)
+        self.xmax = max(xs)
+        self.ymin = min(ys)
+        self.ymax = max(ys)
+    
+        self.xdim = self.xmax-self.xmin+1
+        self.ydim = self.ymax-self.ymin+1
+        return
+
+
+    # Determine the timing window (start and end) cycle of graph 
+    def __get_timing_window(self, traces, stats, start_cycle, end_cycle):
+        start = 0
+        end = 0
+        # If custom cycles are given by using the --cycle argument
+        if (False):
+            start = start_cycle
+            end = end_cycle
+        # Else if timing stats are given as optional input argument
+        elif (stats):
+            start = stats[0]["global_ctr"]
+            end = stats[-1]["global_ctr"]
+        # Otherwise use the first and last trace 
+        # i.e. draw the graph for the entire course of simulation
+        else:
+            start = traces[0]["cycle"]
+            end = traces[-1]["cycle"]
+
+        return start, end
+
+
+
+
   
-        # get tile-group dim
-        self.__get_tg_dim(traces)
+    # main public method
+    def generate(self):
+  
 
         # init image
         self.__init_image()
 
         # create image
-        for trace in traces:
+        for trace in self.traces:
             self.__mark_trace(trace)
 
         #self.img.show()
@@ -329,7 +365,7 @@ class BloodGraph:
         # the current row position of our key
         yt = 0
         # for each color in stalls...
-        for (operation,color) in chain([(stall_bubble, self.stall_bubble_color[stall_bubble]) for stall_bubble in self.stalls_list],
+        for (operation,color) in chain([(stall_bubble, self.stall_bubble_color[stall_bubble]) for stall_bubble in self._STALLS_LIST],
                                  [("unified_instr"    ,self.unified_instr_color),
                                   ("unified_fp_instr" ,self.unified_fp_instr_color)]):
 
@@ -349,19 +385,6 @@ class BloodGraph:
         # save the key
         mode = "abstract" if self.abstract else "detailed"
         img.save("{}.png".format(key_image_fname + "_" + mode))
-        return
-
-    # look through the input file to get the tile group dimension (x,y)
-    def __get_tg_dim(self, traces):
-        xs = list(map(lambda t: t["x"], traces))
-        ys = list(map(lambda t: t["y"], traces))
-        self.xmin = min(xs)
-        self.xmax = max(xs)
-        self.ymin = min(ys)
-        self.ymax = max(ys)
-    
-        self.xdim = self.xmax-self.xmin+1
-        self.ydim = self.ymax-self.ymin+1
         return
 
 
@@ -392,9 +415,9 @@ class BloodGraph:
         # determine color
         if trace["operation"] in self.stall_bubble_color.keys():
             self.pixel[col,row] = self.stall_bubble_color[trace["operation"]]
-        elif trace["operation"] in self.instr_list:
+        elif trace["operation"] in self._INSTRS_LIST:
             self.pixel[col,row] = self.unified_instr_color
-        elif trace["operation"] in self.fp_instr_list:
+        elif trace["operation"] in self._FP_INSTRS_LIST:
             self.pixel[col,row] = self.unified_fp_instr_color
         else:
             raise Exception('Invalid operation in vanilla operation trace log {}'.format(trace["operation"]))
@@ -411,13 +434,13 @@ class CycleAction(argparse.Action):
 
         # Check if start cycle is given as input
         if(not start_str):
-            start_cycle = BloodGraph._DEFAULT_START_CYCLE
+            start_cycle = -1
         else:
             start_cycle = int(start_str)
 
         # Check if end cycle is given as input
         if(not end_str):
-            end_cycle = BloodGraph._DEFAULT_END_CYCLE
+            end_cycle = -1
         else:
             end_cycle = int(end_str)
 
@@ -433,10 +456,10 @@ def parse_args():
     parser = argparse.ArgumentParser(description="Argument parser for blood_graph.py")
     parser.add_argument("--input", default="vanilla_operation_trace.csv", type=str,
                         help="Vanilla operation log file")
-    parser.add_argument("--timing-stats", default="vanilla_stats.csv", type=str,
+    parser.add_argument("--timing-stats", default=None, type=str,
                         help="Vanilla stats log file")
     parser.add_argument("--cycle", nargs='?', required=0, action=CycleAction, 
-                        const = (str(BloodGraph._DEFAULT_START_CYCLE)+"@"+str(BloodGraph._DEFAULT_END_CYCLE)),
+                        const = "-1@-1",
                         help="Cycle window of bloodgraph as start_cycle@end_cycle.")
     parser.add_argument("--abstract", default=False, action='store_true',
                         help="Type of bloodgraph - abstract / detailed")
@@ -453,9 +476,9 @@ def parse_args():
 if __name__ == "__main__":
     args = parse_args()
   
-    bg = BloodGraph(args.timing_stats, args.abstract)
+    bg = BloodGraph(args.input, args.timing_stats, args.start, args.end, args.abstract)
     if not args.no_blood_graph:
-        bg.generate(args.input)
+        bg.generate()
     if args.generate_key:
         bg.generate_key()
 


### PR DESCRIPTION
Addresses issue #281 .
Adds three options for choosing the timing window of blood graphs:
1. --trace: default, use the first and last trace from the trace file as start and end cycle
2. --stats: if the stats file is given as input, use the first kernel_start and last kernel_end stat --> if given as input, it overrides option 1 and narrows the bloodgraph to the window in which the tiles are actually running the kernel
3. --cycle: custom start/end cycles given by the user which overrides the other two 

Minor restructuring of functions and variables as well.

**Merge with PR # 29 in baseline**

