### PR TITLE
LLVM cross-compilation

### DIFF
--- a/software/README.md
+++ b/software/README.md
@@ -1,0 +1,33 @@
+# BSG Manycore Software
+
+This directory hosts software insfrasture useful for developing BSG Manycore kernels.
+Following is the directory structure:
+
+```
+.
+├── bsg_manycore_lib   Run-time library with useful macros and functions.
+├── manycore-llvm-pass Directory with LLVM passes.
+├── mk                 Makefile fragments useful for implementing compilation and simulation flow.
+├── nbf                Stale. To be removed.
+├── py                 All Python scripts used in this repo.
+├── regress            Multi-mode multi-corner (MMMC) regression.
+├── riscv-tools        Scripts to install software toolchains.
+├── spmd               Collection of low-level SPMD Test programs.
+└── tensorlib          Stale. Moved to hb-pytorch. To be removed.
+```
+
+## Compiling for BSG Manycore
+
+Include [./mk/Makefile.buildefs](software/mk/Makefile.builddefs) make fragment to import `make` rules for compiling
+Manycore programs. Some useful flags to customize compilation are:
+
+- `RISCV_BIN_DIR`:        Path to the RISC-V GNU Toolchain installation. Required flag. Default: None.
+- `OPT_LEVEL`:            Compiler optimization level. Default: `-O2`.
+- `RISCV_GCC_EXTRA_OPTS`: Extra compilation falgs to be passed to the C compiler.
+- `RISCV_GXX_EXTRA_OPTS`: Extra compilation falgs to be passed to the C++ compiler.
+- `LINK_SCRIPT`:          Link script for linking kernels. Default is the one generated with 
+                          [bsg_manycore_link_gen.py](software/py/bsg_manycore_link_gen.py).
+- `RISCV_LINK_OPTS`:      Linker options to be prepended with default options.
+- `CLANG`:                Flag to compile with RISC-V LLVM infrastructure instead of GCC.
+- `LLVM_DIR`:             Path to LLVM+Clang installation. Requires LLVM >9.0.0. Default: `./riscv-tools/llvm/llvm-install`.
+- `ENABLE_LLVM_PASSES`:   Enable Manycore LLVM passes when compiling with `CLANG=1`.

--- a/software/mk/Makefile.builddefs
+++ b/software/mk/Makefile.builddefs
@@ -187,7 +187,7 @@ RISCV_GXX_OPTS += $(RISCV_GXX_EXTRA_OPTS)
 spmd_defs = -DPREALLOCATE=0 -DHOST_DEBUG=0
 
 ifdef CLANG
-LLVM_DIR          ?= $(BSG_MANYCORE_DIR)/../bsg-llvm-project/build
+LLVM_DIR          ?= $(BSG_MANYCORE_DIR)/software/riscv-tools/llvm/llvm-install
 LLVM_CLANG        ?= $(LLVM_DIR)/bin/clang
 LLVM_CLANGPP      ?= $(LLVM_DIR)/bin/clang++
 LLVM_OPT          ?= $(LLVM_DIR)/bin/opt

--- a/software/mk/Makefile.builddefs
+++ b/software/mk/Makefile.builddefs
@@ -192,13 +192,12 @@ LLVM_CLANG        ?= $(LLVM_DIR)/bin/clang
 LLVM_CLANGPP      ?= $(LLVM_DIR)/bin/clang++
 LLVM_OPT          ?= $(LLVM_DIR)/bin/opt
 LLVM_LLC          ?= $(LLVM_DIR)/bin/llc
-RUNTIME_FNS       ?= $(BSG_MANYCORE_DIR)/software/bsg_manycore_lib/bsg_tilegroup.h
 CLANG_TARGET_OPTS ?= --target=riscv32 -march=$(ARCH_OP) -mabi=$(ABI)
-
 ifdef LLVM_PASS
-PASS_DIR         ?= $(BSG_MANYCORE_DIR)/software/manycore-llvm-pass
-PASS_LIB         ?= build/manycore/libManycorePass.so
+PASS_DIR          ?= $(BSG_MANYCORE_DIR)/software/manycore-llvm-pass
+PASS_LIB          ?= build/manycore/libManycorePass.so
 endif
