### PR TITLE
Change hetero_type_vec_p to 1-Dimensional Vector

### DIFF
--- a/machines/16x8/Makefile.machine.include
+++ b/machines/16x8/Makefile.machine.include
@@ -19,4 +19,4 @@ BSG_MACHINE_MEM_CFG                   = e_vcache_blocking_dramsim3_hbm2
 
 BSG_MACHINE_BRANCH_TRACE_EN           = 0
 
-BSG_MACHINE_HETERO_TYPE_VEC 				  = default:0
+BSG_MACHINE_HETERO_TYPE_VEC           = default:0

--- a/machines/4x4/Makefile.machine.include
+++ b/machines/4x4/Makefile.machine.include
@@ -15,8 +15,8 @@ BSG_MACHINE_MAX_EPA_WIDTH             = 28
 
 # supported memory cfg
 BSG_MACHINE_MEM_CFG                   = e_vcache_blocking_axi4_nonsynth_mem
-#BSG_MACHINE_MEM_CFG                   = e_vcache_non_blocking_axi4_nonsynth_mem
+#BSG_MACHINE_MEM_CFG                  = e_vcache_non_blocking_axi4_nonsynth_mem
 
 BSG_MACHINE_BRANCH_TRACE_EN           = 0
 
-BSG_MACHINE_HETERO_TYPE_VEC 				  = default:0
+BSG_MACHINE_HETERO_TYPE_VEC           = default:0

--- a/machines/4x4_dmc/Makefile.machine.include
+++ b/machines/4x4_dmc/Makefile.machine.include
@@ -20,4 +20,4 @@ BSG_MACHINE_MEM_CFG                   = e_vcache_blocking_dmc_lpddr
 
 BSG_MACHINE_BRANCH_TRACE_EN           = 0
 
-BSG_MACHINE_HETERO_TYPE_VEC 				  = default:0
+BSG_MACHINE_HETERO_TYPE_VEC           = default:0

--- a/machines/4x4_gs/Makefile.machine.include
+++ b/machines/4x4_gs/Makefile.machine.include
@@ -22,7 +22,7 @@ BSG_MACHINE_MEM_CFG                   = e_vcache_blocking_axi4_nonsynth_mem
 BSG_MACHINE_BRANCH_TRACE_EN           = 0
 
 # it has a gather-scatterer at the bottom-right corner.
-BSG_MACHINE_HETERO_TYPE_VEC 				  = {0,0,0,0},\
-																				{0,0,0,0},\
-																				{0,0,0,0},\
-																				{0,0,0,1}
+BSG_MACHINE_HETERO_TYPE_VEC           = {0,0,0,0,\
+                                         0,0,0,0,\
+                                         0,0,0,0,\
+                                         0,0,0,1}

--- a/machines/4x4_gs/Makefile.machine.include
+++ b/machines/4x4_gs/Makefile.machine.include
@@ -22,7 +22,7 @@ BSG_MACHINE_MEM_CFG                   = e_vcache_blocking_axi4_nonsynth_mem
 BSG_MACHINE_BRANCH_TRACE_EN           = 0
 
 # it has a gather-scatterer at the bottom-right corner.
-BSG_MACHINE_HETERO_TYPE_VEC           = {0,0,0,0,\
-                                         0,0,0,0,\
-                                         0,0,0,0,\
-                                         0,0,0,1}
+BSG_MACHINE_HETERO_TYPE_VEC           = 0,0,0,0,\
+                                        0,0,0,0,\
+                                        0,0,0,0,\
+                                        0,0,0,1

--- a/testbenches/common/v/spmd_testbench.v
+++ b/testbenches/common/v/spmd_testbench.v
@@ -22,7 +22,7 @@ module spmd_testbench;
   parameter bsg_manycore_mem_cfg_e bsg_manycore_mem_cfg_p = `BSG_MACHINE_MEM_CFG;
   parameter bsg_branch_trace_en_p = `BSG_MACHINE_BRANCH_TRACE_EN;
   parameter vcache_miss_fifo_els_p = `BSG_MACHINE_VCACHE_MISS_FIFO_ELS;
-  parameter int hetero_type_vec_p [0:num_tiles_y_p-2][0:num_tiles_x_p-1] = '{`BSG_MACHINE_HETERO_TYPE_VEC};
+  parameter integer hetero_type_vec_p [0:((num_tiles_y_p-1)*num_tiles_x_p) - 1]  = '{`BSG_MACHINE_HETERO_TYPE_VEC};
 
   // constant params
   parameter data_width_p = 32;

