### PR TITLE
Added bsg prefixes to non-blocking load related macros

### DIFF
--- a/software/bsg_manycore_lib/bsg_manycore.h
+++ b/software/bsg_manycore_lib/bsg_manycore.h
@@ -147,12 +147,13 @@ inline void bsg_fence()      { __asm__ __volatile__("fence" :::); }
 //------------------------------------------------------
 
 // Pointers to remote locations (non-scratchpad) could be qualified
-// with bsg_attr_remote. Doing so would tell compiler to assign a different
-// address space to the contents of those pointers and latencies of
-// memory accesses would be considered as 20 cycles. For example,
-// `bsg_attr_remote float* foo;` essentially declares foo as `bsg_attr_remote float*`
-// type, and the compiler assumes loads from `foo` to take 20 cycles
-// on average.
+// with bsg_attr_remote to tell the compiler to assign a remote
+// address space to the data pointed by those pointers. Latencies of
+// memory accesses from those pointers would be considered as 20 cycles.
+// `bsg_attr_remote` acts as a type qualifier for pointers and globals,
+// and `bsg_attr_remote float* foo;` essentially declares foo as
+// `bsg_attr_remote float*` type. Compiler assumes that loads from `foo`
+// would have 20 cycle latency on average.
 #ifdef __clang__
 #define bsg_attr_remote __attribute__((address_space(1)))
 #elif defined(__GNUC__) && !defined(__cplusplus)
@@ -163,17 +164,17 @@ inline void bsg_fence()      { __asm__ __volatile__("fence" :::); }
 
 // This macro is to protect the code from uncertainity with
 // restrict/__restrict/__restrict__. Apparently some Newlib headers
-// define __restrict as nothing, but __restrict__ seems to work. So,
-// we can use bsg_attr_noalias as our main way to resolve pointer alaising
-// and possibly in future we could have `#ifdef`s here to make sure
-// we use the right one in each circumstance.
+// define __restrict as nothing, but __restrict__ seems to work. Hence,
+// we use bsg_attr_noalias as our main way to resolve pointer alaising
+// and possibly in the future, we could have `#ifdef`s here to make sure
+// we use the right one under each circumstance.
 #define bsg_attr_noalias __restrict__
 
-// Unrolling pragma is slightly different for GCC and Clang. So, this
-// defines a wrapper macro bsg_unroll to automatically select the right 
-// pragma. Using this, a loop can be unrolled like this:
+// Unrolling pragma is slightly different for GCC and Clang. We define
+// the wrapper macro `bsg_unroll` to automatically select the right pragma.
+// Using this, a loop can be unrolled like this:
 //
-// bsg_unroll(16) for(size_t idx = start; idx < end; idx++) { 
+// bsg_unroll(16) for(size_t idx = start; idx < end; idx++) {
 //   ...
 // }
 #define PRAGMA(x) _Pragma(#x)

--- a/software/bsg_manycore_lib/bsg_manycore.h
+++ b/software/bsg_manycore_lib/bsg_manycore.h
@@ -155,7 +155,7 @@ inline void bsg_fence()      { __asm__ __volatile__("fence" :::); }
 // on average.
 #ifdef __clang__
 #define bsg_attr_remote __attribute__((address_space(1)))
-#elif defined(__GNUC__) && defined(__cplusplus)
+#elif defined(__GNUC__) && !defined(__cplusplus)
 #define bsg_attr_remote remote
 #else
 #define bsg_attr_remote

--- a/software/bsg_manycore_lib/bsg_manycore.h
+++ b/software/bsg_manycore_lib/bsg_manycore.h
@@ -156,7 +156,8 @@ inline void bsg_fence()      { __asm__ __volatile__("fence" :::); }
 #ifdef __clang__
 #define bsg_attr_remote __attribute__((address_space(1)))
 #elif defined(__GNUC__) && !defined(__cplusplus)
-#define bsg_attr_remote remote
+// TODO: Define the following with correct keyword for GCC
+#define bsg_attr_remote
 #else
 #define bsg_attr_remote
 #endif

--- a/software/bsg_manycore_lib/bsg_manycore.h
+++ b/software/bsg_manycore_lib/bsg_manycore.h
@@ -155,6 +155,8 @@ inline void bsg_fence()      { __asm__ __volatile__("fence" :::); }
 // on average.
 #ifdef __clang__
 #define bsg_attr_remote __attribute__((address_space(1)))