+RUNTIME_FNS       ?= $(BSG_MANYCORE_DIR)/software/bsg_manycore_lib/bsg_tilegroup.h
 
 $(LLVM_DIR):
 	@echo "LLVM is not installed! Follow build instructions in the TRM and \
@@ -219,6 +218,8 @@ $(LLVM_DIR):
 %.bc: %.cpp $(LLVM_DIR) $(RUNTIME_FNS)
 	$(LLVM_CLANGPP) $(CLANG_TARGET_OPTS) $(RISCV_GXX_OPTS) \
 		--sysroot=$(RISCV_BIN_DIR)/../riscv32-unknown-elf-dramfs \
+		-I$(RISCV_BIN_DIR)/../riscv32-unknown-elf-dramfs/include/c++/9.2.0 \
+		-I$(RISCV_BIN_DIR)/../riscv32-unknown-elf-dramfs/include/c++/9.2.0/riscv32-unknown-elf-dramfs \
 		$(OPT_LEVEL) $(spmd_defs) -c -emit-llvm $(INCS) $< -o $@
 
 ifdef LLVM_PASS

--- a/software/mk/Makefile.builddefs
+++ b/software/mk/Makefile.builddefs
@@ -2,6 +2,7 @@
 # Chip Architecture
 
 ARCH_OP=rv32imaf
+ABI=ilp32f
 
 
 #######################################################
@@ -186,12 +187,13 @@ RISCV_GXX_OPTS += $(RISCV_GXX_EXTRA_OPTS)
 spmd_defs = -DPREALLOCATE=0 -DHOST_DEBUG=0
 
 ifdef CLANG
-LLVM_DIR         ?= $(BSG_MANYCORE_DIR)/../bsg-llvm-project/build
-LLVM_CLANG       ?= $(LLVM_DIR)/bin/clang
-LLVM_CLANGPP     ?= $(LLVM_DIR)/bin/clang++
-LLVM_OPT         ?= $(LLVM_DIR)/bin/opt
-LLVM_LLC         ?= $(LLVM_DIR)/bin/llc
-RUNTIME_FNS      ?= $(BSG_MANYCORE_DIR)/software/bsg_manycore_lib/bsg_tilegroup.h
+LLVM_DIR          ?= $(BSG_MANYCORE_DIR)/../bsg-llvm-project/build
+LLVM_CLANG        ?= $(LLVM_DIR)/bin/clang
+LLVM_CLANGPP      ?= $(LLVM_DIR)/bin/clang++
+LLVM_OPT          ?= $(LLVM_DIR)/bin/opt
+LLVM_LLC          ?= $(LLVM_DIR)/bin/llc
+RUNTIME_FNS       ?= $(BSG_MANYCORE_DIR)/software/bsg_manycore_lib/bsg_tilegroup.h
+CLANG_TARGET_OPTS ?= --target=riscv32 -march=$(ARCH_OP) -mabi=$(ABI)
 
 ifdef LLVM_PASS
 PASS_DIR         ?= $(BSG_MANYCORE_DIR)/software/manycore-llvm-pass
@@ -209,13 +211,15 @@ $(LLVM_DIR):
 # Emit -O0 so that loads to consecutive memory locations aren't combined
 # Opt can run optimizations in any order, so it doesn't matter
 %.bc: %.c $(LLVM_DIR) $(RUNTIME_FNS)
-	$(LLVM_CLANG) --target=riscv32 $(RISCV_GCC_OPTS) -mabi=ilp32f \
+	$(LLVM_CLANG) $(CLANG_TARGET_OPTS) $(RISCV_GCC_OPTS) \
 		--sysroot=$(RISCV_BIN_DIR)/../riscv32-unknown-elf-dramfs \
 		$(OPT_LEVEL) $(spmd_defs) -c -emit-llvm $(INCS) $< -o $@
 
 # do the same for C++ sources
 %.bc: %.cpp $(LLVM_DIR) $(RUNTIME_FNS)
-	$(LLVM_CLANGPP) $(RISCV_GXX_OPTS) $(OPT_LEVEL) $(spmd_defs) -c -emit-llvm $(INCS) $< -o $@
+	$(LLVM_CLANGPP) $(CLANG_TARGET_OPTS) $(RISCV_GXX_OPTS) \
+		--sysroot=$(RISCV_BIN_DIR)/../riscv32-unknown-elf-dramfs \
+		$(OPT_LEVEL) $(spmd_defs) -c -emit-llvm $(INCS) $< -o $@
 
 ifdef LLVM_PASS
 PASS_OPTS = -load $(PASS_LIB) -manycore

