### PR TITLE
Small fixes for Verilator

### DIFF
--- a/testbenches/common/v/vanilla_core_trace.v
+++ b/testbenches/common/v/vanilla_core_trace.v
@@ -133,7 +133,7 @@ module vanilla_core_trace
     end
     else begin
       if (~stall_all) begin
-        mem_debug <= {
+        mem_debug <= '{
           pc: exe_debug.pc,
           instr: exe_debug.instr,
           branch_or_jump: exe_debug.branch_or_jump,

--- a/v/bsg_manycore_accel_default.v
+++ b/v/bsg_manycore_accel_default.v
@@ -14,6 +14,7 @@ module bsg_manycore_accel_default
      , parameter vcache_sets_p = "inv"
 
      , parameter num_tiles_x_p = "inv"
+     , parameter num_tiles_y_p = "inv"
 
      // number of  packets we can have outstanding
      , parameter max_out_credits_p = 4


### PR DESCRIPTION
The first fix (`testbenches/common/v/vanilla_core_trace.v`) must have gotten dropped in a rebase. 

The second fix is a new issue that has popped up with the new parameter `num_tiles_y_p`