### PR TITLE
Atomic Add support 

### DIFF
--- a/software/bsg_manycore_lib/bsg_manycore_atomic.h
+++ b/software/bsg_manycore_lib/bsg_manycore_atomic.h
@@ -74,5 +74,40 @@ inline int bsg_amoor_aqrl (int* p, int val)
   return result;
 }
 
+inline int bsg_amoadd (int* p, int val)
+{
+  int result;
+  asm volatile ("amoadd.w %[result], %[val], 0(%[p])" \
+                : [result] "=r" (result) \
+                : [p] "r" (p), [val] "r" (val));
+  return result;
+}
+
+inline int bsg_amoadd_aq (int* p, int val)
+{
+  int result;
+  asm volatile ("amoadd.w.aq %[result], %[val], 0(%[p])" \
+                : [result] "=r" (result) \
+                : [p] "r" (p), [val] "r" (val));
+  return result;
+}
+
+inline int bsg_amoadd_rl (int* p, int val)
+{
+  int result;
+  asm volatile ("amoadd.w.rl %[result], %[val], 0(%[p])" \
+                : [result] "=r" (result) \
+                : [p] "r" (p), [val] "r" (val));
+  return result;
+}
+
+inline int bsg_amoadd_aqrl (int* p, int val)
+{
+  int result;
+  asm volatile ("amoadd.w.aqrl %[result], %[val], 0(%[p])" \
+                : [result] "=r" (result) \
+                : [p] "r" (p), [val] "r" (val));
+  return result;
+}
 
 #endif

--- a/software/spmd/amoadd_test/Makefile
+++ b/software/spmd/amoadd_test/Makefile
@@ -1,7 +1,8 @@
 export BSG_MANYCORE_DIR := $(shell git rev-parse --show-toplevel)
 
-bsg_tiles_X = 4
-bsg_tiles_Y = 4
+# Running tests on full manycore array. Uncomment and modify for a smaller array
+# bsg_tiles_X = 4
+# bsg_tiles_Y = 4
 
 include $(BSG_MANYCORE_DIR)/software/mk/Makefile.master
 include $(BSG_MANYCORE_DIR)/software/mk/Makefile.tail_rules

--- a/software/spmd/amoadd_test/Makefile
+++ b/software/spmd/amoadd_test/Makefile
@@ -1,0 +1,16 @@
+export BSG_MANYCORE_DIR := $(shell git rev-parse --show-toplevel)
+
+bsg_tiles_X = 4
+bsg_tiles_Y = 4
+
+include $(BSG_MANYCORE_DIR)/software/mk/Makefile.master
+include $(BSG_MANYCORE_DIR)/software/mk/Makefile.tail_rules
+
+OBJECT_FILES=main.o
+
+all: main.run
+
+main.riscv: $(LINK_SCRIPT) $(OBJECT_FILES) $(SPMD_COMMON_OBJECTS) $(BSG_MANYCORE_LIB) crt.o
+	$(RISCV_LINK) $(OBJECT_FILES) $(SPMD_COMMON_OBJECTS) -L. "-l:$(BSG_MANYCORE_LIB)" -o $@ $(RISCV_LINK_OPTS)
+
+main.o: Makefile