--- a/software/mk/Makefile.builddefs
+++ b/software/mk/Makefile.builddefs
@@ -186,7 +186,7 @@ RISCV_GXX_OPTS += $(RISCV_GXX_EXTRA_OPTS)
 spmd_defs = -DPREALLOCATE=0 -DHOST_DEBUG=0
 
 ifdef CLANG
-LLVM_DIR         ?= $(BSG_MANYCORE_DIR)/software/riscv-tools/llvm/llvm-install
+LLVM_DIR         ?= $(BSG_MANYCORE_DIR)/../bsg-llvm-project/build
 LLVM_CLANG       ?= $(LLVM_DIR)/bin/clang
 LLVM_CLANGPP     ?= $(LLVM_DIR)/bin/clang++
 LLVM_OPT         ?= $(LLVM_DIR)/bin/opt
@@ -209,7 +209,7 @@ $(LLVM_DIR):
 # Emit -O0 so that loads to consecutive memory locations aren't combined
 # Opt can run optimizations in any order, so it doesn't matter
 %.bc: %.c $(LLVM_DIR) $(RUNTIME_FNS)
-	$(LLVM_CLANG) $(RISCV_GCC_OPTS) $(OPT_LEVEL) $(spmd_defs) -c -emit-llvm $(INCS) $< -o $@
+	$(LLVM_CLANG) $(filter-out -march=%, $(RISCV_GCC_OPTS)) --target=riscv32 $(OPT_LEVEL) $(spmd_defs) -c -emit-llvm $(INCS) $< -o $@
 
 # do the same for C++ sources
 %.bc: %.cpp $(LLVM_DIR) $(RUNTIME_FNS)
@@ -222,7 +222,7 @@ endif
 	$(LLVM_OPT) $(PASS_OPTS) $(OPT_LEVEL) $< -o $@
 
 %.bc.s: %.bc.pass
-	$(LLVM_LLC) $< -o $@
+	$(LLVM_LLC) -march=riscv32 $< -o $@
 
 %.o: %.bc.s
 	$(RISCV_GCC) $(RISCV_GCC_OPTS) $(OPT_LEVEL) -c $< -o $@

--- a/software/mk/Makefile.builddefs
+++ b/software/mk/Makefile.builddefs
@@ -209,7 +209,9 @@ $(LLVM_DIR):
 # Emit -O0 so that loads to consecutive memory locations aren't combined
 # Opt can run optimizations in any order, so it doesn't matter
 %.bc: %.c $(LLVM_DIR) $(RUNTIME_FNS)
-	$(LLVM_CLANG) $(filter-out -march=%, $(RISCV_GCC_OPTS)) --target=riscv32 $(OPT_LEVEL) $(spmd_defs) -c -emit-llvm $(INCS) $< -o $@
+	$(LLVM_CLANG) $(filter-out -march=%, $(RISCV_GCC_OPTS)) --target=riscv32 \
+		--sysroot=$(RISCV_BIN_DIR)/../riscv32-unknown-elf-dramfs \
+		$(OPT_LEVEL) $(spmd_defs) -c -emit-llvm $(INCS) $< -o $@
 
 # do the same for C++ sources
 %.bc: %.cpp $(LLVM_DIR) $(RUNTIME_FNS)

--- a/software/mk/Makefile.builddefs
+++ b/software/mk/Makefile.builddefs
@@ -193,7 +193,7 @@ LLVM_CLANGPP      ?= $(LLVM_DIR)/bin/clang++
 LLVM_OPT          ?= $(LLVM_DIR)/bin/opt
 LLVM_LLC          ?= $(LLVM_DIR)/bin/llc
 CLANG_TARGET_OPTS ?= --target=riscv32 -march=$(ARCH_OP) -mabi=$(ABI)
-ifdef LLVM_PASS
+ifdef ENABLE_LLVM_PASSES
 PASS_DIR          ?= $(BSG_MANYCORE_DIR)/software/manycore-llvm-pass
 PASS_LIB          ?= build/manycore/libManycorePass.so
 endif
@@ -222,7 +222,7 @@ $(LLVM_DIR):
 		-I$(RISCV_BIN_DIR)/../riscv32-unknown-elf-dramfs/include/c++/9.2.0/riscv32-unknown-elf-dramfs \
 		$(OPT_LEVEL) $(spmd_defs) -c -emit-llvm $(INCS) $< -o $@
 
-ifdef LLVM_PASS
+ifdef ENABLE_LLVM_PASSES
 PASS_OPTS = -load $(PASS_LIB) -manycore
 endif
 %.bc.pass: %.bc $(PASS_LIB)
