### PR TITLE
Kernel to estimate DRAM latency

### DIFF
--- a/software/spmd/bsg_cuda_lite_runtime/dram_latency/Makefile
+++ b/software/spmd/bsg_cuda_lite_runtime/dram_latency/Makefile
@@ -23,8 +23,8 @@ KERNEL_NAME ?=kernel_dram_latency
 OBJECT_FILES=main.o kernel_dram_latency.o
 
 RISCV_GXX_EXTRA_OPTS = -DVCACHE_SET=$(BSG_MACHINE_VCACHE_SET) \
-											 -DVCACHE_WAY=$(BSG_MACHINE_VCACHE_WAY) \
-											 -DVCACHE_BLOCK_SIZE_WORDS=$(BSG_MACHINE_VCACHE_BLOCK_SIZE_WORDS)
+                       -DVCACHE_WAY=$(BSG_MACHINE_VCACHE_WAY) \
+                       -DVCACHE_BLOCK_SIZE_WORDS=$(BSG_MACHINE_VCACHE_BLOCK_SIZE_WORDS)
 
 include ../../Makefile.include
 

--- a/software/spmd/bsg_cuda_lite_runtime/dram_latency/Makefile
+++ b/software/spmd/bsg_cuda_lite_runtime/dram_latency/Makefile
@@ -1,0 +1,38 @@
+#########################################################
+# Network Configutaion
+# If not configured, Will use default Values
+	bsg_global_X ?= $(bsg_tiles_X)
+	bsg_global_Y ?= $(bsg_tiles_Y)+1
+
+#########################################################
+#Tile group configuration
+# If not configured, Will use default Values
+	bsg_tiles_org_X ?= 0
+	bsg_tiles_org_Y ?= 1
+
+# If not configured, Will use default Values
+	bsg_tiles_X ?= 2
+	bsg_tiles_Y ?= 2
+
+
+all: main.run
+
+
+KERNEL_NAME ?=kernel_dram_latency
+
+OBJECT_FILES=main.o kernel_dram_latency.o
+
+RISCV_GXX_EXTRA_OPTS = -DVCACHE_SET=$(BSG_MACHINE_VCACHE_SET) \
+											 -DVCACHE_WAY=$(BSG_MACHINE_VCACHE_WAY) \
+											 -DVCACHE_BLOCK_SIZE_WORDS=$(BSG_MACHINE_VCACHE_BLOCK_SIZE_WORDS)
+
+include ../../Makefile.include
+
+
+main.riscv: $(LINK_SCRIPT) $(OBJECT_FILES) $(SPMD_COMMON_OBJECTS) $(BSG_MANYCORE_LIB) ../../common/crt.o
+	$(RISCV_LINK) $(OBJECT_FILES) $(SPMD_COMMON_OBJECTS) -L. "-l:$(BSG_MANYCORE_LIB)" -o $@ $(RISCV_LINK_OPTS)
+
+
+main.o: Makefile
+
+include ../../../mk/Makefile.tail_rules

