### PR TITLE
General refactoring of Vanilla PC Histogram

### DIFF
--- a/software/py/blood_graph.py
+++ b/software/py/blood_graph.py
@@ -8,20 +8,18 @@
 #   output: blood graph file (blood_abstrat/detailed.png)
 #           blood graph key  (key_abstract/detailed.png)
 #
-#   @author tommy and borna
+#   @author Tommy and Borna
 #
 #   How to use:
-#   python blood_graph.py --input {vanilla_operation_trace.csv}
-#                         --timing-stat {vanilla_stats.csv}
+#   python blood_graph.py --trace {vanilla_operation_trace.csv}
+#                         --stats {vanilla_stats.csv}
+#                         --cycle {start_cycle@end_cycle}
 #                         --abstract {optional}
 #                         --generate-key {optional}
-#                         --cycle {start_cycle@end_cycle} (deprecated)
 #
-#   ex) python blood_graph.py --input vanilla_operation_trace.csv
-#                             --timing-stat vanilla_stats.csv
-#                             --abstract --generate-key
 #
-#   {timing-stat}  used for extracting the timing window for blood graph
+#
+#   {stats}        used for extracting the timing window for blood graph
 #   {abstract}     used for abstract simplifed bloodgraph
 #   {generate-key} also generates a color key for the blood graph
 #
@@ -29,6 +27,7 @@
 #   Note: You can use the "Digital Color Meter" in MacOS in order to compare
 #   the values from the color key to the values in the bloodgraph, if you are
 #   having trouble distinguishing a color.
+
 
 import sys
 import csv

--- a/software/py/vanilla_pc_histogram.py
+++ b/software/py/vanilla_pc_histogram.py
@@ -1,22 +1,18 @@
 #
-#   blood_graph.py
+#   vanilla_pc_histogram.py
 #
-#   vanilla_core execution visualizer.
+#   vanilla_core PC execution count profiler
 # 
-#   input: vanilla_operation_trace.csv.log
-#   output: bitmap file (blood.bmp)
+#   input: vanilla_operation_trace.csv
+#   output: PC Histogram stats pc_stats/manycore_pc_histogram.log 
 #
-#   @author Tommy Borna
+#   @author Borna behsani@cs.washington.edu
 #
 #   How to use:
-#   python blood_graph.py --cycle {start_cycle@end_cycle}  
-#                         --abstract {optional} --input {vanilla_operation_trace.csv.log}
+#   python vanilla_pc_histogram.py --trace {vanilla_ operation_trace.csv}
+#                                  --tile (optional)
 #
-#   ex) python blood_graph.py --cycle 10000@150000  
-#                             --abstract --input vanilla_operation_trace.csv.log
-#
-#   {cycle}       start_cycle@end_cycle of execution
-#   {abstract}    used for abstract simplifed bloodgraph
+#   {tile}    also generate PC histogram for each tile in a separate file
 
 
 import os
@@ -28,8 +24,6 @@ from collections import Counter
 
 
 class PCHistogram:
-    _DEFAULT_START_CYCLE = 0 
-    _DEFAULT_END_CYCLE   = 500000
 
     _BSG_PC_ADDR_SHIFT = 2
     _BSG_PC_ADDR_STEP = 1 << _BSG_PC_ADDR_SHIFT
@@ -53,18 +47,27 @@ class PCHistogram:
 
 
     # default constructor
-    def __init__(self, per_tile_stat, input_file):
+    def __init__(self, per_tile_stat, trace_file):
 
         self.per_tile_stat = per_tile_stat
 
-        self.traces = []
-        self.manycore_pc_cnt = Counter()
-        self.tile_pc_cnt = Counter()
+        # Parse operation trace file and extract traces 
+        self.traces, self.manycore_dim_y, self.manycore_dim_x = self.__parse_traces (trace_file)
 
+        # Generate per tile PC count dictionary
+        self.tile_pc_cnt = self.__generate_tile_pc_cnt(self.traces)
+
+        # Generate PC count dictionary for the entire network
+        self.manycore_pc_cnt = self.__generate_manycore_pc_cnt(self.tile_pc_cnt)
+
+        return
+
+
+    # parse trace file and extract traces
+    def __parse_traces(self, trace_file):
+        traces = []
         unorigin = (0,0)
-
-        # parse vanilla_operation_trace.log
-        with open(input_file) as f:
+        with open(trace_file) as f:
             csv_reader = csv.DictReader(f, delimiter=",")
             for row in csv_reader:
                 trace = {}
@@ -74,33 +77,19 @@ class PCHistogram:
                 trace["cycle"] = int(row["cycle"])
                 trace["pc"] = int(row["pc"], 16)
                 unorigin = max((trace['y'], trace['x']), unorigin)
+                traces.append(trace)
 
