### PR TITLE
Added a comment that describes barrier initialization

### DIFF
--- a/software/bsg_manycore_lib/bsg_tile_group_barrier.hpp
+++ b/software/bsg_manycore_lib/bsg_tile_group_barrier.hpp
@@ -40,6 +40,22 @@ template <int BARRIER_X_DIM>
 class bsg_row_barrier {
 private:
 
+        // The initialization assignments here have no effect if the
+        // barrier is instantiated at global scope (as is recommended
+        // practice)
+
+        // When the barrier is declared at global scope _local_alert
+        // and _done_list are located in the .bss.dmem segment.
+        
+        // These are initialized to 0 by the bsg_manycore_loader,
+        // which sets all data in the bss segment to 0 (as per ELF
+        // specification
+        // refspecs.linuxbase.org/LSB_3.0.0/LSB-PDA/LSB-PDA/specialsections.html)
+
+        // IF the location of _local_alsert and _done_list changes in
+        // the linker segments (e.g. to DRAM, for some reason) they
+        // MUST be initialized to 0 to work correctly.
+        
     volatile unsigned int  _local_alert = 0;
     volatile unsigned char _done_list[ BARRIER_X_DIM ] = {0};
 

--- a/software/bsg_manycore_lib/bsg_tile_group_barrier.hpp
+++ b/software/bsg_manycore_lib/bsg_tile_group_barrier.hpp
@@ -45,15 +45,15 @@ private:
         // practice)
 
         // When the barrier is declared at global scope _local_alert
-        // and _done_list are located in the .bss.dmem segment.
+        // and _done_list are located in the .bss.dmem section.
         
         // These are initialized to 0 by the bsg_manycore_loader,
-        // which sets all data in the bss segment to 0 (as per ELF
+        // which sets all data in the bss section to 0 (as per ELF
         // specification
         // refspecs.linuxbase.org/LSB_3.0.0/LSB-PDA/LSB-PDA/specialsections.html)
 
         // IF the location of _local_alsert and _done_list changes in
-        // the linker segments (e.g. to DRAM, for some reason) they
+        // the linker sections (e.g. to DRAM, for some reason) they
         // MUST be initialized to 0 to work correctly.
         
     volatile unsigned int  _local_alert = 0;


### PR DESCRIPTION
I've added a comment that I think is worth documenting. 

This is something that scared me. I was worried that we were not initializing the barriers before launching a tile. Thankfully, Max knows his C/C++ and ELF files and handled this last year.

However, the process of confirming this comment took a few days, and a meeting with Max. I've added a comment to avoid anyone performing the same traversal. 