### PR TITLE
DPI interface for profiler

### DIFF
--- a/testbenches/common/v/vanilla_core_profiler.v
+++ b/testbenches/common/v/vanilla_core_profiler.v
@@ -1323,7 +1323,7 @@ module vanilla_core_profiler
                    stat_r.fcvt_s_w + stat_r.fcvt_s_wu +
                    stat_r.fcvt_w_s + stat_r.fcvt_wu_s +
                    stat_r.fmv_w_x + stat_r.fmv_x_w +
-                   2 * stat_r.fmadd +
+                   2 * stat_r.fmadd + // Fused multiply-add counts as two instructions in FLOP statistics
                    stat_r.fmsub + stat_r.fnmsub + stat_r.fnmadd +
                    stat_r.feq + stat_r.flt + stat_r.fle +
                    stat_r.fclass +

--- a/testbenches/common/v/vanilla_core_profiler.v
+++ b/testbenches/common/v/vanilla_core_profiler.v
@@ -1248,6 +1248,8 @@ module vanilla_core_profiler
    logic init_l;
    initial begin
       init_l = 0;
+      $display("BSG INFO: Profiler %M");
+      
    end
 
    // Initialize this Manycore DPI Interface
@@ -1273,7 +1275,13 @@ module vanilla_core_profiler
       if(reset_i)
         $display("BSG_WARN: bsg_dpi_vanilla_core_profiler called while tile is in reset");
 
-      return (clk_i & edgepol_l & ~reset_i);
+      // Originally, this was : 
+      //     return (clk_i & edgepol_l & ~reset_i);
+      //
+      // However, in delay based simulation environments (i.e. VCS)
+      // where # is supported, it is possible to call this method at
+      // strange times.
+      return (~reset_i);
    endfunction
 
    // Instruction class queries that are supported by the
@@ -1296,6 +1304,7 @@ module vanilla_core_profiler
          $fatal(1, "BSG ERROR (%M): get_instr_count() called while reset_i === 1");
       end
 
+      /* See comment in is_window, above. Keeping for posterity.
       if(clk_i === 0) begin
          $fatal(1, "BSG ERROR (%M): get_instr_count() must be called when clk_i == 1");
       end
@@ -1303,7 +1312,7 @@ module vanilla_core_profiler
       if(edgepol_l === 0) begin
          $fatal(1, "BSG ERROR (%M): get_instr_count() must be called after the positive edge of clk_i has been evaluated");
       end
-
+       */
       case (itype)
         e_instr_float: begin
            // Return the total number of floating point operations

--- a/testbenches/dpi/vanilla_core_profiler.hpp
+++ b/testbenches/dpi/vanilla_core_profiler.hpp
@@ -40,7 +40,7 @@ namespace bsg_nonsynth_dpi{
                  * @return a valid instance of dpi_vanilla_core_profiler
                  */
                 dpi_vanilla_core_profiler(const std::string &hierarchy)
-                        : dpi_base("TOP.manycore_tb_top.manycore.y[1].x[0].tile.proc.h.z.vcore.vcore_prof")
+                        : dpi_base(hierarchy)
                 {
                 }
                 

--- a/testbenches/dpi/vanilla_core_profiler.hpp
+++ b/testbenches/dpi/vanilla_core_profiler.hpp
@@ -1,0 +1,81 @@
+// This header file defines a C++ API that wraps the System Verilog
+// DPI provided by vanilla_core_profiler.v in
+// bsg_manycore/testbenches/common/v/
+#ifndef __BSG_NONSYNTH_DPI_VANILLA_CORE_PROFILER
+#define __BSG_NONSYNTH_DPI_VANILLA_CORE_PROFILER
+#include <bsg_nonsynth_dpi.hpp>
+#include <bsg_nonsynth_dpi_errno.hpp>
+#include <string>
+
+// These are DPI functions provided by SystemVerilog compiler. If they
+// are not found at link time, compilation will fail. See the
+// corresponding function declarations in vanilla_core_profiler.v for
+// additional information.
+extern "C" {
+        extern void bsg_dpi_init();
+        extern void bsg_dpi_fini();
+        extern unsigned char bsg_dpi_vanilla_core_profiler_is_window();
+        extern void bsg_dpi_vanilla_core_profiler_get_instr_count(int itype, int *count);
+}
+
+namespace bsg_nonsynth_dpi{
+        /*
+         * dpi_vanilla_core_profiler wraps an instantiation of
+         * vanilla_core_profiler in a verilog design and provides
+         * C/C++-like functionality to the DPI interface.
+         *
+         * Functions:
+         *   dpi_vanilla_core_profiler: Constructor
+         *   get_instr_count: Get number of instructions executed for a particular class of instructions
+         */
+        class dpi_vanilla_core_profiler : public dpi_base{
+        public:
+
+                /**
+                 * Return an instance of dpi_vanilla_core_profiler
+                 *
+                 * @param[in] hierarchy The path to the
+                 *   vanilla_core_profiler instance in the design hierarchy
+                 *
+                 * @return a valid instance of dpi_vanilla_core_profiler
+                 */
+                dpi_vanilla_core_profiler(const std::string &hierarchy)
+                        : dpi_base("TOP.manycore_tb_top.manycore.y[1].x[0].tile.proc.h.z.vcore.vcore_prof")
+                {
+                }
+                
+                /**
+                 * Get the number of instructions executed for a
+                 * particular class of instructions
+                 *
+                 * @param[in] itype an integer representing the class
+                 * of instructions to query. Three types are
+                 * supported: 0 (float, for floating point arithmetic
+                 * operations), 1, (integer, for integer arithmetic
+                 * operations) and 2 (for all instructions, including
+                 * control flow).
+                 *
+                 * @param[out] count Number of instructions executed
+                 *
+                 * @return BSG_NONSYNTH_DPI_SUCCESS on success,
+                 * BSG_NONSYNTH_DPI_NOT_WINDOW when not in valid clock
+                 * window.
+                 */
+                int get_instr_count(int itype, int *count){
+                        prev = svSetScope(scope);
+                        if(!bsg_dpi_vanilla_core_profiler_is_window()){
+                                svSetScope(prev);
+                                return BSG_NONSYNTH_DPI_NOT_WINDOW;
+                        }
+
+                        //TOP.manycore_tb_top.manycore.y[1].x[0].tile.proc.h.z.vcore.vcore_prof
+                        bsg_dpi_vanilla_core_profiler_get_instr_count(itype, count);
+
+                        svSetScope(prev);
+                        return BSG_NONSYNTH_DPI_SUCCESS;
+                }
+
+        };
+}
+
+#endif // __BSG_NONSYNTH_DPI_VANILLA_CORE_PROFILER

--- a/testbenches/dpi/vanilla_core_profiler.hpp
+++ b/testbenches/dpi/vanilla_core_profiler.hpp
@@ -68,7 +68,6 @@ namespace bsg_nonsynth_dpi{
                                 return BSG_NONSYNTH_DPI_NOT_WINDOW;
                         }
 
-                        //TOP.manycore_tb_top.manycore.y[1].x[0].tile.proc.h.z.vcore.vcore_prof
                         bsg_dpi_vanilla_core_profiler_get_instr_count(itype, count);
 
                         svSetScope(prev);


### PR DESCRIPTION
This DPI interface allows a simulator to read floating point instructions executed, integer arithmetic instructions executed, and total number of instructions executed. 

It works in Verilator and VCS. A corresponding PR (and testbench) will be in bsg_replicant.