-                # update min and max pc read from traces 
-                #self.max_pc_val = max(self.max_pc_val, trace["pc"])
-                #self.min_pc_val = min(self.min_pc_val, trace["pc"])
+        manycore_dim_y = unorigin[0] + 1
+        manycore_dim_x = unorigin[1] + 1
 
-                self.traces.append(trace)
-
-        self.min_pc_val = min (trace["pc"] for trace in self.traces)
-        self.max_pc_val = max (trace["pc"] for trace in self.traces)
+        return traces, manycore_dim_y, manycore_dim_x
 
 
-        self.manycore_dim_y = unorigin[0] + 1
-        self.manycore_dim_x = unorigin[1] + 1
-
-        self.tile_pc_cnt = self.__generate_tile_pc_cnt(self.traces)
-        self.manycore_pc_cnt = self.__generate_manycore_pc_cnt(self.tile_pc_cnt)
-
-        self.__print_manycore_stats_all(self.manycore_pc_cnt)
-        if(self.per_tile_stat):
-            self.__print_per_tile_stats_all(self.tile_pc_cnt)
-        return 
 
     # print a line of stat into stats file based on stat type
     def __print_stat(self, stat_file, stat_type, *argv):
         stat_file.write(self.print_format[stat_type].format(*argv));
         return
-
 
 
 
@@ -119,6 +108,8 @@ class PCHistogram:
         return tile_pc_cnt
 
 
+
+
     # Sum pc counts for all tiles to generate manycore pc count
     def __generate_manycore_pc_cnt(self, tile_pc_cnt):
         manycore_pc_cnt = Counter()
@@ -127,83 +118,18 @@ class PCHistogram:
                 manycore_pc_cnt += tile_pc_cnt[y][x]
         return manycore_pc_cnt
 
-                
 
 
 
-    # Traverse the pc counter in order for a specific tile 
-    # and prints number of executions for every range
-    def __print_per_tile_pc_histogram(self, y, x, stat_file, tile_pc_cnt):
-        pc_start = self.min_pc_val 
-        pc_end   = self.min_pc_val
-
-        self.__print_stat(stat_file, "pc_header", "PC Block", "Exe Cnt", "Block Size", "Total Intrs Exe Cnt");
-        self.__print_stat(stat_file, "lbreak");
-
-        while (pc_start <= self.max_pc_val and pc_end <= self.max_pc_val):
-            if(tile_pc_cnt[y][x][pc_start] == 0):
-                pc_start += self._BSG_PC_ADDR_STEP
-                pc_end += self._BSG_PC_ADDR_STEP
-            elif (tile_pc_cnt[y][x][pc_start] == tile_pc_cnt[y][x][pc_end]):
-                 pc_end += self._BSG_PC_ADDR_STEP
-            else:
-                 start = pc_start
-                 end = pc_end - self._BSG_PC_ADDR_STEP
-                 pc_cnt = tile_pc_cnt[y][x][start]
-                 block_size = ((end - start) >> self._BSG_PC_ADDR_SHIFT) + 1
-                 exe_cnt = pc_cnt * block_size
-
-                 self.__print_stat(stat_file, "pc_data"
-                                            , start
-                                            , end
-                                            , pc_cnt
-                                            , block_size
-                                            , exe_cnt);
-                 pc_start = pc_end
-
-        if(pc_start < self.max_pc_val - self._BSG_PC_ADDR_STEP):
-            if (tile_pc_cnt[y][x][pc_start] > 0):
-                 start = pc_start
-                 end = pc_end - self._BSG_PC_ADDR_STEP
-                 pc_cnt = tile_pc_cnt[y][x][start]
-                 block_size = ((end - start) >> self._BSG_PC_ADDR_SHIFT) + 1
-                 exe_cnt = pc_cnt * block_size
-
-                 self.__print_stat(stat_file, "pc_data"
-                                            , start
-                                            , end
-                                            , pc_cnt
-                                            , block_size
-                                            , exe_cnt);
-        return
-
-
-    # Prints the pc histogram for each tile in a separate file
-    def __print_per_tile_stats_all(self, tile_pc_cnt):
-        stats_path = os.getcwd() + "/pc_stats/tile/"
-        if not os.path.exists(stats_path):
-            os.mkdir(stats_path)
-        for y in range(self.manycore_dim_y):
-            for x in range(self.manycore_dim_x):
-                stat_file = open( (stats_path + "tile_" + str(y) + "_" + str(x) + "_pc_histogram.log"), "w")
-                self.__print_per_tile_pc_histogram(y, x, stat_file, tile_pc_cnt);
-                stat_file.close()
-        return
-
-
-
-
-
-
-    # Traverse the pc counter in order for the entire manycore
-    # and prints number of executions for every range
-    def __print_manycore_pc_histogram(self, stat_file, manycore_pc_cnt):
+    # Traverse the PC's in the give PC counter in order
+    # and print number of executions for every basic block
+    def __print_pc_histogram(self, stat_file, pc_cnt):
 
         self.__print_stat(stat_file, "pc_header", "PC Block", "Exe Cnt", "Block Size", "Total Intrs Exe Cnt");
         self.__print_stat(stat_file, "lbreak");
 
         # Create a sorted list of all PC's executed 
