### PR TITLE
Change BEEBS repeat factor to 1

### DIFF
--- a/software/spmd/beebs/Makefile
+++ b/software/spmd/beebs/Makefile
@@ -19,7 +19,7 @@ include $(BSG_MANYCORE_DIR)/software/spmd/beebs/Makefile.bmarklist
 bsg_tiles_X = 1
 bsg_tiles_Y = 1
 
-REPEAT_FACTOR = 2 # Number of iterations each benchmark is run
+REPEAT_FACTOR = 1 # Number of iterations each benchmark is run
 
 BEEBS_DIR := $(BSG_MANYCORE_DIR)/imports/beebs
 RUN_DIR := $(BSG_MANYCORE_DIR)/software/spmd/beebs


### PR DESCRIPTION
We currently use beebs as a test rather than a benchmark. So, reduced the repeat factor to just 1 so that we don't have to wait disproportionately long for beebs to finish.