### PR TITLE
Fixed Profilers for Verilator

### DIFF
--- a/testbenches/common/v/bsg_manycore_link_to_cache_tracer.v
+++ b/testbenches/common/v/bsg_manycore_link_to_cache_tracer.v
@@ -40,15 +40,16 @@ module bsg_manycore_link_to_cache_tracer
 
   integer fd;
 
-  initial begin
-    #1;
+   always @(negedge reset_i)
     if (trace_en_i) begin
       fd = $fopen("vcache.log", "w");
       $fwrite(fd, "");
       $fclose(fd);
+    end
+   
+   always @(negedge clk_i) begin
+      if (trace_en_i) begin
 
-      forever begin
-        @(negedge clk_i) begin
           if (~reset_i) begin
             if (v_o & ready_i) begin
               fd = $fopen("vcache.log", "a");
@@ -69,11 +70,7 @@ module bsg_manycore_link_to_cache_tracer
 
               $fclose(fd);
             end
-          end
-        end
-      end
-    end
-  end
-
-
+          end // if (~reset_i)
+      end // if (trace_en_i)
+   end // always @ (negedge clk_i)
 endmodule

--- a/testbenches/common/v/infinite_mem_profiler.v
+++ b/testbenches/common/v/infinite_mem_profiler.v
@@ -46,10 +46,10 @@ module infinite_mem_profiler
 
   always_ff @ (posedge clk_i) begin
     if (reset_i) begin
-      ld_count_r <= '0;
-      st_count_r <= '0;
-      amoswap_count_r <= 0;
-      amoor_count_r <= 0;
+      ld_count_r = '0;
+      st_count_r = '0;
+      amoswap_count_r = 0;
+      amoor_count_r = 0;
     end
     else begin
       if (inc_ld) ld_count_r++;
@@ -63,19 +63,21 @@ module infinite_mem_profiler
   //
 
   integer fd;