--- a/software/spmd/amoadd_test/main.c
+++ b/software/spmd/amoadd_test/main.c
@@ -1,0 +1,65 @@
+/*
+  Description:
+  Test to check if atomic adds work
+  Every tile atomically updates the 2 counter variables in DRAM using 2 methods and tile 0 checks if the value is the same using both techniques and is equal to the sum of bsg_x_id * bsg_y_id
+*/
+
+#include "bsg_manycore.h"
+#include "bsg_set_tile_x_y.h"
+#include "bsg_manycore_atomic.h"
+
+#define BSG_TILE_GROUP_X_DIM bsg_tiles_X
+#define BSG_TILE_GROUP_Y_DIM bsg_tiles_Y
+#include "bsg_tile_group_barrier.h"
+INIT_TILE_GROUP_BARRIER(r_barrier, c_barrier, 0, bsg_tiles_X-1, 0, bsg_tiles_Y-1);
+
+int data[2] __attribute__ ((section (".dram"))) = {0};
+int lock __attribute__ ((section (".dram"))) = {0};
+
+void atomic_add()
+{
+  // Perform an atomic add using amoadd.w
+  int value0 = __bsg_x * __bsg_y;
+  int result = bsg_amoadd_aq(&data[0], value0);
+
+  // Perform an atomic add using amoswaps 
+  // Acquires a lock and then updates the memory location in the critical region
+  int lock_val = 1;
+
+  // acquire
+  do {
+    lock_val = bsg_amoswap_aq(&lock, 1);
+  } while (lock_val != 0);
+
+  // Critical region
+  int value1 = data[1] + __bsg_x *__bsg_y;
+  data[1] = value1;
+
+  // release
+  bsg_amoswap_rl(&lock, 0);
+
+  // Wait for all cores to finish
+  bsg_fence();
+  bsg_tile_group_barrier(&r_barrier, &c_barrier);
+
+  if (__bsg_id == 0)
+  {
+    bsg_printf("%d\n", data[0]);
+    bsg_printf("%d\n", data[1]);
+
+    if ((data[0] == data[1]) && (data[0] == 36))
+      bsg_finish();
+    else
+      bsg_fail();
+  }
+}
+
+int main()
+{
+
+  bsg_set_tile_x_y();
+
+  atomic_add();
+
+  bsg_wait_while(1);
+}

--- a/software/spmd/amoadd_test/main.c
+++ b/software/spmd/amoadd_test/main.c
@@ -47,7 +47,15 @@ void atomic_add()
     bsg_printf("%d\n", data[0]);
     bsg_printf("%d\n", data[1]);
 
-    if ((data[0] == data[1]) && (data[0] == 36))
+    int expected = 0;
+    int sum = 0;
+    for (int i = 0; i < bsg_tiles_X; i++)
+      expected += i;
+    for (int i = 0; i < bsg_tiles_Y; i++)
+      sum += i;
+    expected *= sum;
+
+    if ((data[0] == data[1]) && (data[0] == expected))
       bsg_finish();
     else
       bsg_fail();

--- a/software/spmd/vcache_atomics/main.c
+++ b/software/spmd/vcache_atomics/main.c
@@ -4,6 +4,7 @@
 
 int lock __attribute__ ((section (".dram"))) = {0};
 int lock2 __attribute__ ((section (".dram"))) = {0};
+int lock3 __attribute__ ((section (".dram"))) = {0};
 
 int main()
 {
@@ -47,6 +48,24 @@ int main()
     result2 = bsg_amoor_aqrl(&lock2,16);
     if (result2 != 15) bsg_fail();
     bsg_printf("%d\n", result2);
+
+
+    lock3= 10;
+    int result3 = bsg_amoadd(&lock3,10);
+    if (result3 != 10) bsg_fail();
+    bsg_printf("%d\n", result3);
+
+    result3 = bsg_amoadd_aq(&lock3,2);
+    if (result3 != 20) bsg_fail();
+    bsg_printf("%d\n", result3);
+
+    result3 = bsg_amoadd_rl(&lock3,18);
+    if (result3 != 22) bsg_fail();
+    bsg_printf("%d\n", result3);
+
+    result3 = bsg_amoadd_aqrl(&lock3,40);
+    if (result3 != 40) bsg_fail();
+    bsg_printf("%d\n", result3);
 
     bsg_finish();
   }

--- a/v/bsg_manycore_link_to_cache.v
+++ b/v/bsg_manycore_link_to_cache.v
@@ -151,7 +151,7 @@ module bsg_manycore_link_to_cache
       e_cache_op: begin
         return_pkt_type = e_return_credit;
       end
-      e_remote_amoswap, e_remote_amoor: begin
+      e_remote_amoswap, e_remote_amoor, e_remote_amoadd: begin
         return_pkt_type = e_return_int_wb;
       end
       // should never happen
@@ -265,6 +265,10 @@ module bsg_manycore_link_to_cache
 
             e_remote_amoor: begin
               cache_pkt.opcode = AMOOR_W;
+            end
+
+            e_remote_amoadd: begin
+              cache_pkt.opcode = AMOADD_W;
             end
 
             e_cache_op: begin

