### PR TITLE
Added DPI interface for vanilla_operation_trace.csv

### DIFF
--- a/software/spmd/bsg_cuda_lite_runtime/tracer/Makefile
+++ b/software/spmd/bsg_cuda_lite_runtime/tracer/Makefile
@@ -1,0 +1,34 @@
+#########################################################
+# Network Configutaion
+# If not configured, Will use default Values
+	bsg_global_X ?= $(bsg_tiles_X)
+	bsg_global_Y ?= $(bsg_tiles_Y)+1
+
+#########################################################
+#Tile group configuration
+# If not configured, Will use default Values
+	bsg_tiles_org_X ?= 0
+	bsg_tiles_org_Y ?= 1
+
+# If not configured, Will use default Values
+	bsg_tiles_X ?= 2
+	bsg_tiles_Y ?= 2
+
+
+all: main.run
+
+
+KERNEL_NAME ?=kernel_vec_add_parallel
+
+OBJECT_FILES=main.o kernel_vec_add_parallel.o
+
+include ../../Makefile.include
+
+
+main.riscv: $(LINK_SCRIPT) $(OBJECT_FILES) $(SPMD_COMMON_OBJECTS) $(BSG_MANYCORE_LIB) ../../common/crt.o
+	$(RISCV_LINK) $(OBJECT_FILES) $(SPMD_COMMON_OBJECTS) -L. "-l:$(BSG_MANYCORE_LIB)" -o $@ $(RISCV_LINK_OPTS)
+
+
+main.o: Makefile
+
+include ../../../mk/Makefile.tail_rules

--- a/software/spmd/bsg_cuda_lite_runtime/tracer/kernel_vec_add_parallel.cpp
+++ b/software/spmd/bsg_cuda_lite_runtime/tracer/kernel_vec_add_parallel.cpp
@@ -1,0 +1,21 @@
+//This kernel adds 2 vectors 
+
+#include "bsg_manycore.h"
+#include "bsg_set_tile_x_y.h"
+
+#include "bsg_tile_group_barrier.hpp"
+
+bsg_barrier<bsg_tiles_X, bsg_tiles_Y> barrier;
+
+extern "C" __attribute__ ((noinline))
+int kernel_vec_add_parallel(int *A, int *B, int *C, int N, int block_size_x) {
+
+	int start_x = block_size_x * (__bsg_tile_group_id_y * __bsg_grid_dim_x + __bsg_tile_group_id_x); 
+	for (int iter_x = __bsg_id; iter_x < block_size_x; iter_x += bsg_tiles_X * bsg_tiles_Y) { 
+		C[start_x + iter_x] = A[start_x + iter_x] + B[start_x + iter_x];
+	}
+
+	barrier.sync();
+
+	return 0;
+}

--- a/software/spmd/bsg_cuda_lite_runtime/tracer/main.c
+++ b/software/spmd/bsg_cuda_lite_runtime/tracer/main.c
@@ -1,0 +1,1 @@
+../main/main.c

--- a/testbenches/dpi/vanilla_core_profiler.hpp
+++ b/testbenches/dpi/vanilla_core_profiler.hpp
@@ -16,6 +16,9 @@ extern "C" {
         extern void bsg_dpi_fini();
         extern unsigned char bsg_dpi_vanilla_core_profiler_is_window();
         extern void bsg_dpi_vanilla_core_profiler_get_instr_count(int itype, int *count);
+        extern void bsg_dpi_vanilla_core_profiler_trace_disable();
+        extern void bsg_dpi_vanilla_core_profiler_trace_enable();
+
 }
 
 namespace bsg_nonsynth_dpi{
@@ -74,6 +77,19 @@ namespace bsg_nonsynth_dpi{
                         return BSG_NONSYNTH_DPI_SUCCESS;
                 }
 
+                // Enable Tracefile Generation
+                void trace_enable(){
+                        prev = svSetScope(scope);
+                        bsg_dpi_vanilla_core_profiler_trace_enable();
+                        svSetScope(prev);
+                }
+                
+                // Disable Tracefile Generation
+                void trace_disable(){
+                        prev = svSetScope(scope);
+                        bsg_dpi_vanilla_core_profiler_trace_disable();
+                        svSetScope(prev);
+                }
         };
 }
 


### PR DESCRIPTION
New interface (which is backward compatible, `+trace` still works) allows users to turn tracing on/off from C/C++

For small kernels, this results in a 50% smaller trace file, and at LEAST 94% smaller trace file for kernels with large datasets because the API can eliminate tracing during data transfer. (Or, they can include it. But the user gets to decide now).

I've also added a regression test kernel that performs vector add, and demonstrates the C/C++ API.