### PR TITLE
Minor refactor of Vcache profiler, stats parser and stall graph

### DIFF
--- a/software/py/vanilla_stats_parser.py
+++ b/software/py/vanilla_stats_parser.py
@@ -156,6 +156,10 @@ class VanillaStatsParser:
                     "timing_header"   : type_fmt["name"]       + type_fmt["type"] + type_fmt["type"]    + type_fmt["type"]    + type_fmt["type"]    + type_fmt["type"]    + "\n",
                     "tile_timing_data": type_fmt["cord"]       + type_fmt["int"]  + type_fmt["int"]     + type_fmt["float"]   + type_fmt["percent"] + type_fmt["percent"] + "\n",
                     "timing_data"     : type_fmt["name"]       + type_fmt["int"]  + type_fmt["int"]     + type_fmt["float"]   + type_fmt["percent"] + type_fmt["percent"] + "\n",
+
+                "vcache_timing_header": type_fmt["name"]       + type_fmt["type"] + type_fmt["type"]    + type_fmt["type"]    + type_fmt["type"]    + "\n",
+                "vcache_timing_data"  : type_fmt["name"]       + type_fmt["int"]  + type_fmt["int"]     + type_fmt["int"]     + type_fmt["int"]     +"\n",
+
                     "instr_header"    : type_fmt["name"]       + type_fmt["int"]  + type_fmt["type"]    + "\n",
                     "instr_data"      : type_fmt["name"]       + type_fmt["int"]  + type_fmt["percent"] + "\n",
                     "instr_data_indt" : type_fmt["name_indt"]  + type_fmt["int"]  + type_fmt["percent"] + "\n",
@@ -487,6 +491,47 @@ class VanillaStatsParser:
         for tag in manycore_stat.keys():
             if(manycore_stat[tag]["global_ctr"]):
                 self.__print_manycore_tag_stats_tile_timing(stat_file, tag, tiles, manycore_stat, tile_stat)
+        self.__print_stat(stat_file, "end_lbreak")
+        return   
+
+
+
+
+    # print execution timing for the entire manycoree per vcache bank for a certain tag
+    def __print_manycore_tag_stats_vcache_timing(self, stat_file, tag):
+        self.__print_stat(stat_file, "tag_separator", tag)
+
+        for vcache in self.active_vcaches:
+            self.__print_stat(stat_file, "vcache_timing_data"
+                                         ,vcache
+                                         ,(self.vcache_stat[tag][vcache]["instr_total"])
+                                         ,(self.vcache_stat[tag][vcache]["miss_total"])
+                                         ,(self.vcache_stat[tag][vcache]["stall_total"])
+                                         ,(self.vcache_stat[tag][vcache]["global_ctr"]))
+
+        self.__print_stat(stat_file, "vcache_timing_data"
+                                     ,"total"
+                                     ,(self.manycore_vcache_stat[tag]["instr_total"])
+                                     ,(self.manycore_vcache_stat[tag]["miss_total"])
+                                     ,(self.manycore_vcache_stat[tag]["stall_total"])
+                                     ,(self.manycore_vcache_stat[tag]["global_ctr"]))
+        return
+
+
+    # Prints manycore timing stats per vcache bank for all tags 
+    def __print_manycore_stats_vcache_timing(self, stat_file):
+        stat_file.write("Per-Vcache-Bank Timing Stats\n")
+        self.__print_stat(stat_file, "vcache_timing_header"
+                                     ,"Vcache Bank No."
+                                     ,"Aggr Hit Requests"
+                                     ,"Aggr Misse Requests"
+                                     ,"Aggr Stall Cycles"
+                                     ,"Aggr Total Cycles")
+        self.__print_stat(stat_file, "start_lbreak")
+
+        for tag in self.manycore_vcache_stat.keys():
+            if(self.manycore_vcache_stat[tag]["global_ctr"]):
+                self.__print_manycore_tag_stats_vcache_timing(stat_file, tag)
         self.__print_stat(stat_file, "end_lbreak")
         return   
 