-        pc_list = sorted(manycore_pc_cnt.keys())
+        pc_list = sorted(pc_cnt.keys())
 
 
         start = 0
@@ -216,17 +142,17 @@ class PCHistogram:
         # equal to that of previous PC
         # Once this condition no longer holds, print the basic block and repeat
         while (end < len(pc_list)):
-            if (not (manycore_pc_cnt[pc_list[start]] == manycore_pc_cnt[pc_list[end]]
+            if (not (pc_cnt[pc_list[start]] == pc_cnt[pc_list[end]]
                      and pc_list[end] - pc_list[end-1] == self._BSG_PC_ADDR_STEP) ):
                 
-                pc_cnt = manycore_pc_cnt[pc_list[start]]
+                block_pc_cnt = pc_cnt[pc_list[start]]
                 block_size = ((pc_list[end-1] - pc_list[start]) >> self._BSG_PC_ADDR_SHIFT) + 1
-                exe_cnt = pc_cnt * block_size
+                exe_cnt = block_pc_cnt * block_size
 
                 self.__print_stat(stat_file, "pc_data"
                                            , pc_list[start]
                                            , pc_list[end-1]
-                                           , pc_cnt
+                                           , block_pc_cnt
                                            , block_size
                                            , exe_cnt);
                 start = end
@@ -235,7 +161,7 @@ class PCHistogram:
 
 
         # Print once more for the last basic block 
-        pc_cnt = manycore_pc_cnt[pc_list[start]]
+        pc_cnt = pc_cnt[pc_list[start]]
         block_size = ((pc_list[end-1] - pc_list[start]) >> self._BSG_PC_ADDR_SHIFT) + 1
         exe_cnt = pc_cnt * block_size
 
@@ -249,16 +175,30 @@ class PCHistogram:
 
 
 
+
+    # Prints the pc histogram for each tile in a separate file
+    def print_per_tile_stats_all(self):
+        stats_path = os.getcwd() + "/pc_stats/tile/"
+        if not os.path.exists(stats_path):
+            os.mkdir(stats_path)
+        for y in range(self.manycore_dim_y):
+            for x in range(self.manycore_dim_x):
+                stat_file = open( (stats_path + "tile_" + str(y) + "_" + str(x) + "_pc_histogram.log"), "w")
+                self.__print_pc_histogram(stat_file, self.tile_pc_cnt[y][x]);
+                stat_file.close()
+        return
+
+
+
     # Prints the pc histogram for the entire manycore 
-    def __print_manycore_stats_all(self, manycore_pc_cnt):
+    def print_manycore_stats_all(self):
         stats_path = os.getcwd() + "/pc_stats/"
         if not os.path.exists(stats_path):
             os.mkdir(stats_path)
         stats_file = open( (stats_path + "manycore_pc_histogram.log"), "w")
-        self.__print_manycore_pc_histogram(stats_file, manycore_pc_cnt);
+        self.__print_pc_histogram(stats_file, self.manycore_pc_cnt);
         stats_file.close()
         return
-
 
 
 
@@ -266,7 +206,7 @@ class PCHistogram:
 # Parse input arguments and options 
 def parse_args():  
     parser = argparse.ArgumentParser(description="Argument parser for vanilla_pc_histogram.py")
-    parser.add_argument("--input", default="vanilla_operation_trace.csv.log", type=str,
+    parser.add_argument("--trace", default="vanilla_operation_trace.csv.log", type=str,
                         help="Vanilla operation log file")
     parser.add_argument("--tile", default=False, action='store_true',
                         help="Also generate separate pc histogram files for each tile.")
@@ -275,7 +215,18 @@ def parse_args():
     return args
 
 
+
+
 # main()
 if __name__ == "__main__":
     args = parse_args()
-    pch = PCHistogram(args.tile, args.input)
+    pch = PCHistogram(args.tile, args.trace)
+
+    # Print PC histogram for the entire network
+    pch.print_manycore_stats_all()
+
+    # Print PC histogram for each tile in a separate file 
+    if(args.tile):
+        pch.print_per_tile_stats_all()
+
+


### PR DESCRIPTION
- Previously the PC histogram would traverse the entire range of possible PC's, possibly from 0x00000000 to 0xffffffff to generate histogram --> very inefficient and painfully slow
- Modified it to only traverse the PC's seen in the vanilla operation trace file
- Updated commentary
- Refactored and added some functions to make the code more modular 
- Got rid of redundant print stats functions 

**Merge with PR # in baseline.**
