### PR TITLE
Fix for compiling riscv-isa-sim with GCC10

### DIFF
--- a/software/riscv-tools/Makefile
+++ b/software/riscv-tools/Makefile
@@ -40,6 +40,7 @@ DEPENDS_DIR       := $(CURDIR)/depends
 SPIKE_REPO        := riscv-isa-sim
 SPIKE_URL         := https://github.com/riscv/riscv-isa-sim.git
 SPIKE_PATCH       := spike.patch
+SPIKE_GCC_PATCH   := spike-gcc.patch
 SPIKE_TAG         := v1.0.0
 
 LLVM_DIR          := $(CURDIR)/llvm
@@ -104,7 +105,7 @@ checkout-spike:
 	@rm -rf $(SPIKE_REPO);
 	git clone --recursive $(SPIKE_URL);
 	cd $(SPIKE_REPO) && git checkout tags/$(SPIKE_TAG)
-	cd $(SPIKE_REPO) && git apply ../$(SPIKE_PATCH)
+	cd $(SPIKE_REPO) && git apply ../$(SPIKE_PATCH) && git apply ../$(SPIKE_GCC_PATCH)
 
 checkout-all: 
 	$(MAKE) checkout-repos 

--- a/software/riscv-tools/spike-gcc.patch
+++ b/software/riscv-tools/spike-gcc.patch
@@ -1,0 +1,37 @@
+From 49f42517db5ec1a217ca87f0a9a3934695de0644 Mon Sep 17 00:00:00 2001
+From: Marcus Chow <mchow009@ucr.edu>
+Date: Mon, 17 Aug 2020 12:15:50 -0700
+Subject: [PATCH] Add missing stdexcept imports (GCC 10)
+
+---
+ fesvr/dtm.cc    | 1 +
+ riscv/devices.h | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/fesvr/dtm.cc b/fesvr/dtm.cc
+index 5409321..3f5b03b 100644
+--- a/fesvr/dtm.cc
++++ b/fesvr/dtm.cc
+@@ -6,6 +6,7 @@
+ #include <string.h>
+ #include <assert.h>
+ #include <pthread.h>
++#include <stdexcept>
+
+ #define RV_X(x, s, n) \
+   (((x) >> (s)) & ((1 << (n)) - 1))
+diff --git a/riscv/devices.h b/riscv/devices.h
+index 4e4d27f..eedde95 100644
+--- a/riscv/devices.h
++++ b/riscv/devices.h
+@@ -6,6 +6,7 @@
+ #include <string>
+ #include <map>
+ #include <vector>
++#include <stdexcept>
+
+ class processor_t;
+
+--
+1.8.3.1
+


### PR DESCRIPTION
Adds stdexport imports to riscv-isa-sim that are needed for gcc10. It's the same fix as this issue here...
https://github.com/riscv/riscv-isa-sim/pull/459