@@ -234,7 +234,7 @@ endif
 %.o: %.bc.s
 	$(RISCV_GCC) $(RISCV_GCC_OPTS) $(OPT_LEVEL) -c $< -o $@
 
-ifdef LLVM_PASS
+ifdef ENABLE_LLVM_PASSES
 $(PASS_LIB): $(PASS_DIR)/manycore/Manycore.cpp $(LLVM_DIR)
 	mkdir -p build
 	cd build && LLVM_DIR=$(LLVM_DIR) cmake3 $(PASS_DIR) -Dbsg_group_size:INTEGER=$(bsg_group_size) && make

--- a/software/mk/Makefile.builddefs
+++ b/software/mk/Makefile.builddefs
@@ -209,7 +209,7 @@ $(LLVM_DIR):
 # Emit -O0 so that loads to consecutive memory locations aren't combined
 # Opt can run optimizations in any order, so it doesn't matter
 %.bc: %.c $(LLVM_DIR) $(RUNTIME_FNS)
-	$(LLVM_CLANG) $(filter-out -march=%, $(RISCV_GCC_OPTS)) --target=riscv32 \
+	$(LLVM_CLANG) --target=riscv32 $(RISCV_GCC_OPTS) -mabi=ilp32f \
 		--sysroot=$(RISCV_BIN_DIR)/../riscv32-unknown-elf-dramfs \
 		$(OPT_LEVEL) $(spmd_defs) -c -emit-llvm $(INCS) $< -o $@
 
@@ -224,7 +224,7 @@ endif
 	$(LLVM_OPT) $(PASS_OPTS) $(OPT_LEVEL) $< -o $@
 
 %.bc.s: %.bc.pass
-	$(LLVM_LLC) -march=riscv32 $< -o $@
+	$(LLVM_LLC) $< -o $@
 
 %.o: %.bc.s
 	$(RISCV_GCC) $(RISCV_GCC_OPTS) $(OPT_LEVEL) -c $< -o $@

--- a/software/mk/Makefile.builddefs
+++ b/software/mk/Makefile.builddefs
@@ -191,9 +191,12 @@ LLVM_CLANG       ?= $(LLVM_DIR)/bin/clang
 LLVM_CLANGPP     ?= $(LLVM_DIR)/bin/clang++
 LLVM_OPT         ?= $(LLVM_DIR)/bin/opt
 LLVM_LLC         ?= $(LLVM_DIR)/bin/llc
+RUNTIME_FNS      ?= $(BSG_MANYCORE_DIR)/software/bsg_manycore_lib/bsg_tilegroup.h
+
+ifdef LLVM_PASS
 PASS_DIR         ?= $(BSG_MANYCORE_DIR)/software/manycore-llvm-pass
 PASS_LIB         ?= build/manycore/libManycorePass.so
-RUNTIME_FNS      ?= $(BSG_MANYCORE_DIR)/software/bsg_manycore_lib/bsg_tilegroup.h
+endif
 
 $(LLVM_DIR):
 	@echo "LLVM is not installed! Follow build instructions in the TRM and \
@@ -205,15 +208,18 @@ $(LLVM_DIR):
 
 # Emit -O0 so that loads to consecutive memory locations aren't combined
 # Opt can run optimizations in any order, so it doesn't matter
-%.bc: %.c $(PASS_LIB) $(LLVM_DIR) $(RUNTIME_FNS)
+%.bc: %.c $(LLVM_DIR) $(RUNTIME_FNS)
 	$(LLVM_CLANG) $(RISCV_GCC_OPTS) $(OPT_LEVEL) $(spmd_defs) -c -emit-llvm $(INCS) $< -o $@
 
 # do the same for C++ sources
-%.bc: %.cpp $(PASS_LIB) $(LLVM_DIR) $(RUNTIME_FNS)
+%.bc: %.cpp $(LLVM_DIR) $(RUNTIME_FNS)
 	$(LLVM_CLANGPP) $(RISCV_GXX_OPTS) $(OPT_LEVEL) $(spmd_defs) -c -emit-llvm $(INCS) $< -o $@
 
-%.bc.pass: %.bc
-	$(LLVM_OPT) -load $(PASS_LIB) -manycore $(OPT_LEVEL) $< -o $@
+ifdef LLVM_PASS
+PASS_OPTS = -load $(PASS_LIB) -manycore
+endif
+%.bc.pass: %.bc $(PASS_LIB)
+	$(LLVM_OPT) $(PASS_OPTS) $(OPT_LEVEL) $< -o $@
 
 %.bc.s: %.bc.pass
 	$(LLVM_LLC) $< -o $@
