### PR TITLE
Fix multi-driven (?) net issue

### DIFF
--- a/v/bsg_manycore.v
+++ b/v/bsg_manycore.v
@@ -100,17 +100,20 @@ module bsg_manycore
   // Pipeline the reset. The bsg_manycore_tile has a single pipeline register
   // on reset already, so we only want to pipeline reset_depth_p-1 times.
   logic [reset_depth_p-1:0][num_tiles_y_p-1:0][num_tiles_x_p-1:0] reset_i_r;
+  logic [num_tiles_y_p-1:0][num_tiles_x_p-1:0]                    reset_i_lo;
+   
+  assign reset_i_lo = {(num_tiles_y_p*num_tiles_x_p){reset_i}};
 
-  assign reset_i_r[0] = {(num_tiles_y_p*num_tiles_x_p){reset_i}};
-
+   always_ff @(posedge clk_i) begin
+      reset_i_r[0] <= reset_i_lo;
+   end
   genvar k;
-  for (k = 1; k < reset_depth_p; k++)
+  for (k = 1; k < reset_depth_p - 1; k++)
     begin
-      always_ff @(posedge clk_i)
-        begin
+       always_ff @(posedge clk_i) begin
           reset_i_r[k] <= reset_i_r[k-1];
-        end
     end
+   end
 
    for (r = 1; r < num_tiles_y_p; r = r+1)
      begin: y

--- a/v/bsg_manycore.v
+++ b/v/bsg_manycore.v
@@ -105,11 +105,11 @@ module bsg_manycore
   assign reset_i_lo = {(num_tiles_y_p*num_tiles_x_p){reset_i}};
 
   genvar k;
-  for (k = 0; k < reset_depth_p; k++)
+  for (k = 1; k < reset_depth_p; k++)
     begin
       always_ff @(posedge clk_i)
         begin
-          reset_i_r[k] <= (k == 0) ? {(num_tiles_y_p*num_tiles_x_p){reset_i}} : reset_i_r[k-1];
+          reset_i_r[k] <= (k == 1) ? {(num_tiles_y_p*num_tiles_x_p){reset_i}} : reset_i_r[k-1];
         end
    end
 

--- a/v/bsg_manycore.v
+++ b/v/bsg_manycore.v
@@ -104,14 +104,13 @@ module bsg_manycore
    
   assign reset_i_lo = {(num_tiles_y_p*num_tiles_x_p){reset_i}};
 
-   always_ff @(posedge clk_i) begin
-      reset_i_r[0] <= reset_i_lo;
-   end
   genvar k;
-  for (k = 1; k < reset_depth_p; k++)
+  for (k = 0; k < reset_depth_p; k++)
     begin
-       always_ff @(posedge clk_i) begin
-          reset_i_r[k] <= reset_i_r[k-1];
+      always_ff @(posedge clk_i)
+        begin
+          reset_i_r[k] <= (k == 0) ? {(num_tiles_y_p*num_tiles_x_p){reset_i}} : reset_i_r[k-1];
+        end
     end
    end
 

--- a/v/bsg_manycore.v
+++ b/v/bsg_manycore.v
@@ -111,7 +111,6 @@ module bsg_manycore
         begin
           reset_i_r[k] <= (k == 0) ? {(num_tiles_y_p*num_tiles_x_p){reset_i}} : reset_i_r[k-1];
         end
-    end
    end
 
    for (r = 1; r < num_tiles_y_p; r = r+1)

--- a/v/bsg_manycore.v
+++ b/v/bsg_manycore.v
@@ -100,9 +100,6 @@ module bsg_manycore
   // Pipeline the reset. The bsg_manycore_tile has a single pipeline register
   // on reset already, so we only want to pipeline reset_depth_p-1 times.
   logic [reset_depth_p-1:0][num_tiles_y_p-1:0][num_tiles_x_p-1:0] reset_i_r;
-  logic [num_tiles_y_p-1:0][num_tiles_x_p-1:0]                    reset_i_lo;
-   
-  assign reset_i_lo = {(num_tiles_y_p*num_tiles_x_p){reset_i}};
 
   genvar k;
   for (k = 1; k < reset_depth_p; k++)

--- a/v/bsg_manycore.v
+++ b/v/bsg_manycore.v
@@ -108,7 +108,7 @@ module bsg_manycore
       reset_i_r[0] <= reset_i_lo;
    end
   genvar k;
-  for (k = 1; k < reset_depth_p - 1; k++)
+  for (k = 1; k < reset_depth_p; k++)
     begin
        always_ff @(posedge clk_i) begin
           reset_i_r[k] <= reset_i_r[k-1];


### PR DESCRIPTION
Fixed a (Verilator-percieved) issue where a net was driven by both blocking and non-blocking assignments