@@ -1184,6 +1229,7 @@ class VanillaStatsParser:
 
         # If vcache stats is given as input, also print vcache stats
         if (self.vcache):
+            self.__print_manycore_stats_vcache_timing(manycore_stats_file)
             self.__print_manycore_stats_miss(manycore_stats_file, "VCache Per-Tag Miss Stats", self.manycore_vcache_stat, self.vcache_misses)
             self.__print_manycore_stats_stall(manycore_stats_file, "VCache Per-Tag Stall Stats", self.manycore_vcache_stat, self.vcache_stalls)
             self.__print_manycore_stats_instr(manycore_stats_file, "VCache Per-Tag Instruction Stats", self.manycore_vcache_stat, self.vcache_instrs)

--- a/software/py/vanilla_stats_parser.py
+++ b/software/py/vanilla_stats_parser.py
@@ -678,11 +678,16 @@ class VanillaStatsParser:
         # Print stall stats for manycore
         for stall in stalls:
             stall_format = "stall_data_indt" if stall.startswith('stall_depend_') else "stall_data"
-            self.__print_stat(stat_file, stall_format, stall,
-                                         stat[tag][stall],
-                                         (100 * np.float64(stat[tag][stall]) / stat[tag]["stall_total"])
+            self.__print_stat(stat_file, stall_format, stall
+                                         ,stat[tag][stall]
+                                         ,(100 * np.float64(stat[tag][stall]) / stat[tag]["stall_total"])
                                          ,(100 * np.float64(stat[tag][stall]) / stat[tag]["global_ctr"]))
 
+        not_stall = stat[tag]["global_ctr"] - stat[tag]["stall_total"]
+        self.__print_stat(stat_file, "stall_data", "not_stall"
+                                     ,not_stall
+                                     ,(100 * np.float64(not_stall) / stat[tag]["stall_total"])
+                                     ,(100 * np.float64(not_stall) / stat[tag]["global_ctr"]))
         return
 
 

--- a/software/py/vanilla_stats_parser.py
+++ b/software/py/vanilla_stats_parser.py
@@ -157,8 +157,8 @@ class VanillaStatsParser:
                     "tile_timing_data": type_fmt["cord"]       + type_fmt["int"]  + type_fmt["int"]     + type_fmt["float"]   + type_fmt["percent"] + type_fmt["percent"] + "\n",
                     "timing_data"     : type_fmt["name"]       + type_fmt["int"]  + type_fmt["int"]     + type_fmt["float"]   + type_fmt["percent"] + type_fmt["percent"] + "\n",
 
-                "vcache_timing_header": type_fmt["name"]       + type_fmt["type"] + type_fmt["type"]    + type_fmt["type"]    + type_fmt["type"]    + "\n",
-                "vcache_timing_data"  : type_fmt["name"]       + type_fmt["int"]  + type_fmt["int"]     + type_fmt["int"]     + type_fmt["int"]     +"\n",
+                    "vcache_timing_header": type_fmt["name"]   + type_fmt["type"] + type_fmt["type"]    + type_fmt["type"]    + type_fmt["type"]    + type_fmt["type"]   + "\n",
+                    "vcache_timing_data"  : type_fmt["name"]   + type_fmt["int"]  + type_fmt["int"]     + type_fmt["int"]     + type_fmt["int"]     + type_fmt["float"]   + "\n",
 
                     "instr_header"    : type_fmt["name"]       + type_fmt["int"]  + type_fmt["type"]    + "\n",
                     "instr_data"      : type_fmt["name"]       + type_fmt["int"]  + type_fmt["percent"] + "\n",
@@ -502,19 +502,35 @@ class VanillaStatsParser:
         self.__print_stat(stat_file, "tag_separator", tag)
 
         for vcache in self.active_vcaches:
+
+            hit_cnt = self.vcache_stat[tag][vcache]["instr_total"]
+            miss_cnt = self.vcache_stat[tag][vcache]["miss_total"]
+            stall_cnt = self.vcache_stat[tag][vcache]["stall_total"]
+            cycle_cnt = self.vcache_stat[tag][vcache]["global_ctr"]
+            utilization = np.float64(hit_cnt + miss_cnt) / cycle_cnt
+
             self.__print_stat(stat_file, "vcache_timing_data"
                                          ,vcache
-                                         ,(self.vcache_stat[tag][vcache]["instr_total"])
-                                         ,(self.vcache_stat[tag][vcache]["miss_total"])
-                                         ,(self.vcache_stat[tag][vcache]["stall_total"])
-                                         ,(self.vcache_stat[tag][vcache]["global_ctr"]))
+                                         ,hit_cnt
+                                         ,miss_cnt
+                                         ,stall_cnt
+                                         ,cycle_cnt
+                                         ,utilization)
+
+
+        hit_cnt = self.manycore_vcache_stat[tag]["instr_total"]
+        miss_cnt = self.manycore_vcache_stat[tag]["miss_total"]
+        stall_cnt = self.manycore_vcache_stat[tag]["stall_total"]
+        cycle_cnt = self.manycore_vcache_stat[tag]["global_ctr"]
+        utilization = np.float64(hit_cnt + miss_cnt) / cycle_cnt
 
         self.__print_stat(stat_file, "vcache_timing_data"
                                      ,"total"
-                                     ,(self.manycore_vcache_stat[tag]["instr_total"])
-                                     ,(self.manycore_vcache_stat[tag]["miss_total"])
-                                     ,(self.manycore_vcache_stat[tag]["stall_total"])
-                                     ,(self.manycore_vcache_stat[tag]["global_ctr"]))
+                                     ,hit_cnt
+                                     ,miss_cnt
+                                     ,stall_cnt
+                                     ,cycle_cnt
+                                     ,utilization)
         return
 
 