@@ -221,10 +227,11 @@ $(LLVM_DIR):
 %.o: %.bc.s
 	$(RISCV_GCC) $(RISCV_GCC_OPTS) $(OPT_LEVEL) -c $< -o $@
 
-
+ifdef LLVM_PASS
 $(PASS_LIB): $(PASS_DIR)/manycore/Manycore.cpp $(LLVM_DIR)
 	mkdir -p build
 	cd build && LLVM_DIR=$(LLVM_DIR) cmake3 $(PASS_DIR) -Dbsg_group_size:INTEGER=$(bsg_group_size) && make
+endif
 
 else
 %.o: %.c

--- a/software/mk/Makefile.builddefs
+++ b/software/mk/Makefile.builddefs
@@ -188,6 +188,7 @@ spmd_defs = -DPREALLOCATE=0 -DHOST_DEBUG=0
 ifdef CLANG
 LLVM_DIR         ?= $(BSG_MANYCORE_DIR)/software/riscv-tools/llvm/llvm-install
 LLVM_CLANG       ?= $(LLVM_DIR)/bin/clang
+LLVM_CLANGPP     ?= $(LLVM_DIR)/bin/clang++
 LLVM_OPT         ?= $(LLVM_DIR)/bin/opt
 LLVM_LLC         ?= $(LLVM_DIR)/bin/llc
 PASS_DIR         ?= $(BSG_MANYCORE_DIR)/software/manycore-llvm-pass
@@ -209,7 +210,7 @@ $(LLVM_DIR):
 
 # do the same for C++ sources
 %.bc: %.cpp $(PASS_LIB) $(LLVM_DIR) $(RUNTIME_FNS)
-	$(LLVM_CLANG) $(RISCV_GXX_OPTS) $(OPT_LEVEL) $(spmd_defs) -c -emit-llvm $(INCS) $< -o $@
+	$(LLVM_CLANGPP) $(RISCV_GXX_OPTS) $(OPT_LEVEL) $(spmd_defs) -c -emit-llvm $(INCS) $< -o $@
 
 %.bc.pass: %.bc
 	$(LLVM_OPT) -load $(PASS_LIB) -manycore $(OPT_LEVEL) $< -o $@

--- a/software/mk/Makefile.llvminstall
+++ b/software/mk/Makefile.llvminstall
@@ -6,28 +6,29 @@ ifndef RISCV_INSTALL_DIR
     $(error Need to define RISCV_INSTALL_DIR)
 endif
 
+# devtoolset-8
+HOST_TOOLCHAIN ?= /opt/rh/devtoolset-8/root/usr/bin
+
 llvm-install:
 	mkdir -p $(LLVM_DIR)/llvm-build && mkdir -p $(LLVM_DIR)/llvm-install
-	# Clone LLVM sources
-	cd $(LLVM_DIR) && wget http://releases.llvm.org/7.0.1/llvm-7.0.1.src.tar.xz && \
-	    tar -xf llvm-7.0.1.src.tar.xz && mv llvm-7.0.1.src llvm-src && rm llvm-7.0.1.src.tar.xz
-	# Clone clang sources
-	cd $(LLVM_DIR)/llvm-src/tools && wget http://releases.llvm.org/7.0.1/cfe-7.0.1.src.tar.xz \
-	    && tar -xf cfe-7.0.1.src.tar.xz && mv cfe-7.0.1.src clang && rm cfe-7.0.1.src.tar.xz
-	# -DGCC_INSTALL_PREFIX, -DDEFAULT_SYSROOT, -DLLVM_DEFAULT_TARGET_TRIPLE
-	# aren't strictly necessary, but otherwise there'd be more options to
-	# pass on the command line for clang. We Only need X86 and RISCV targets.
+	# Get LLVM sources
+	cd $(LLVM_DIR) && \
+	  wget https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.0/llvm-10.0.0.src.tar.xz \
+	    && tar -xf llvm-10.0.0.src.tar.xz && mv llvm-10.0.0.src llvm-src && rm llvm-10.0.0.src.tar.xz
+	# Get Clang sources
+	cd $(LLVM_DIR)/llvm-src/tools && \
+	  wget https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.0/clang-10.0.0.src.tar.xz \
+	    && tar -xf clang-10.0.0.src.tar.xz && mv clang-10.0.0.src clang && rm clang-10.0.0.src.tar.xz
+	# Install only X86 and RISCV targets
 	cd $(LLVM_DIR)/llvm-build \
 	    && cmake3 -DCMAKE_BUILD_TYPE="Debug" \