+#elif defined(__GNUC__) && defined(__cplusplus)
+#define bsg_attr_remote remote
 #else
 #define bsg_attr_remote
 #endif

--- a/software/bsg_manycore_lib/bsg_manycore.h
+++ b/software/bsg_manycore_lib/bsg_manycore.h
@@ -147,38 +147,38 @@ inline void bsg_fence()      { __asm__ __volatile__("fence" :::); }
 //------------------------------------------------------
 
 // Pointers to remote locations (non-scratchpad) could be qualified
-// with __remote. Doing so would tell compiler to assign a different
+// with bsg_attr_remote. Doing so would tell compiler to assign a different
 // address space to the contents of those pointers and latencies of
 // memory accesses would be considered as 20 cycles. For example,
-// `__remote float* foo;` essentially declares foo as `__remote float*`
+// `bsg_attr_remote float* foo;` essentially declares foo as `bsg_attr_remote float*`
 // type, and the compiler assumes loads from `foo` to take 20 cycles
 // on average.
 #ifdef __clang__
-#define __remote __attribute__((address_space(1)))
+#define bsg_attr_remote __attribute__((address_space(1)))
 #else
-#define __remote
+#define bsg_attr_remote
 #endif
 
 // This macro is to protect the code from uncertainity with
 // restrict/__restrict/__restrict__. Apparently some Newlib headers
 // define __restrict as nothing, but __restrict__ seems to work. So,
-// we can use NOALIAS as our main way to resolve pointer alaising
+// we can use bsg_attr_noalias as our main way to resolve pointer alaising
 // and possibly in future we could have `#ifdef`s here to make sure
 // we use the right one in each circumstance.
-#define NOALIAS __restrict__
+#define bsg_attr_noalias __restrict__
 
 // Unrolling pragma is slightly different for GCC and Clang. So, this
-// defines a wrapper macro UNROLL to automatically select the right 
+// defines a wrapper macro bsg_unroll to automatically select the right 
 // pragma. Using this, a loop can be unrolled like this:
 //
-// UNROLL(16) for(size_t idx = start; idx < end; idx++) { 
+// bsg_unroll(16) for(size_t idx = start; idx < end; idx++) { 
 //   ...
 // }
 #define PRAGMA(x) _Pragma(#x)
 #ifdef __clang__
-#define UNROLL(n) PRAGMA(unroll n)
+#define bsg_unroll(n) PRAGMA(unroll n)
 #else
-#define UNROLL(n) PRAGMA(GCC unroll n)
+#define bsg_unroll(n) PRAGMA(GCC unroll n)
 #endif
 
 

--- a/software/bsg_manycore_lib/bsg_manycore.h
+++ b/software/bsg_manycore_lib/bsg_manycore.h
@@ -156,8 +156,7 @@ inline void bsg_fence()      { __asm__ __volatile__("fence" :::); }
 #ifdef __clang__
 #define bsg_attr_remote __attribute__((address_space(1)))
 #elif defined(__GNUC__) && !defined(__cplusplus)
-// TODO: Define the following with correct keyword for GCC
-#define bsg_attr_remote
+#define bsg_attr_remote __remote
 #else
 #define bsg_attr_remote
 #endif

--- a/software/spmd/nbloads/Makefile
+++ b/software/spmd/nbloads/Makefile
@@ -1,0 +1,19 @@
+bsg_tiles_X = 1
+bsg_tiles_Y = 1
+
+
+all: main.run
+
+
+OBJECT_FILES=main.o
+
+include ../Makefile.include
+
+
+main.riscv: $(LINK_SCRIPT) $(OBJECT_FILES) $(SPMD_COMMON_OBJECTS) $(BSG_MANYCORE_LIB) crt.o
+	$(RISCV_LINK) $(OBJECT_FILES) $(SPMD_COMMON_OBJECTS) -L. "-l:$(BSG_MANYCORE_LIB)" -o $@ $(RISCV_LINK_OPTS)
+
+
+main.o: Makefile
+
+include ../../mk/Makefile.tail_rules

--- a/software/spmd/nbloads/Makefile
+++ b/software/spmd/nbloads/Makefile
@@ -5,7 +5,7 @@ bsg_tiles_Y = 1
 all: main.run
 
 
