### PR TITLE
Removed .* matching from .dram section in link gen

### DIFF
--- a/software/py/bsg_manycore_link_gen.py
+++ b/software/py/bsg_manycore_link_gen.py
@@ -166,7 +166,7 @@ class bsg_manycore_link_gen:
       ['.eh_frame'         , ['.eh_frame','.eh_frame*']],
       ['.striped.data.dmem', ['.striped.data']],
       ['.rodata.dram'      , ['.rodata','.rodata*']],
-      ['.dram'             , ['.dram','.dram.*', '.*']],
+      ['.dram'             , ['.dram','.dram.*']],
       ]
 
     sections = "SECTIONS {\n\n"


### PR DESCRIPTION
The new linker script generator globs everything left during linking, into .dram. This includes debug symbols. 

This PR fixes that, by removing .* from .dram. This re-enables the ability to print in-line sources during disassembly. 

With the current solution the debug symbols are ALL loaded into the simulation during execution. This signficantly slows down runtime for large kernels when debug symbols are compiled.

If there's a better fix, I'm all ears. This is a high-priority needs-to-be-fixed for me. 