@@ -526,7 +542,8 @@ class VanillaStatsParser:
                                      ,"Aggr Hit Requests"
                                      ,"Aggr Misse Requests"
                                      ,"Aggr Stall Cycles"
-                                     ,"Aggr Total Cycles")
+                                     ,"Aggr Total Cycles"
+                                     ,"Utilization")
         self.__print_stat(stat_file, "start_lbreak")
 
         for tag in self.manycore_vcache_stat.keys():

--- a/software/py/vanilla_stats_parser.py
+++ b/software/py/vanilla_stats_parser.py
@@ -154,7 +154,8 @@ class VanillaStatsParser:
     print_format = {"tg_timing_header": type_fmt["name"]       + type_fmt["type"] + type_fmt["type"]    + type_fmt["type"]    + type_fmt["type"]    + type_fmt["type"]    + type_fmt["type"]    + "\n",
                     "tg_timing_data"  : type_fmt["name"]       + type_fmt["int"]  + type_fmt["int"]     + type_fmt["int"]     + type_fmt["float"]   + type_fmt["percent"] + type_fmt["percent"] + "\n",
                     "timing_header"   : type_fmt["name"]       + type_fmt["type"] + type_fmt["type"]    + type_fmt["type"]    + type_fmt["type"]    + type_fmt["type"]    + "\n",
-                    "timing_data"     : type_fmt["cord"]       + type_fmt["int"]  + type_fmt["int"]     + type_fmt["float"]   + type_fmt["percent"] + type_fmt["percent"] + "\n",
+                    "tile_timing_data": type_fmt["cord"]       + type_fmt["int"]  + type_fmt["int"]     + type_fmt["float"]   + type_fmt["percent"] + type_fmt["percent"] + "\n",
+                    "timing_data"     : type_fmt["name"]       + type_fmt["int"]  + type_fmt["int"]     + type_fmt["float"]   + type_fmt["percent"] + type_fmt["percent"] + "\n",
                     "instr_header"    : type_fmt["name"]       + type_fmt["int"]  + type_fmt["type"]    + "\n",
                     "instr_data"      : type_fmt["name"]       + type_fmt["int"]  + type_fmt["percent"] + "\n",
                     "instr_data_indt" : type_fmt["name_indt"]  + type_fmt["int"]  + type_fmt["percent"] + "\n",
@@ -459,7 +460,7 @@ class VanillaStatsParser:
         self.__print_stat(stat_file, "tag_separator", tag)
 
         for tile in tiles:
-            self.__print_stat(stat_file, "timing_data"
+            self.__print_stat(stat_file, "tile_timing_data"
                               ,tile[0]
                               ,tile[1]
                               ,(tile_stat[tag][tile]["instr_total"])
@@ -468,11 +469,10 @@ class VanillaStatsParser:
                               ,(100 * tile_stat[tag][tile]["global_ctr"] / manycore_stat[tag]["global_ctr"])
                               ,(100 * np.float64(tile_stat[tag][tile]["global_ctr"]) / tile_stat["kernel"][tile]["global_ctr"]))
 
-        self.__print_stat(stat_file, "tg_timing_data"
+        self.__print_stat(stat_file, "timing_data"
                                      ,"total"
                                      ,(manycore_stat[tag]["instr_total"])
                                      ,(manycore_stat[tag]["global_ctr"])
-                                     ,0
                                      ,(manycore_stat[tag]["instr_total"] / manycore_stat[tag]["global_ctr"])
                                      ,(np.float64(100 * manycore_stat[tag]["global_ctr"]) / manycore_stat[tag]["global_ctr"])
                                      ,(np.float64(100 * manycore_stat[tag]["global_ctr"]) / manycore_stat["kernel"]["global_ctr"]))
@@ -539,7 +539,7 @@ class VanillaStatsParser:
     def __print_per_tile_tag_stats_timing(self, stat_file, tile, tag, manycore_stat, tile_stat):
         self.__print_stat(stat_file, "tag_separator", tag)
 
-        self.__print_stat(stat_file, "timing_data"
+        self.__print_stat(stat_file, "tile_timing_data"
                                      ,tile[0]
                                      ,tile[1]
                                      ,(tile_stat[tag][tile]["instr_total"])

--- a/software/py/vcache_stall_graph.py
+++ b/software/py/vcache_stall_graph.py
@@ -162,15 +162,23 @@ class VcacheStallGraph:
 
 
     # default constructor
-    def __init__(self, trace_file, stats_file, cycle, abstract):
+    def __init__(self, trace_file, stats_file, cycle, abstract, no_stall_graph):
 
         self.abstract = abstract
+        self.no_stall_graph = no_stall_graph
 
         # Determine coloring rules based on mode {abstract / detailed}
         if (self.abstract):
             self.operation_color     = self._ABSTRACT_OPERATION_COLOR
         else:
             self.operation_color     = self._DETAILED_OPERATION_COLOR
+
+
+        # If trace file is missing exit with warning
+        if not os.path.exists(trace_file):
+            print("Warning: vcache trace file not found, skipping victim cache stall graph generation.")
+            self.no_stall_graph = True
+            return
 
 
         # Parse vcache operation trace file to generate traces
@@ -356,8 +364,8 @@ def parse_args():
 if __name__ == "__main__":
     args = parse_args()
   
-    bg = VcacheStallGraph(args.trace, args.stats, args.cycle, args.abstract)
-    if not args.no_stall_graph:
+    bg = VcacheStallGraph(args.trace, args.stats, args.cycle, args.abstract, args.no_stall_graph)
+    if not bg.no_stall_graph:
         bg.generate()
     if args.generate_key:
         bg.generate_key()

--- a/testbenches/common/v/vcache_profiler.v
+++ b/testbenches/common/v/vcache_profiler.v
@@ -58,22 +58,22 @@ module vcache_profiler
   // Manycore performs all types of stores operations using the SM, therefore
   // mask_op should be hight while evaluating the store signals, but not for
   // load signals 
-  wire inc_ld       = v_o & yumi_i & decode_v_r.ld_op;
-  wire inc_ld_ld    = v_o & yumi_i & decode_v_r.ld_op & ~decode_v_r.mask_op & decode_v_r.data_size_op == 2'b11 & decode_v_r.sigext_op;  // load double (reserved for 64-bit)
-  wire inc_ld_ldu   = v_o & yumi_i & decode_v_r.ld_op & ~decode_v_r.mask_op & decode_v_r.data_size_op == 2'b11 & ~decode_v_r.sigext_op; // load double unsigned (reserved for 64-bit) 
-  wire inc_ld_lw    = v_o & yumi_i & decode_v_r.ld_op & ~decode_v_r.mask_op & decode_v_r.data_size_op == 2'b10 & decode_v_r.sigext_op;  // load word
-  wire inc_ld_lwu   = v_o & yumi_i & decode_v_r.ld_op & ~decode_v_r.mask_op & decode_v_r.data_size_op == 2'b10 & ~decode_v_r.sigext_op; // load word unsigned
-  wire inc_ld_lh    = v_o & yumi_i & decode_v_r.ld_op & ~decode_v_r.mask_op & decode_v_r.data_size_op == 2'b01 & decode_v_r.sigext_op;  // load half
-  wire inc_ld_lhu   = v_o & yumi_i & decode_v_r.ld_op & ~decode_v_r.mask_op & decode_v_r.data_size_op == 2'b01 & ~decode_v_r.sigext_op; // load half unsigned
-  wire inc_ld_lb    = v_o & yumi_i & decode_v_r.ld_op & ~decode_v_r.mask_op & decode_v_r.data_size_op == 2'b00 & decode_v_r.sigext_op;  // load byte
-  wire inc_ld_lbu   = v_o & yumi_i & decode_v_r.ld_op & ~decode_v_r.mask_op & decode_v_r.data_size_op == 2'b00 & ~decode_v_r.sigext_op; // load byte unsigned
+  wire inc_ld       = v_o & yumi_i & decode_v_r.ld_op & ~miss_v;
+  wire inc_ld_ld    = v_o & yumi_i & decode_v_r.ld_op & ~miss_v & ~decode_v_r.mask_op & decode_v_r.data_size_op == 2'b11 & decode_v_r.sigext_op;  // load double (reserved for 64-bit)
+  wire inc_ld_ldu   = v_o & yumi_i & decode_v_r.ld_op & ~miss_v & ~decode_v_r.mask_op & decode_v_r.data_size_op == 2'b11 & ~decode_v_r.sigext_op; // load double unsigned (reserved for 64-bit) 
+  wire inc_ld_lw    = v_o & yumi_i & decode_v_r.ld_op & ~miss_v & ~decode_v_r.mask_op & decode_v_r.data_size_op == 2'b10 & decode_v_r.sigext_op;  // load word
+  wire inc_ld_lwu   = v_o & yumi_i & decode_v_r.ld_op & ~miss_v & ~decode_v_r.mask_op & decode_v_r.data_size_op == 2'b10 & ~decode_v_r.sigext_op; // load word unsigned
+  wire inc_ld_lh    = v_o & yumi_i & decode_v_r.ld_op & ~miss_v & ~decode_v_r.mask_op & decode_v_r.data_size_op == 2'b01 & decode_v_r.sigext_op;  // load half
+  wire inc_ld_lhu   = v_o & yumi_i & decode_v_r.ld_op & ~miss_v & ~decode_v_r.mask_op & decode_v_r.data_size_op == 2'b01 & ~decode_v_r.sigext_op; // load half unsigned
+  wire inc_ld_lb    = v_o & yumi_i & decode_v_r.ld_op & ~miss_v & ~decode_v_r.mask_op & decode_v_r.data_size_op == 2'b00 & decode_v_r.sigext_op;  // load byte
+  wire inc_ld_lbu   = v_o & yumi_i & decode_v_r.ld_op & ~miss_v & ~decode_v_r.mask_op & decode_v_r.data_size_op == 2'b00 & ~decode_v_r.sigext_op; // load byte unsigned
 
   // All store operations from bsg_manycore are performed with the store mask op
-  wire inc_st       = v_o & yumi_i & decode_v_r.st_op;
-  wire inc_sm_sd    = v_o & yumi_i & decode_v_r.st_op & decode_v_r.mask_op & ($countones(mask_v_r) == 8); // store double (reserved for 64-bit)
-  wire inc_sm_sw    = v_o & yumi_i & decode_v_r.st_op & decode_v_r.mask_op & ($countones(mask_v_r) == 4); // store word
-  wire inc_sm_sh    = v_o & yumi_i & decode_v_r.st_op & decode_v_r.mask_op & ($countones(mask_v_r) == 2); // store half
-  wire inc_sm_sb    = v_o & yumi_i & decode_v_r.st_op & decode_v_r.mask_op & ($countones(mask_v_r) == 1); // store byte
+  wire inc_st       = v_o & yumi_i & decode_v_r.st_op & ~miss_v;
+  wire inc_sm_sd    = v_o & yumi_i & decode_v_r.st_op & ~miss_v & decode_v_r.mask_op & ($countones(mask_v_r) == 8); // store double (reserved for 64-bit)
+  wire inc_sm_sw    = v_o & yumi_i & decode_v_r.st_op & ~miss_v & decode_v_r.mask_op & ($countones(mask_v_r) == 4); // store word
+  wire inc_sm_sh    = v_o & yumi_i & decode_v_r.st_op & ~miss_v & decode_v_r.mask_op & ($countones(mask_v_r) == 2); // store half
+  wire inc_sm_sb    = v_o & yumi_i & decode_v_r.st_op & ~miss_v & decode_v_r.mask_op & ($countones(mask_v_r) == 1); // store byte
 
   wire inc_tagst    = v_o & yumi_i & decode_v_r.tagst_op;   // tag store                
   wire inc_tagfl    = v_o & yumi_i & decode_v_r.tagfl_op;   // tag flush

--- a/testbenches/common/v/vcache_profiler.v
+++ b/testbenches/common/v/vcache_profiler.v
@@ -59,21 +59,21 @@ module vcache_profiler
   // mask_op should be hight while evaluating the store signals, but not for
   // load signals 
   wire inc_ld       = v_o & yumi_i & decode_v_r.ld_op & ~miss_v;
-  wire inc_ld_ld    = v_o & yumi_i & decode_v_r.ld_op & ~miss_v & ~decode_v_r.mask_op & decode_v_r.data_size_op == 2'b11 & decode_v_r.sigext_op;  // load double (reserved for 64-bit)
-  wire inc_ld_ldu   = v_o & yumi_i & decode_v_r.ld_op & ~miss_v & ~decode_v_r.mask_op & decode_v_r.data_size_op == 2'b11 & ~decode_v_r.sigext_op; // load double unsigned (reserved for 64-bit) 
-  wire inc_ld_lw    = v_o & yumi_i & decode_v_r.ld_op & ~miss_v & ~decode_v_r.mask_op & decode_v_r.data_size_op == 2'b10 & decode_v_r.sigext_op;  // load word
-  wire inc_ld_lwu   = v_o & yumi_i & decode_v_r.ld_op & ~miss_v & ~decode_v_r.mask_op & decode_v_r.data_size_op == 2'b10 & ~decode_v_r.sigext_op; // load word unsigned
-  wire inc_ld_lh    = v_o & yumi_i & decode_v_r.ld_op & ~miss_v & ~decode_v_r.mask_op & decode_v_r.data_size_op == 2'b01 & decode_v_r.sigext_op;  // load half
-  wire inc_ld_lhu   = v_o & yumi_i & decode_v_r.ld_op & ~miss_v & ~decode_v_r.mask_op & decode_v_r.data_size_op == 2'b01 & ~decode_v_r.sigext_op; // load half unsigned
-  wire inc_ld_lb    = v_o & yumi_i & decode_v_r.ld_op & ~miss_v & ~decode_v_r.mask_op & decode_v_r.data_size_op == 2'b00 & decode_v_r.sigext_op;  // load byte
-  wire inc_ld_lbu   = v_o & yumi_i & decode_v_r.ld_op & ~miss_v & ~decode_v_r.mask_op & decode_v_r.data_size_op == 2'b00 & ~decode_v_r.sigext_op; // load byte unsigned
+  wire inc_ld_ld    = inc_ld & ~decode_v_r.mask_op & decode_v_r.data_size_op == 2'b11 & decode_v_r.sigext_op;  // load double (reserved for 64-bit)
+  wire inc_ld_ldu   = inc_ld & ~decode_v_r.mask_op & decode_v_r.data_size_op == 2'b11 & ~decode_v_r.sigext_op; // load double unsigned (reserved for 64-bit) 
+  wire inc_ld_lw    = inc_ld & ~decode_v_r.mask_op & decode_v_r.data_size_op == 2'b10 & decode_v_r.sigext_op;  // load word
+  wire inc_ld_lwu   = inc_ld & ~decode_v_r.mask_op & decode_v_r.data_size_op == 2'b10 & ~decode_v_r.sigext_op; // load word unsigned
+  wire inc_ld_lh    = inc_ld & ~decode_v_r.mask_op & decode_v_r.data_size_op == 2'b01 & decode_v_r.sigext_op;  // load half
+  wire inc_ld_lhu   = inc_ld & ~decode_v_r.mask_op & decode_v_r.data_size_op == 2'b01 & ~decode_v_r.sigext_op; // load half unsigned
+  wire inc_ld_lb    = inc_ld & ~decode_v_r.mask_op & decode_v_r.data_size_op == 2'b00 & decode_v_r.sigext_op;  // load byte
+  wire inc_ld_lbu   = inc_ld & ~decode_v_r.mask_op & decode_v_r.data_size_op == 2'b00 & ~decode_v_r.sigext_op; // load byte unsigned
 
   // All store operations from bsg_manycore are performed with the store mask op
   wire inc_st       = v_o & yumi_i & decode_v_r.st_op & ~miss_v;
-  wire inc_sm_sd    = v_o & yumi_i & decode_v_r.st_op & ~miss_v & decode_v_r.mask_op & ($countones(mask_v_r) == 8); // store double (reserved for 64-bit)
-  wire inc_sm_sw    = v_o & yumi_i & decode_v_r.st_op & ~miss_v & decode_v_r.mask_op & ($countones(mask_v_r) == 4); // store word
-  wire inc_sm_sh    = v_o & yumi_i & decode_v_r.st_op & ~miss_v & decode_v_r.mask_op & ($countones(mask_v_r) == 2); // store half
-  wire inc_sm_sb    = v_o & yumi_i & decode_v_r.st_op & ~miss_v & decode_v_r.mask_op & ($countones(mask_v_r) == 1); // store byte
+  wire inc_sm_sd    = inc_st & decode_v_r.mask_op & ($countones(mask_v_r) == 8); // store double (reserved for 64-bit)
+  wire inc_sm_sw    = inc_st & decode_v_r.mask_op & ($countones(mask_v_r) == 4); // store word
+  wire inc_sm_sh    = inc_st & decode_v_r.mask_op & ($countones(mask_v_r) == 2); // store half
+  wire inc_sm_sb    = inc_st & decode_v_r.mask_op & ($countones(mask_v_r) == 1); // store byte
 
   wire inc_tagst    = v_o & yumi_i & decode_v_r.tagst_op;   // tag store                
   wire inc_tagfl    = v_o & yumi_i & decode_v_r.tagfl_op;   // tag flush


### PR DESCRIPTION
* Changed vcache profiler to not count missing load/store requests as completed operations (This way, missing requests + hit requests + stall cycles = total cycles)
* Added warning if the vcache_stats.csv or vcache_operation_trace.csv is missing. This way simulation doesn't terminate with errors if it is using infinite_mem (4x4_fast_n_fake)
* Added a not_stall section to the vcache stall stats (% of useful work)
* Added a per-vcache statistics with utilization for the manycore_stats.log 
* Minor bug fixes.


