### PR TITLE
scoreboard critical path

### DIFF
--- a/v/vanilla_bean/scoreboard.v
+++ b/v/vanilla_bean/scoreboard.v
@@ -112,6 +112,8 @@ module scoreboard
 
  
   // dependency logic
+  // As the register is scored (in EXE), the instruction in ID that has WAW or RAW dependency on this register stalls.
+  // The register that is being cleared does not stall ID. 
   logic [num_src_port_p-1:0] depend_on_rs;
   logic depend_on_rd;
 

--- a/v/vanilla_bean/scoreboard.v
+++ b/v/vanilla_bean/scoreboard.v
@@ -110,21 +110,22 @@ module scoreboard
     end
   end
 
-  logic [els_p-1:0] score_combined;
-  assign score_combined = score_bits | scoreboard_r;
-
+ 
+  // dependency logic
   logic [num_src_port_p-1:0] depend_on_rs;
   logic depend_on_rd;
 
   for (genvar i = 0; i < num_src_port_p; i++) begin
-    assign depend_on_rs[i] = score_combined[src_id_i[i]] & ~(clear_combined[src_id_i[i]]) & op_reads_rf_i[i];
+    assign depend_on_rs[i] = (scoreboard_r[src_id_i[i]] | ((score_id_i == src_id_i[i]) & score_i))
+                           & ~((clear_id_i == src_id_i[i]) & clear_i)
+                           & op_reads_rf_i[i];
   end
 
-  assign depend_on_rd = score_combined[dest_id_i] & ~(clear_combined[dest_id_i]) & op_writes_rf_i;
+  assign depend_on_rd = (scoreboard_r[dest_id_i] | ((score_id_i == dest_id_i) & score_i))
+                      & ~((clear_id_i == dest_id_i) & clear_i)
+                      & op_writes_rf_i;
 
   assign dependency_o = (|depend_on_rs) | depend_on_rd;
-
-
 
 
   // synopsys translate_off


### PR DESCRIPTION
Area
---------
Before:
proc/h_z/vcore/float_sb             138.3379
proc/h_z/vcore/int_sb               122.4922

After:
proc/h_z/vcore/float_sb             120.6778
proc/h_z/vcore/int_sb               109.4285


Timing
report_timing -through [get_pin proc/h_z/vcore/float_sb/score_i] -through [get_pin proc/h_z/vcore/float_sb/dependency_o]
----------------
Before (262 ps):
  proc/h_z/vcore/float_sb/score_i (bsg_manycore_tile_scoreboard_els_p32_num_src_port_p3_num_clear_port_p1_x0_tied_to_zero_p0_0) <-
0.00     393.23 f
  proc/h_z/vcore/float_sb/score_demux/v_i (bsg_manycore_tile_bsg_decode_with_v_num_out_p32_1)
                                                          0.00     393.23 f
  proc/h_z/vcore/float_sb/score_demux/U1/Z (BUFX6)
                                                         18.89     412.12 f
  proc/h_z/vcore/float_sb/score_demux/U8/Z (CKAN2X1)
                                                         23.91     436.03 f
  proc/h_z/vcore/float_sb/score_demux/o[16] (bsg_manycore_tile_bsg_decode_with_v_num_out_p32_1)
                                                          0.00     436.03 f
  proc/h_z/vcore/float_sb/U220/Z (CKNR2X1)
                                                         24.69     460.72 r
  proc/h_z/vcore/float_sb/U213/Z (NR2X1_R)
                                                         22.16     482.88 f
  proc/h_z/vcore/float_sb/U45/Z (NR4X1_A)
                                                         37.81     520.69 r
  proc/h_z/vcore/float_sb/U118/Z (NR3X1)
                                                         21.73     542.42 f
  proc/h_z/vcore/float_sb/U42/Z (NR4X1_A)
                                                         39.54     581.97 r
  proc/h_z/vcore/float_sb/U57/Z (AOI211X1)
                                                         20.65     602.62 f
  proc/h_z/vcore/float_sb/U56/Z (OR4IAX1)
                                                         53.15     655.77 f
  proc/h_z/vcore/float_sb/dependency_o (bsg_manycore_tile_scoreboard_els_p32_num_src_port_p3_num_clear_port_p1_x0_tied_to_zero_p0_0) <-
                                                          0.00     655.77 f

After (100 ps):
  proc/h_z/vcore/float_sb/score_i (bsg_manycore_tile_scoreboard_els_p32_num_src_port_p3_num_clear_port_p1_x0_tied_to_zero_p0_0) <-
                                                          0.00     548.41 f
  proc/h_z/vcore/float_sb/U4/Z (INVX1)     33.04     581.45 r
  proc/h_z/vcore/float_sb/U192/Z (AOI31X1)
                                                         13.82     595.27 f
  proc/h_z/vcore/float_sb/U3/Z (OR4X1_A)
                                                         53.23     648.50 f
  proc/h_z/vcore/float_sb/dependency_o (bsg_manycore_tile_scoreboard_els_p32_num_src_port_p3_num_clear_port_p1_x0_tied_to_zero_p0_0) <-
                                                          0.00     648.50 f
