### PR TITLE
Target specific LLVM flags; Utility macros for Clang.

### DIFF
--- a/software/mk/Makefile.builddefs
+++ b/software/mk/Makefile.builddefs
@@ -197,7 +197,7 @@ CLANG_TARGET_OPTS ?= --target=riscv32 -march=$(ARCH_OP) -mabi=$(ABI)
 # Ideally LLC should infer targets option provided to Clang. But LLC 11.0.0 fails
 # to infer the architecture extensions correctly. Hence the information is repeated
 # in LLC target options below.
-LLC_TARGET_OPTS   ?= -march=riscv32 -mattr=+m,+a,+f
+LLC_TARGET_OPTS   ?= -march=riscv32 -mcpu=hb-rv32 -mattr=+m,+a,+f
 
 ifdef ENABLE_LLVM_PASSES
 PASS_DIR          ?= $(BSG_MANYCORE_DIR)/software/manycore-llvm-pass

--- a/software/mk/Makefile.builddefs
+++ b/software/mk/Makefile.builddefs
@@ -193,10 +193,17 @@ LLVM_CLANGPP      ?= $(LLVM_DIR)/bin/clang++
 LLVM_OPT          ?= $(LLVM_DIR)/bin/opt
 LLVM_LLC          ?= $(LLVM_DIR)/bin/llc
 CLANG_TARGET_OPTS ?= --target=riscv32 -march=$(ARCH_OP) -mabi=$(ABI)
+
+# Ideally LLC should infer targets option provided to Clang. But LLC 11.0.0 fails
+# to infer the architecture extensions correctly. Hence the information is repeated
+# in LLC target options below.
+LLC_TARGET_OPTS   ?= -march=riscv32 -mattr=+m,+a,+f
+
 ifdef ENABLE_LLVM_PASSES
 PASS_DIR          ?= $(BSG_MANYCORE_DIR)/software/manycore-llvm-pass
 PASS_LIB          ?= build/manycore/libManycorePass.so
 endif
+
 RUNTIME_FNS       ?= $(BSG_MANYCORE_DIR)/software/bsg_manycore_lib/bsg_tilegroup.h
 
 $(LLVM_DIR):
@@ -229,7 +236,7 @@ endif
 	$(LLVM_OPT) $(PASS_OPTS) $(OPT_LEVEL) -S $< -o $@
 
 %.ll.s: %.ll.pass
-	$(LLVM_LLC) $< -o $@
+	$(LLVM_LLC) $(LLC_TARGET_OPTS) $< -o $@
 
 %.o: %.ll.s
 	$(RISCV_GCC) $(RISCV_GCC_OPTS) $(OPT_LEVEL) -c $< -o $@

--- a/software/mk/Makefile.llvminstall
+++ b/software/mk/Makefile.llvminstall
@@ -5,6 +5,14 @@ endif
 # devtoolset-8
 HOST_TOOLCHAIN ?= /opt/rh/devtoolset-8/root/usr/bin
 
+# Build tool: Pick ninja over make if available
+ifndef GENERATOR
+  GENERATOR = 'Unix Makefiles'
+  ifneq (,$(shell which ninja))
+    GENERATOR = 'Ninja'
+  endif
+endif
+
 llvm-install:
 	mkdir -p $(LLVM_DIR)/llvm-build && mkdir -p $(LLVM_DIR)/llvm-install
 	# Get LLVM sources
@@ -13,7 +21,7 @@ llvm-install:
     cd ./llvm-src && git fetch && git checkout hb-dev
 	# Install only X86 and RISCV targets
 	cd $(LLVM_DIR)/llvm-build \
-	    && cmake3 -DCMAKE_BUILD_TYPE="Debug" \
+	    && cmake3 -G $(GENERATOR) -DCMAKE_BUILD_TYPE="Debug" \
       -DLLVM_ENABLE_PROJECTS="clang" \
 	    -DCMAKE_INSTALL_PREFIX="$(LLVM_DIR)/llvm-install" \
 	    -DCMAKE_C_COMPILER=$(HOST_TOOLCHAIN)/gcc \
@@ -23,4 +31,4 @@ llvm-install:
 	    -DLLVM_USE_SPLIT_DWARF=True \
 	    -DLLVM_OPTIMIZED_TABLEGEN=True \
 	    ../llvm-src/llvm
-	cd  $(LLVM_DIR)/llvm-build && cmake3 --build . -- -j12 && make install
+	cd  $(LLVM_DIR)/llvm-build && cmake3 --build . --target install -- -j 12

--- a/software/mk/Makefile.tail_rules
+++ b/software/mk/Makefile.tail_rules
@@ -37,6 +37,6 @@ clean:
 	-rm -rf *.o *.a *.jou *.log *.pelog *.pb bsg_manycore_io_complex_rom.v *.riscv *.wdb *.bin *.hex *.ld
 	-rm -rf xsim.dir *.mem stack.info.*
 	-rm -rf ./simv csrc simv.daidir ucli.key DVEfiles *.vpd *.vdb coverage* constfile.txt
-	-rm -rf build/ *.bc*
+	-rm -rf build/ *.bc* *.ll*
 	-rm -rf lfs.c *.nbf *.csv
 	-rm -rf $(CLEAN_ITEMS)


### PR DESCRIPTION
- Added target specific flags to `llc` command, to be safe with future versions of LLVM.
- Added `-fno-fast-math` flag to `float_all_ops` testcase, as this testcase specifically tests FP compliance.