### PR TITLE
Testcase to compare NANs

### DIFF
--- a/software/spmd/bsg_cuda_lite_runtime/float_all_ops/Makefile
+++ b/software/spmd/bsg_cuda_lite_runtime/float_all_ops/Makefile
@@ -24,6 +24,8 @@ OBJECT_FILES=main.o kernel_float_all_ops.o
 
 include ../../Makefile.include
 
+RISCV_GCC_EXTRA_OPTS = -fno-fast-math
+RISCV_GXX_EXTRA_OPTS = -fno-fast-math
 
 main.riscv: $(LINK_SCRIPT) $(OBJECT_FILES) $(SPMD_COMMON_OBJECTS) $(BSG_MANYCORE_LIB) ../../common/crt.o
 	$(RISCV_LINK) $(OBJECT_FILES) $(SPMD_COMMON_OBJECTS) -L. "-l:$(BSG_MANYCORE_LIB)" -o $@ $(RISCV_LINK_OPTS)

--- a/software/spmd/float_cmp/Makefile
+++ b/software/spmd/float_cmp/Makefile
@@ -1,0 +1,18 @@
+bsg_tiles_X = 1
+bsg_tiles_Y = 1
+
+
+all: main.run
+
+
+OBJECT_FILES=main.o
+
+include ../Makefile.include
+
+main.riscv: $(LINK_SCRIPT) $(OBJECT_FILES) $(SPMD_COMMON_OBJECTS) $(BSG_MANYCORE_LIB) crt.o
+	$(RISCV_LINK) $(OBJECT_FILES) $(SPMD_COMMON_OBJECTS) -L. "-l:$(BSG_MANYCORE_LIB)" -o $@ $(RISCV_LINK_OPTS)
+
+
+main.o: Makefile
+
+include ../../mk/Makefile.tail_rules

--- a/software/spmd/float_cmp/Makefile
+++ b/software/spmd/float_cmp/Makefile
@@ -9,6 +9,10 @@ OBJECT_FILES=main.o
 
 include ../Makefile.include
 
+# This makes sure compiler doesn't perform unsafe optimizations with
+# INFs and NaNs.
+RISCV_GCC_EXTRA_OPTS = -fno-fast-math
+
 main.riscv: $(LINK_SCRIPT) $(OBJECT_FILES) $(SPMD_COMMON_OBJECTS) $(BSG_MANYCORE_LIB) crt.o
 	$(RISCV_LINK) $(OBJECT_FILES) $(SPMD_COMMON_OBJECTS) -L. "-l:$(BSG_MANYCORE_LIB)" -o $@ $(RISCV_LINK_OPTS)
 

--- a/software/spmd/float_cmp/main.c
+++ b/software/spmd/float_cmp/main.c
@@ -1,0 +1,27 @@
+#include "bsg_manycore.h"
+#include "bsg_set_tile_x_y.h"
+#include <math.h>
+
+float A[1] = {NAN};
+
+int main()
+{
+  bsg_set_tile_x_y();
+
+  if (__bsg_id == 0)
+  {
+    int a = (NAN >= NAN) ? 1 : 0;
+    int b = (A[0] >= A[0]) ? 1 : 0;
+
+    if(a != b) {
+      bsg_printf("Error: mismatch with NAN >= NAN:\n");
+      bsg_printf("     Hardcoded comparison reuslted in %d\n", a);
+      bsg_printf("     Array element comparison reuslted in %d\n", b);
+      bsg_fail();
+    }
+
+    bsg_finish();
+  }
+
+  bsg_wait_while(1);
+}

--- a/software/spmd/float_cmp/main.c
+++ b/software/spmd/float_cmp/main.c
@@ -13,8 +13,8 @@ int main()
     int a = (NAN >= NAN) ? 1 : 0;
     int b = (A[0] >= A[0]) ? 1 : 0;
 
-    if(a != b) {
-      bsg_printf("Error: mismatch with NAN >= NAN:\n");
+    if(a != 0 || b != 0) {
+      bsg_printf("Error: NAN >= NAN is equal to 0, but got following...\n");
       bsg_printf("     Hardcoded comparison reuslted in %d\n", a);
       bsg_printf("     Array element comparison reuslted in %d\n", b);
       bsg_fail();


### PR DESCRIPTION
Checks NAN comparison compliance by disabling `-ffast-math` optimizations.