### PR TITLE
Switch to BSG GCC in RISC-V Tools

### DIFF
--- a/software/riscv-tools/Makefile
+++ b/software/riscv-tools/Makefile
@@ -33,7 +33,7 @@ TARGET_CFLAGS     := '-fno-common'
 
 TOOLCHAIN_REPO    := riscv-gnu-toolchain
 TOOLCHAIN_URL     := https://github.com/bespoke-silicon-group/$(TOOLCHAIN_REPO)
-TOOLCHAIN_VERSION := 7305a41
+TOOLCHAIN_VERSION := d74b7fc
 
 DEPENDS_DIR       := $(CURDIR)/depends
 
@@ -89,10 +89,12 @@ ifeq ($(shell [ $(call git-version,1) -gt 1 ] && \
 else
 	cd $(TOOLCHAIN_REPO) && git submodule update --init --recursive;
 endif
-
+	# **** This patch is no longer necessary with hardfloat, which adds 
+	#      fdiv and fsqrt support
+	#     Leaving for posterity ***
 	# This patch is necessary if target abi is ilp32f because of the issue
 	# https://github.com/riscv/riscv-gnu-toolchain/issues/530
-	cd $(TOOLCHAIN_REPO)/riscv-gcc && git apply $(CURDIR)/riscv-gcc.patch
+	# cd $(TOOLCHAIN_REPO)/riscv-gcc && git apply $(CURDIR)/riscv-gcc.patch
 
 
 checkout-spike:

--- a/software/riscv-tools/Makefile
+++ b/software/riscv-tools/Makefile
@@ -33,7 +33,7 @@ TARGET_CFLAGS     := '-fno-common'
 
 TOOLCHAIN_REPO    := riscv-gnu-toolchain
 TOOLCHAIN_URL     := https://github.com/bespoke-silicon-group/$(TOOLCHAIN_REPO)
-TOOLCHAIN_VERSION := d74b7fc
+TOOLCHAIN_VERSION := 5245929
 
 DEPENDS_DIR       := $(CURDIR)/depends
 
@@ -89,9 +89,9 @@ ifeq ($(shell [ $(call git-version,1) -gt 1 ] && \
 else
 	cd $(TOOLCHAIN_REPO) && git submodule update --init --recursive;
 endif
-	# **** This patch is no longer necessary with hardfloat, which adds 
-	#      fdiv and fsqrt support
-	#     Leaving for posterity ***
+	# **** This patch is no longer necessary. Its changes have
+	#      been applied in the bsg_manycore_gcc branch of
+	#      riscv-gcc.
 	# This patch is necessary if target abi is ilp32f because of the issue
 	# https://github.com/riscv/riscv-gnu-toolchain/issues/530
 	# cd $(TOOLCHAIN_REPO)/riscv-gcc && git apply $(CURDIR)/riscv-gcc.patch


### PR DESCRIPTION
In our local branch of riscv-gnu-toolchain, in the riscv-gcc submodule, I switched from the master branch to bsg_manycore_gcc (formerly named max-gcc) 

In addition, I also removed the commands that patched riscv-gcc. @vb000 can you confirm that I correctly applied this patch in riscv-gcc? https://github.com/bespoke-silicon-group/riscv-gcc/commit/8d25c1fa02742dac58e96a34704ad4d0262b76e5