--- a/testbenches/common/v/spmd_testbench.v
+++ b/testbenches/common/v/spmd_testbench.v
@@ -22,7 +22,7 @@ module spmd_testbench;
   parameter bsg_manycore_mem_cfg_e bsg_manycore_mem_cfg_p = `BSG_MACHINE_MEM_CFG;
   parameter bsg_branch_trace_en_p = `BSG_MACHINE_BRANCH_TRACE_EN;
   parameter vcache_miss_fifo_els_p = `BSG_MACHINE_VCACHE_MISS_FIFO_ELS;
-  parameter integer hetero_type_vec_p [0:((num_tiles_y_p-1)*num_tiles_x_p) - 1]  = '{`BSG_MACHINE_HETERO_TYPE_VEC};
+  parameter int hetero_type_vec_p [0:((num_tiles_y_p-1)*num_tiles_x_p) - 1]  = '{`BSG_MACHINE_HETERO_TYPE_VEC};
 
   // constant params
   parameter data_width_p = 32;

--- a/v/bsg_manycore.v
+++ b/v/bsg_manycore.v
@@ -17,16 +17,16 @@ module bsg_manycore
 
     // change the default values from "inv" back to -1
     // since num_tiles_x_p and num_tiles_y_p will be used to define the size of 2D array
-    // hetero_type_vec_p, they should be integer by default to avoid tool crash during
+    // hetero_type_vec_p, they should be int by default to avoid tool crash during
     // synthesis (DC versions at least up to 2018.06)
     , parameter int num_tiles_x_p = -1
     , parameter int num_tiles_y_p = -1
 
    // This is used to define heterogeneous arrays. Each index defines
    // the type of an X/Y coordinate in the array. This is a vector of
-   // num_tiles_x_p*num_tiles_y_p integers; type "0" is the
+   // num_tiles_x_p*num_tiles_y_p ints; type "0" is the
    // default. See bsg_manycore_hetero_socket.v for more types.
-   , parameter integer hetero_type_vec_p [0:((num_tiles_y_p-1)*num_tiles_x_p) - 1]  = '{default:0}
+   , parameter int hetero_type_vec_p [0:((num_tiles_y_p-1)*num_tiles_x_p) - 1]  = '{default:0}
 
    // this is the addr width on the manycore network packet (word addr).
    // also known as endpoint physical address (EPA).

--- a/v/bsg_manycore.v
+++ b/v/bsg_manycore.v
@@ -69,7 +69,6 @@ module bsg_manycore
     , input [num_tiles_x_p-1:0][link_sif_width_lp-1:0] io_link_sif_i
     , output [num_tiles_x_p-1:0][link_sif_width_lp-1:0] io_link_sif_o
   );
-//'{default:0}
 
    // synopsys translate_off
    initial

--- a/v/bsg_manycore.v
+++ b/v/bsg_manycore.v
@@ -19,13 +19,14 @@ module bsg_manycore
     // since num_tiles_x_p and num_tiles_y_p will be used to define the size of 2D array
     // hetero_type_vec_p, they should be integer by default to avoid tool crash during
     // synthesis (DC versions at least up to 2018.06)
-    , parameter num_tiles_x_p = -1
-    , parameter num_tiles_y_p = -1
+    , parameter int num_tiles_x_p = -1
+    , parameter int num_tiles_y_p = -1
 
-   // for heterogeneous, this is a vector of num_tiles_x_p*num_tiles_y_p bytes;
-   // each byte contains the type of core being instantiated
-   // type 0 is the standard core
-   , parameter int hetero_type_vec_p [0:num_tiles_y_p-2][0:num_tiles_x_p-1]  ='{default:0}
+   // This is used to define heterogeneous arrays. Each index defines
+   // the type of an X/Y coordinate in the array. This is a vector of
+   // num_tiles_x_p*num_tiles_y_p integers; type "0" is the
+   // default. See bsg_manycore_hetero_socket.v for more types.
+   , parameter integer hetero_type_vec_p [0:((num_tiles_y_p-1)*num_tiles_x_p) - 1]  = '{default:0}
 
    // this is the addr width on the manycore network packet (word addr).
    // also known as endpoint physical address (EPA).