--- a/software/spmd/bsg_cuda_lite_runtime/dram_latency/kernel_dram_latency.cpp
+++ b/software/spmd/bsg_cuda_lite_runtime/dram_latency/kernel_dram_latency.cpp
@@ -1,0 +1,66 @@
+// Kernel to estimate DRAM latency
+
+#include "bsg_manycore.h"
+#include "bsg_set_tile_x_y.h"
+#include <stdint.h>
+#include <stddef.h>
+
+const size_t VCACHE_NUM_BLOCKS = VCACHE_SET * VCACHE_WAY;
+const size_t VCACHE_SIZE_WORDS = VCACHE_NUM_BLOCKS * VCACHE_BLOCK_SIZE_WORDS;
+
+const size_t NUM_BANKS = 2 * bsg_tiles_Y;
+
+const uint32_t DRAM_START_ADDR = 0x80000000;
+
+// Returns the eva we should write to given the index in
+// the Vcache.
+//
+// Inverse of bsg_manycore/v/vanilla_bean/hash_function.v
+// Based on bsg_manycore/v/vanilla_bean/hash_function_reverse.v
+uint32_t vcache_inverse_hash_function(size_t block_index,
+                                      size_t bank) {
+  return 0x80000000;
+}
+
+// Issues a load to given vcache block index and bank
+inline void load_vcache_index(size_t i, size_t bank) {
+  uint32_t eva = vcache_inverse_hash_function(i, bank);
+
+  int dummy;
+  asm volatile (
+      "lw %0, 0(%1)"
+      : "=r" (dummy)
+      : "r" (eva));
+}
+
+// Flushes the vcache associated with a given bank
+void flush_vcache(size_t bank) {
+  // Distribute vcache block indices among all tiles
+  size_t len_per_tile = VCACHE_SIZE_WORDS / (bsg_tiles_X * bsg_tiles_Y) + 1;
+  size_t start = __bsg_id * len_per_tile;
+  size_t end = start + len_per_tile;
+  end = (end > VCACHE_SIZE_WORDS) ? VCACHE_SIZE_WORDS : end;
+
+  // Issue load to each block index
+  for(size_t i = start; i < end; ++i)
+    load_vcache_index(i, bank);
+}
+
+extern "C" __attribute__ ((noinline))
+int kernel_dram_latency(int dummy) {
+  // Flush vcahe associated with bank 0
+  flush_vcache(0);
+
+  // Opens a new page assuming vcache size would be
+  // a page boundary.
+  load_vcache_index(VCACHE_NUM_BLOCKS, 0);
+
+  bsg_cuda_print_stat_kernel_start();
+  size_t offset = VCACHE_NUM_BLOCKS + 1;
+  // Issue loads to 64 blocks in the opened page
+  for(size_t i = offset; i < offset + 64; ++i)
+    load_vcache_index(i, 0);
+  bsg_cuda_print_stat_kernel_end();
+
+  return 0;
+}

--- a/software/spmd/bsg_cuda_lite_runtime/dram_latency/kernel_dram_latency.cpp
+++ b/software/spmd/bsg_cuda_lite_runtime/dram_latency/kernel_dram_latency.cpp
@@ -59,10 +59,10 @@ inline void load_vcache_index(size_t i, size_t bank) {
 // Flushes the vcache associated with a given bank
 void flush_vcache(size_t bank) {
   // Distribute vcache block indices among all tiles
-  size_t len_per_tile = VCACHE_SIZE_WORDS / (bsg_tiles_X * bsg_tiles_Y) + 1;
+  size_t len_per_tile = VCACHE_NUM_BLOCKS / (bsg_tiles_X * bsg_tiles_Y) + 1;
   size_t start = __bsg_id * len_per_tile;
   size_t end = start + len_per_tile;
-  end = (end > VCACHE_SIZE_WORDS) ? VCACHE_SIZE_WORDS : end;
+  end = (end > VCACHE_NUM_BLOCKS) ? VCACHE_NUM_BLOCKS : end;
 
   // Issue load to each block index
   for(size_t i = start; i < end; ++i)

--- a/software/spmd/bsg_cuda_lite_runtime/dram_latency/main.c
+++ b/software/spmd/bsg_cuda_lite_runtime/dram_latency/main.c
@@ -1,0 +1,10 @@
+#include "bsg_manycore.h"
+#include "bsg_set_tile_x_y.h"
+#include "bsg_cuda_lite_runtime.h"
+
+
+int main()
+{
+        __wait_until_valid_func();
+}
+


### PR DESCRIPTION
Approach:
- Flush the Vcache:
  - Implemented a function to compute eva from block index, and vcache inverse hash function.
  - Using the block index --> eva function, load from all blocks in vcache associated with bank 0.
- Load from the page starting right after the Vcache size with print stats enabled.

It's unclear how we can test this test. Two ideas I'm considering:
- Look in the waveform to make sure load requests are only to vcache 0.
- Probably, I can confirm this in vcache stats output.