-
-  initial begin
-  
-    #1; // we need to wait for one time unit so that my_x_i becomes a known value.
-
-    if (my_x_i == '0) begin
+  string header;
+   initial begin
       fd = $fopen(logfile_p, "w");
+      $fwrite(fd,"");
+   end
+
+  always @(negedge reset_i) begin
+     if (my_x_i == '0) begin
+      fd = $fopen(logfile_p, "a");
       $fwrite(fd, "x,y,global_ctr,tag,ld,st,amoswap,amoor\n");
       $fclose(fd);
     end
+  end
 
-    forever begin
-      @(negedge clk_i) begin
+   always @(negedge clk_i) begin
         if (~reset_i & print_stat_v_i) begin
           fd = $fopen(logfile_p, "a");
           $fwrite(fd, "%0d,%0d,%0d,%0d,%0d,%0d,%0d,%0d\n",
@@ -83,9 +85,8 @@ module infinite_mem_profiler
             amoswap_count_r,amoor_count_r);   
           $fclose(fd);
         end
-      end
-    end
-  end
+   end
+   
 
 
 endmodule

--- a/testbenches/common/v/instr_trace.v
+++ b/testbenches/common/v/instr_trace.v
@@ -26,9 +26,9 @@ module instr_trace
     fd = $fopen("instr.log", "w");
     $fwrite(fd, "");
     $fclose(fd);
+  end
 
-    forever begin
-      @(negedge clk_i) begin
+   always @(negedge clk_i) begin
       if (my_x_i == 1'b0 & my_y_i == 2'b01 & ~reset_i && (trace_en_i == 1)) begin //
 
         fd = $fopen("instr.log", "a");
@@ -43,11 +43,7 @@ module instr_trace
     
         $fclose(fd);
 
-      end //
       end
-    end
-    
-
-  end
-
+   end
+   
 endmodule

--- a/testbenches/common/v/vanilla_core_profiler.v
+++ b/testbenches/common/v/vanilla_core_profiler.v
@@ -616,11 +616,11 @@ module vanilla_core_profiler
 
   always_ff @ (posedge clk_i) begin
     if (reset_i) begin
-      stat_r <= '0;
+         stat_r = '0;
     end
     else begin
       stat_r.cycle++;
-      stat_r.instr <= stat_r.instr + instr_inc + fp_instr_inc;
+         stat_r.instr = stat_r.instr + instr_inc + fp_instr_inc;
 
       if (stall_all) begin
         if (stall_remote_ld_wb) stat_r.stall_remote_ld_wb++;
@@ -770,14 +770,15 @@ module vanilla_core_profiler
 
   integer fd, fd2;
   string header;
+   initial begin
+      fd = $fopen(logfile_lp, "w");
+      $fwrite(fd,"");
+   end
 
-  initial begin
-  
-    #1; // we need to wait for one time unit so that my_x_i and my_y_i becomes a known value.
-
+   always @(negedge reset_i) begin      
     // the origin tile opens the logfile and writes the csv header.
     if ((my_x_i == x_cord_width_p'(origin_x_cord_p)) & (my_y_i == y_cord_width_p'(origin_y_cord_p))) begin
-      fd = $fopen(logfile_lp, "w");
+      fd = $fopen(logfile_lp, "a");
       $fwrite(fd, "time,");
       $fwrite(fd, "x,");
       $fwrite(fd, "y,");
@@ -927,10 +928,11 @@ module vanilla_core_profiler
         $fwrite(fd2, "cycle,x,y,pc,operation\n");
         $fclose(fd2);
       end
-    end
+    end // if ((my_x_i == x_cord_width_p'(origin_x_cord_p)) & (my_y_i == y_cord_width_p'(origin_y_cord_p)))
+   end // always @ (my_x_i)
+   
 
-    forever begin
-      @(negedge clk_i)  begin
+   always @(negedge clk_i)  begin
         // stat printing
         if (~reset_i & print_stat_v_i & print_stat_tag.y_cord == my_y_i & print_stat_tag.x_cord == my_x_i) begin
           $display("[BSG_INFO][VCORE_PROFILER] t=%0t x,y=%02d,%02d printing stats.", $time, my_x_i, my_y_i);
@@ -1221,19 +1223,7 @@ module vanilla_core_profiler
 
           $fclose(fd2);
         end
-      end
-    end
-
-
-  end
-
-
-
-
-
-
-
-
+   end // always @ (negedge clk_i)
 
    // DPI Profiler interface. See interface comments below.
    export "DPI-C" function bsg_dpi_init;

--- a/testbenches/common/v/vanilla_core_trace.v
+++ b/testbenches/common/v/vanilla_core_trace.v
@@ -150,7 +150,7 @@ module vanilla_core_trace
           remote_store_data: exe_debug.remote_store_data
         };
 
-        wb_debug <= {
+        wb_debug <= '{
           pc: mem_debug.pc,
           instr: mem_debug.instr,
           branch_or_jump: mem_debug.branch_or_jump,
@@ -198,10 +198,9 @@ module vanilla_core_trace
     fd = $fopen("vanilla.log","w");
     $fwrite(fd, "");
     $fclose(fd);
+  end
 
-    forever begin
-
-      @(negedge clk_i) begin
+  always @(negedge clk_i) begin
         stamp = "";
         pc_instr = "";
         fp_pc_instr = "";
@@ -295,12 +294,9 @@ module vanilla_core_trace
 
           $fclose(fd);
 
-
-
-        end
-      end
-    end
-  end
+        end // if (~reset_i & (trace_en_i == 1))     
+  end // always @ (negedge clk_i)
+   
  
 
 

--- a/testbenches/common/v/vcache_non_blocking_profiler.v
+++ b/testbenches/common/v/vcache_non_blocking_profiler.v
@@ -128,7 +128,7 @@ module vcache_non_blocking_profiler
 
   always_ff @ (posedge clk_i) begin
     if (reset_i) begin
-      stat_r <= '0;
+      stat_r = '0;
     end
     else begin
       if (ld_hit_inc) stat_r.ld_hit++;
@@ -160,9 +160,10 @@ module vcache_non_blocking_profiler
       $fwrite(fd, "instance,global_ctr,tag,ld_hit,st_hit,ld_hit_under_miss,st_hit_under_miss,ld_miss,st_miss,ld_mhu,st_mhu,dma_read_req,dma_write_req\n");
       $fclose(fd);
     end
+  end
+   
   
-    forever begin
-      @(negedge clk_i) begin
+   always @(negedge clk_i) begin
         if (~reset_i & print_stat_v_i) begin
 
           $display("[BSG_INFO][VCACHE_PROFILER] %s t=%0t printing stats.", my_name, $time);
@@ -178,10 +179,8 @@ module vcache_non_blocking_profiler
           );   
           $fclose(fd);
         end
-      end
-    end
-
-  end 
+   end
+   
 
 
   // string match helper

--- a/testbenches/common/v/vcache_profiler.v
+++ b/testbenches/common/v/vcache_profiler.v
@@ -143,7 +143,7 @@ module vcache_profiler
   always_ff @ (posedge clk_i) begin
 
     if (reset_i) begin
-      stat_r <= '0;
+      stat_r = '0;
     end
     else begin
 
@@ -218,11 +218,11 @@ module vcache_profiler
         $fclose(trace_fd);
       //end
     end
+  end
 
 
 
-    forever begin
-      @(negedge clk_i) begin
+    always @(negedge clk_i) begin
         if (~reset_i & print_stat_v_i) begin
 
           $display("[BSG_INFO][VCACHE_PROFILER] %s t=%0t printing stats.", my_name, $time);
@@ -375,11 +375,8 @@ module vcache_profiler
           end
 
           $fclose(trace_fd);
-        end
-
-      end
-    end
-  end
+        end // if (~reset_i & trace_en_i)
+    end // always @ (negedge clk_i)
 
 
   // string match helper


### PR DESCRIPTION
Verilator added support for $root, so I took another stab at this. This is the first (and most important?) of the profilers. 

In general: 

- Replaced forever with `always @(negedge clk_i)`
- Replaced `#1` with `always @(my_x_i)` on the assumption that my_x_i and my_y_i only change once
- Fixed an issue where stat_r had both blocking and non-blocking assignments. 

I'm least comfortable with replacing `#1` with `always @(my_x_i)`. It seems like we have to guarantee that `my_y_i` has to change before `my_x_i. @tommydcjung Do you have any ideas here?

Also, apologies. My text editor "fixed" indentation and inserted whitespace. Turn on ignore whitespace changes to see the 30-ish lines I had to change.