@@ -68,6 +69,7 @@ module bsg_manycore
     , input [num_tiles_x_p-1:0][link_sif_width_lp-1:0] io_link_sif_i
     , output [num_tiles_x_p-1:0][link_sif_width_lp-1:0] io_link_sif_o
   );
+//'{default:0}
 
    // synopsys translate_off
    initial
@@ -81,7 +83,7 @@ module bsg_manycore
         for(i=0; i < num_tiles_y_p-1; i++) begin
                 $write("## ");
                 for(j=0; j< num_tiles_x_p; j++) begin
-                        $write("%0d,", hetero_type_vec_p[i][j]);
+                        $write("%0d,", hetero_type_vec_p[i * num_tiles_x_p + j]);
                 end
                 $write("\n");
         end
@@ -124,7 +126,7 @@ module bsg_manycore
                 .y_cord_width_p(y_cord_width_lp),
                 .data_width_p(data_width_p),
                 .addr_width_p(addr_width_p),
-                .hetero_type_p( hetero_type_vec_p[r-1][c] ),
+                .hetero_type_p( hetero_type_vec_p[(r-1) * num_tiles_x_p + c] ),
                 .debug_p(debug_p)
                 ,.branch_trace_en_p(branch_trace_en_p)
                 ,.num_tiles_x_p(num_tiles_x_p)

--- a/v/bsg_manycore_hetero_socket.v
+++ b/v/bsg_manycore_hetero_socket.v
@@ -52,7 +52,7 @@ module bsg_manycore_hetero_socket
     , parameter debug_p = 0
     , parameter branch_trace_en_p = 0
     , parameter max_out_credits_p = 200
-    , parameter hetero_type_p = 0
+    , parameter int hetero_type_p = 0
     , parameter num_tiles_x_p="inv"
     , parameter vcache_block_size_in_words_p="inv"
     , parameter vcache_sets_p="inv"

--- a/v/bsg_manycore_hetero_socket.v
+++ b/v/bsg_manycore_hetero_socket.v
@@ -24,10 +24,10 @@
                           ,.vcache_block_size_in_words_p(vcache_block_size_in_words_p) \
                           ,.vcache_sets_p(vcache_sets_p)                               \
                           ,.debug_p(debug_p)                                           \
-                          ,.branch_trace_en_p(branch_trace_en_p)                                 \
-			                    ,.icache_entries_p(icache_entries_p)                         \
+                          ,.branch_trace_en_p(branch_trace_en_p)                       \
+                          ,.icache_entries_p(icache_entries_p)                         \
                           ,.icache_tag_width_p (icache_tag_width_p)                    \
-            		          ,.max_out_credits_p(max_out_credits_p)                       \
+                          ,.max_out_credits_p(max_out_credits_p)                       \
                           ,.num_tiles_x_p(num_tiles_x_p)                               \
                           ) z                                                          \
           (.clk_i                                                                      \
@@ -46,7 +46,7 @@ module bsg_manycore_hetero_socket
     , parameter data_width_p = "inv"
     , parameter addr_width_p = "inv"
     , parameter dmem_size_p = "inv"
-		, parameter icache_entries_p = "inv" // in words
+    , parameter icache_entries_p = "inv" // in words
     , parameter icache_tag_width_p = "inv"
     , parameter vcache_size_p = "inv"
     , parameter debug_p = 0
@@ -84,7 +84,7 @@ module bsg_manycore_hetero_socket
   `HETERO_TYPE_MACRO(7,bsg_manycore_accel_default) else
   `HETERO_TYPE_MACRO(8,bsg_manycore_accel_default) else
   begin : nh
-	  // synopsys translate_off
+  // synopsys translate_off
     initial begin
       $error("## unidentified hetero core type ",hetero_type_p);
       $finish();


### PR DESCRIPTION
Verilator can't infer constant-ness through 2D vectors passed as parameters ([Issue](https://github.com/verilator/verilator/issues/2272)). 

Therefore, I've switched hetero_type_vec_p to a 1-dimensional vector. 

I updated the Makefile.machine.include files. I also removed tabs, and updated the comment describing the vector.

Is there a way to run regression on all the machines in Manycore? Is there one that tests the scatter gather accelerator?

This is the last major blocking issue to compiling Manycore in Verilator. 