--- a/v/bsg_manycore_tile_vcache.v
+++ b/v/bsg_manycore_tile_vcache.v
@@ -40,6 +40,10 @@ module bsg_manycore_tile_vcache
 
     , parameter wh_link_sif_width_lp = 
       `bsg_ready_and_link_sif_width(wh_flit_width_p)
+
+    , parameter vcache_amo_support_p = (1 << e_cache_amo_swap)
+                                | (1 << e_cache_amo_or)
+                                | (1 << e_cache_amo_add)
   )
   (
     input clk_i
@@ -204,6 +208,7 @@ module bsg_manycore_tile_vcache
     ,.sets_p(vcache_sets_p)
     ,.ways_p(vcache_ways_p)
     ,.dma_data_width_p(vcache_dma_data_width_p)
+    ,.amo_support_p(vcache_amo_support_p)
   ) cache (
     .clk_i(clk_i)
     ,.reset_i(reset_r)

--- a/v/vanilla_bean/bsg_vanilla_pkg.v
+++ b/v/vanilla_bean/bsg_vanilla_pkg.v
@@ -59,9 +59,10 @@ typedef struct packed {
 
 // remote request from vanilla core
 //
-typedef enum logic [0:0] {
+typedef enum logic [1:0] {
   e_vanilla_amoswap
   , e_vanilla_amoor
+  , e_vanilla_amoadd
 } bsg_vanilla_amo_type_e;
 
 typedef struct packed
@@ -477,6 +478,7 @@ typedef struct packed {
 `define RV32_LR_W_AQ    {5'b00010,2'b10,5'b00000,5'b?????,3'b010,5'b?????,`RV32_AMO_OP}
 `define RV32_AMOSWAP_W  {5'b00001,2'b??,5'b?????,5'b?????,3'b010,5'b?????,`RV32_AMO_OP}
 `define RV32_AMOOR_W    {5'b01000,2'b??,5'b?????,5'b?????,3'b010,5'b?????,`RV32_AMO_OP}
+`define RV32_AMOADD_W   {5'b00000,2'b??,5'b?????,5'b?????,3'b010,5'b?????,`RV32_AMO_OP}
 
 // RV32F Instruction Encodings
 `define RV32_OP_FP            7'b1010011

--- a/v/vanilla_bean/cl_decode.v
+++ b/v/vanilla_bean/cl_decode.v
@@ -93,7 +93,8 @@ always_comb begin
     `RV32_AMO_OP: begin
       // According the ISA, LR instruction don't read rs2
       decode_o.read_rs2 = (instruction_i.funct7 ==? 7'b00001??)   // amoswap
-                            | (instruction_i.funct7 ==? 7'b01000??);  // amoor
+                            | (instruction_i.funct7 ==? 7'b01000??)  // amoor
+                            | (instruction_i.funct7 ==? 7'b00000??); // amoadd
     end
     default: begin
       decode_o.read_rs2 = 1'b0;
@@ -202,6 +203,10 @@ always_comb begin
     `RV32_AMOOR_W: begin
       decode_o.is_amo_op = 1'b1;
       decode_o.amo_type = e_vanilla_amoor;
+    end
+    `RV32_AMOADD_W: begin
+      decode_o.is_amo_op = 1'b1;
+      decode_o.amo_type = e_vanilla_amoadd;
     end
     default: begin
       decode_o.is_amo_op = 1'b0;

--- a/v/vanilla_bean/network_tx.v
+++ b/v/vanilla_bean/network_tx.v
@@ -169,6 +169,7 @@ module network_tx
       case (remote_req_i.amo_type)
         e_vanilla_amoswap:  out_packet.op_v2 = e_remote_amoswap;
         e_vanilla_amoor:    out_packet.op_v2 = e_remote_amoor;
+        e_vanilla_amoadd:   out_packet.op_v2 = e_remote_amoadd;
         default:            out_packet.op_v2 = e_remote_amoswap;  // should never happen.
       endcase
     end


### PR DESCRIPTION
The manycore currently supports only AMOSWAP and AMOOR operations. This PR adds AMOADD support as well. 

Correspondly macros for software use in `bsg_manycore_atomic.h` have been added, an update to the `vcache_atomics` test and a multicore test exercising the use of atomic adds.