### PR TITLE
Add bsg_dpi_next() to manycore DPI interface to support VCS simulation

### DIFF
--- a/testbenches/dpi/bsg_nonsynth_dpi_manycore.v
+++ b/testbenches/dpi/bsg_nonsynth_dpi_manycore.v
@@ -316,4 +316,20 @@ module bsg_nonsynth_dpi_manycore
       debug_o = switch_i;
    endfunction
 
+`ifndef VERILATOR
+   // Evaluate the simulation, until the next clk_i positive edge.
+   //
+   // Call bsg_dpi_next in simulators where the C testbench does not
+   // control the progression of time (i.e. NOT Verilator).
+   //
+   // The #1 statement guarantees that the positive edge has been
+   // evaluated, which is necessary for ordering in all of the DPI
+   // functions.
+   export "DPI-C" task bsg_dpi_next;
+   task bsg_dpi_next();
+      @(posedge clk_i);
+      #1;
+   endtask // bsg_dpi_next
+`endif
+
 endmodule


### PR DESCRIPTION
In VCS, the clock is controlled by the simulator. This means that when the "host" C/C++ wants time to pass in the RTL it must yield to the simulator using a delay statement (or similar). This is how the aws-vcs platform simulates in replicant.

This PR effectively adds a method to "yield" from the host C/C++ into the RTL simulation, until the next clock edge. This allows the Manycore DPI interface to be used with VCS. As a happy result,  the same RTL top level and C/C++ libraries to simulate with both VCS and Verilator tools.