-	    -DLLVM_TARGETS_TO_BUILD="X86" \
-	    -DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD="RISCV" \
+	    -DCMAKE_C_COMPILER=$(HOST_TOOLCHAIN)/gcc \
+	    -DCMAKE_CXX_COMPILER=$(HOST_TOOLCHAIN)/g++ \
+	    -DLLVM_TARGETS_TO_BUILD="X86;RISCV" \
 	    -DBUILD_SHARED_LIBS=True \
 	    -DLLVM_USE_SPLIT_DWARF=True \
 	    -DLLVM_OPTIMIZED_TABLEGEN=True \
 	    -DCMAKE_INSTALL_PREFIX="$(LLVM_DIR)/llvm-install" \
-	    -DGCC_INSTALL_PREFIX="$(LLVM_DIR)/local" \
-	    -DDEFAULT_SYSROOT="$(RISCV_INSTALL_DIR)/riscv32-unknown-elf" \
-	    -DLLVM_DEFAULT_TARGET_TRIPLE="riscv32-unknown-elf" \
 	    ../llvm-src
 	cd  $(LLVM_DIR)/llvm-build && cmake3 --build . -- -j12 && make install
 	rm -rf $(LLVM_DIR)/llvm-build $(LLVM_DIR)/llvm-src

--- a/software/spmd/Makefile
+++ b/software/spmd/Makefile
@@ -27,7 +27,9 @@ endif
 
 ENABLE_VCACHE=1
 
-export LLVM_DIR=/mnt/bsg/diskbits/neilryan/llvm/llvm-install
+ifdef CLANG
+  export CLANG=1
+endif
 
 ###############################################
 # VCS Unified Coverage Report Generator options

--- a/software/spmd/c++/Makefile
+++ b/software/spmd/c++/Makefile
@@ -1,14 +1,14 @@
-BSG_MANYCORE_DIR ?= ../../..
-
 bsg_tiles_X = 1
-bsg_tileS_Y = 1
+bsg_tiles_Y = 1
+
+all: main.run
 
 OBJECT_FILES := main.o
 
-include $(BSG_MANYCORE_DIR)/software/spmd/Makefile.include
+include ../Makefile.include
 
-main.riscv: $(LINK_SCRIPT) $(OBJECT_FILES) $(SPMD_COMMON_OBJECTS)
-	$(RISCV_LINK)  $(filter %.o, $^) -o $@ $(RISCV_LINK_OPTS)
+main.riscv: $(LINK_SCRIPT) $(OBJECT_FILES) $(SPMD_COMMON_OBJECTS) $(BSG_MANYCORE_LIB)
+	$(RISCV_LINK)  $(filter %.o, $^) -L. "-l:$(BSG_MANYCORE_LIB)" -o $@ $(RISCV_LINK_OPTS)
 
 main.o: Makefile
 

--- a/software/spmd/c++/main.cpp
+++ b/software/spmd/c++/main.cpp
@@ -1,11 +1,22 @@
+#include <cstring>
+#include "bsg_manycore.h"
+#include "bsg_set_tile_x_y.h"
+
 class A {
 public:
         A(int member = 0) : member(member) {}
         int member;
 };
+
 int main(void)
 {
         A a;
         a = 2;
-        return 0;
+
+        char s[] = "12345";
+        if(strlen(s) != 5) {
+          bsg_fail();
+        }
+
+        bsg_finish();
 }


### PR DESCRIPTION
Neil built a great flow for compiling and running llvm, including a pass. This PR extends that with the following:
- Cross-compiling with generic LLVM build. So Manycore can work with system LLVM! (Provided, system LLVM is >=9.0.0)
- Ability to use C/C++ standard libraries. 
- Options for compiling with accurate ABI and ISA extensions.
- Option to enable/disable the pass.
- With C/C++ stdlib support, any program using `Makefile.builddefs` can be compiled with LLVM now: just run `make CLANG=1`.

Regression with LLVM: 
- Only three tests fail with Clang enabled: `bsg_tile_group_barrier`  `bypass_core` and `bsg_lr_acq`!!!
- May be an extra setting is required for correct atomic support, or could be a problem with codegen for atomics. Will look into it later, as the current priority is updating the cost model.