-OBJECT_FILES=main.o
+OBJECT_FILES=main.o vec_add.o vec_sub.o
 
 include ../Makefile.include
 

--- a/software/spmd/nbloads/main.c
+++ b/software/spmd/nbloads/main.c
@@ -1,3 +1,13 @@
+/**
+ * Sanity test to verify non-blocking load keywords:
+ *
+ *   - bsg_attr_remote : Declares pointers as remote pointers.
+ *   - bsg_attr_noalias: Hints compiler that data pointed by the pointer
+ *                       will not be aliased by other pointers within the
+ *                       pointer's scope.
+ *   - bsg_unroll      : Applies compiler specific unroll pragma.
+ */
+
 #include "bsg_manycore.h"
 #include "bsg_set_tile_x_y.h"
 

--- a/software/spmd/nbloads/main.c
+++ b/software/spmd/nbloads/main.c
@@ -1,0 +1,30 @@
+#include "bsg_manycore.h"
+#include "bsg_set_tile_x_y.h"
+
+bsg_attr_remote int vec1[4] __attribute__ ((section (".dram"))) = {1, 1, 1, 1};
+bsg_attr_remote int vec2[4] __attribute__ ((section (".dram"))) = {1, 1, 1, 1};
+
+void vec_add(bsg_attr_remote int* bsg_attr_noalias A,
+             bsg_attr_remote int* bsg_attr_noalias B,
+             int N) {
+  bsg_unroll(4)
+  for(int i = 0; i < N; ++i)
+    A[i] += B[i];
+}
+
+int main() {
+  bsg_set_tile_x_y();
+
+  if(__bsg_id == 0) {
+    vec_add(vec1, vec2, 4);
+
+    for(int i = 0; i < 4; ++i) {
+      if(vec1[i] != 2)
+        bsg_fail();
+    }
+
+    bsg_finish();
+  }
+
+  bsg_wait_while(1);
+}

--- a/software/spmd/nbloads/main.c
+++ b/software/spmd/nbloads/main.c
@@ -16,20 +16,27 @@ bsg_attr_remote int vec2[4] __attribute__ ((section (".dram"))) = {1, 1, 1, 1};
 
 void vec_add(bsg_attr_remote int* bsg_attr_noalias A,
              bsg_attr_remote int* bsg_attr_noalias B,
-             int N) {
-  bsg_unroll(4)
-  for(int i = 0; i < N; ++i)
-    A[i] += B[i];
-}
+             int N);
+
+void vec_sub(bsg_attr_remote int* bsg_attr_noalias A,
+             bsg_attr_remote int* bsg_attr_noalias B,
+             int N);
 
 int main() {
   bsg_set_tile_x_y();
 
   if(__bsg_id == 0) {
+    vec_sub(vec1, vec2, 4);
+
+    for(int i = 0; i < 4; ++i) {
+      if(vec1[i] != 0)
+        bsg_fail();
+    }
+
     vec_add(vec1, vec2, 4);
 
     for(int i = 0; i < 4; ++i) {
-      if(vec1[i] != 2)
+      if(vec1[i] != 1)
         bsg_fail();
     }
 

--- a/software/spmd/nbloads/vec_add.c
+++ b/software/spmd/nbloads/vec_add.c
@@ -1,0 +1,9 @@
+#include "bsg_manycore.h"
+
+void vec_add(bsg_attr_remote int* bsg_attr_noalias A,
+             bsg_attr_remote int* bsg_attr_noalias B,
+             int N) {
+  bsg_unroll(4)
+  for(int i = 0; i < N; ++i)
+    A[i] += B[i];
+}

--- a/software/spmd/nbloads/vec_sub.cpp
+++ b/software/spmd/nbloads/vec_sub.cpp
@@ -1,0 +1,13 @@
+#include "bsg_manycore.h"
+
+extern "C" {
+
+void vec_sub(bsg_attr_remote int* bsg_attr_noalias A,
+             bsg_attr_remote int* bsg_attr_noalias B,
+             int N) {
+  bsg_unroll(4)
+  for(int i = 0; i < N; ++i)
+    A[i] -= B[i];
+}
+
+}


### PR DESCRIPTION
Update non-blocking loads related macros with bsg prefixes:

- `__remote` --> `bsg_attr_remote`
- `NOALIAS` --> `bsg_attr_noalias`
- `UNROLL` --> `bsg_unroll`

Tested on pytorch regression.