### PR TITLE
PC Profiler

### DIFF
--- a/software/bsg_manycore_lib/bsg_manycore.h
+++ b/software/bsg_manycore_lib/bsg_manycore.h
@@ -76,6 +76,19 @@ typedef volatile void *bsg_remote_void_ptr;
 #define bsg_fail_x(x)       do {  bsg_remote_int_ptr ptr = bsg_remote_ptr_io(x,0xEAD8); *ptr = ((bsg_y << 16) + bsg_x); while (1); } while(0)
 #define bsg_print_time()   do {  bsg_remote_int_ptr ptr = bsg_remote_ptr_io(IO_X_INDEX,0xEAD4); *ptr = ((bsg_y << 16) + bsg_x); } while(0)
 
+// Static, inline functions for starting and stopping the PC profiler
+static inline void bsg_pc_profiler_start()
+{
+        __asm__ __volatile__ ("csrs mie, %0": : "r" (0x20000));
+        // Enable interrupts if not already enabled; One instruction overhead if interrupts were already enabled
+        __asm__ __volatile__ ("csrs mstatus, %0" : : "r" (0x8));
+}
+static inline void bsg_pc_profiler_end()
+{
+        // Disable trace interupts; Other interrupts might still be active so don't clear mstatus interrupt enable bit
+        __asm__ __volatile__ ("csrc mie, %0": : "r" (0x20000));
+}
+
 #define bsg_putchar( c )       do {  bsg_remote_uint8_ptr ptr = (bsg_remote_uint8_ptr) bsg_remote_ptr_io(IO_X_INDEX,0xEADC); *ptr = c; } while(0)
 #define bsg_putchar_err( c )       do {  bsg_remote_uint8_ptr ptr = (bsg_remote_uint8_ptr) bsg_remote_ptr_io(IO_X_INDEX,0xEEE0); *ptr = c; } while(0)
 

--- a/software/spmd/Makefile
+++ b/software/spmd/Makefile
@@ -19,7 +19,8 @@ NO-RECURSE = \
 	striped_struct_vector	\
 	beebs saif \
 	interrupt_tests \
-	bp_manycore_test
+	bp_manycore_test \
+	pc_profiler
 
 # Define this variable on cmd line to run coverage analysis. Currently
 # supports VCS coverage: run "make COVERAGE=VCS"

--- a/software/spmd/pc_profiler/Makefile
+++ b/software/spmd/pc_profiler/Makefile
@@ -1,7 +1,8 @@
 export BSG_MANYCORE_DIR := $(shell git rev-parse --show-toplevel)
 
-bsg_tiles_X= 4
-bsg_tiles_Y= 4
+# Uncomment if you have want to work on a smaller subset of the entire array
+# bsg_tiles_X= 4
+# bsg_tiles_Y= 4
 MAX_CYCLES= 10000000
 
 include $(BSG_MANYCORE_DIR)/software/mk/Makefile.master

--- a/software/spmd/pc_profiler/Makefile
+++ b/software/spmd/pc_profiler/Makefile
@@ -1,0 +1,22 @@
+export BSG_MANYCORE_DIR := $(shell git rev-parse --show-toplevel)
+
+bsg_tiles_X= 4
+bsg_tiles_Y= 4
+MAX_CYCLES= 10000000
+
+include $(BSG_MANYCORE_DIR)/software/mk/Makefile.master
+
+# Amount of space for the histogram
+HIST_SPACE ?= 16777216
+PROFILE ?= 0
+
+# Function lining is automatic at O2 level, but makes extracting profiled histogram harder (only when simulating smaller histogram array sizes (i.e < 16MB))
+RISCV_GCC_OPTS += -DHIST_SPACE=$(HIST_SPACE) -DPROFILE=$(PROFILE)
+RISCV_LINK_OPTS = -march=rv32imaf -nostdlib -nostartfiles -mno-relax
+
+OBJECT_FILES = profiler.o main.o
+
+%.riscv: $(LINK_SCRIPT) $(OBJECT_FILES) $(SPMD_COMMON_OBJECTS) $(BSG_MANYCORE_LIB)
+	$(RISCV_LINK) $(OBJECT_FILES) $(SPMD_COMMON_OBJECTS) -L. "-l:$(BSG_MANYCORE_LIB)" -o $@ $(RISCV_LINK_OPTS)
+
+include $(BSG_MANYCORE_DIR)/software/mk/Makefile.tail_rules

--- a/software/spmd/pc_profiler/Makefile
+++ b/software/spmd/pc_profiler/Makefile
@@ -5,7 +5,7 @@ export BSG_MANYCORE_DIR := $(shell git rev-parse --show-toplevel)
 # bsg_tiles_Y= 4
 MAX_CYCLES= 10000000
 
-include $(BSG_MANYCORE_DIR)/software/mk/Makefile.master
+include $(BSG_MANYCORE_DIR)/software/spmd/Makefile.include
 
 # Amount of space for the histogram
 HIST_SPACE ?= 16777216
@@ -17,7 +17,11 @@ RISCV_LINK_OPTS = -march=rv32imaf -nostdlib -nostartfiles -mno-relax
 
 OBJECT_FILES = profiler.o main.o
 
+# Redefine the HIST_SPACE variable for a smaller histogram instead of the default which is 16MB
+all: main.run
+
 %.riscv: $(LINK_SCRIPT) $(OBJECT_FILES) $(SPMD_COMMON_OBJECTS) $(BSG_MANYCORE_LIB)
 	$(RISCV_LINK) $(OBJECT_FILES) $(SPMD_COMMON_OBJECTS) -L. "-l:$(BSG_MANYCORE_LIB)" -o $@ $(RISCV_LINK_OPTS)
 
 include $(BSG_MANYCORE_DIR)/software/mk/Makefile.tail_rules
+

--- a/software/spmd/pc_profiler/README.md
+++ b/software/spmd/pc_profiler/README.md
@@ -1,0 +1,21 @@
+# PC Profiler
+
+This folder contains an implementation of a PC Profiler along with an example program. The example program computes the fibonacci series and then reads the histogram to see if it matches with the expected histogram.
+
+## Running the PC Profiler
+
+The current implementation of the PC Profiler requires you to use profiler.S instead of the default CRT to enable/disable profiling. An example is given in the Makefile in `software/spmd/pc_profiler`
+
+To run a program with the PC Profiler enabled, use 
+
+`make all PROFILE=1`
+
+Note: Currently the histogram to store the PC Profiler hits is stored in the DRAM. By default, the space reserved is 16 MB. This is a very large number in simulation and takes the SPMD loader a large amount of time to zero out this memory. In order to get quick estimates, modify the `HIST_SPACE` variable. Therefore, the command will now look like - 
+
+`make all PROFILE=1 HIST_SPACE=4096 (4KB histogram space)`
+
+## Items still to be taken care of - 
+
+There are a few items however that needs to be taken care of
+- A suitable location in the repository for the profiler code
+- A scheme to separate the profiler code (trace interrupt handler) from the CRT itself.

--- a/software/spmd/pc_profiler/main.c
+++ b/software/spmd/pc_profiler/main.c
@@ -32,7 +32,6 @@ void fibonacci()
 
 void read_histogram()
 {
-  // Fixme: This array is populated statically by observing disassembly. Need to make it standalone
   int expectation[10] = {1 * NUM_TILES, 1 * NUM_TILES, 10 * NUM_TILES, 10 * NUM_TILES, 10 * NUM_TILES, 10 * NUM_TILES, 10 * NUM_TILES, 1 * NUM_TILES, 1 * NUM_TILES, 1 * NUM_TILES};
 
   int *i;

--- a/software/spmd/pc_profiler/main.c
+++ b/software/spmd/pc_profiler/main.c
@@ -3,11 +3,7 @@
 #include "bsg_manycore.h"
 #include "bsg_set_tile_x_y.h"
 
-// Histogram location?
-// 1. Can histogram base address be accessed directly from symbol table?
-// 2. Should linker be modified so that histogram is statically assigned a region in memory?
-// Fixme: Histogram base address adjusted to the right value after looking at disassembly
-#define HISTOGRAM_BASE_ADDR 0x81000290
+extern int _histogram_arr;
 
 #ifndef HIST_SPACE
 #define HIST_SPACE 16777216
@@ -36,14 +32,13 @@ void fibonacci()
 
 void read_histogram()
 {
-  int val;
-  int count = 0;
   // Fixme: This array is populated statically by observing disassembly. Need to make it standalone
   int expectation[10] = {1 * NUM_TILES, 1 * NUM_TILES, 10 * NUM_TILES, 10 * NUM_TILES, 10 * NUM_TILES, 10 * NUM_TILES, 10 * NUM_TILES, 1 * NUM_TILES, 1 * NUM_TILES, 1 * NUM_TILES};
-  // Adjust start value based on disassembly since function is small and therefore inlined with O2 optimization
-  int *i;
 
-  for (i = (HISTOGRAM_BASE_ADDR); i < (HISTOGRAM_BASE_ADDR + HIST_SPACE); i++)
+  int *i;
+  int val;
+  int count = 0;
+  for (i = &_histogram_arr; i < (&_histogram_arr + (HIST_SPACE >> 2)); i++)
   {
     val = *i;
     if (val != 0)
@@ -52,8 +47,7 @@ void read_histogram()
       if (expectation[count] != val)
         bsg_fail();
       count++;
-    }
-      
+    }    
   }
 
   bsg_finish();

--- a/software/spmd/pc_profiler/main.c
+++ b/software/spmd/pc_profiler/main.c
@@ -1,0 +1,90 @@
+// Program to print 10 fibonacci numbers; A sample program that will get profiled
+
+#include "bsg_manycore.h"
+#include "bsg_set_tile_x_y.h"
+
+// Histogram location?
+// 1. Can histogram base address be accessed directly from symbol table?
+// 2. Should linker be modified so that histogram is statically assigned a region in memory?
+// Fixme: Histogram base address adjusted to the right value after looking at disassembly
+#define HISTOGRAM_BASE_ADDR 0x81000290
+
+#ifndef HIST_SPACE
+#define HIST_SPACE 16777216
+#endif
+
+#define NUM_TILES bsg_group_size
+
+// Sample program to print 10 fibonacci numbers
+void fibonacci()
+{
+  int i;
+  int a = 0;
+  int b = 1;
+  int temp = 0;
+
+  for (i = 0; i < 10; i++)
+  {
+    temp = a + b;
+    a = b;
+    b = temp;
+  }
+
+  if (a != 55)
+    bsg_fail();
+}
+
+void read_histogram()
+{
+  int val;
+  int count = 0;
+  // Fixme: This array is populated statically by observing disassembly. Need to make it standalone
+  int expectation[10] = {1 * NUM_TILES, 1 * NUM_TILES, 10 * NUM_TILES, 10 * NUM_TILES, 10 * NUM_TILES, 10 * NUM_TILES, 10 * NUM_TILES, 1 * NUM_TILES, 1 * NUM_TILES, 1 * NUM_TILES};
+  // Adjust start value based on disassembly since function is small and therefore inlined with O2 optimization
+  int *i;
+
+  for (i = (HISTOGRAM_BASE_ADDR); i < (HISTOGRAM_BASE_ADDR + HIST_SPACE); i++)
+  {
+    val = *i;
+    if (val != 0)
+    {
+      bsg_printf("%p: %x\n", i, val);
+      if (expectation[count] != val)
+        bsg_fail();
+      count++;
+    }
+      
+  }
+
+  bsg_finish();
+}
+
+void main()
+{
+  // tile setup
+  bsg_set_tile_x_y();
+
+
+  // Start profiling code, enable interrupts
+  int mie, mstatus;
+  mie = 0x20000;
+  mstatus = 0x8;
+  __asm__ __volatile__ ("csrw mie, %0": : "r" (mie));
+  __asm__ __volatile__ ("csrw mstatus, %0" : : "r" (mstatus));
+
+  // Code to be profiled
+  fibonacci();
+
+  // Reading histogram, disable interrupts
+  mie = mstatus = 0;
+  __asm__ __volatile__ ("csrw mie, %0": : "r" (mie));
+  __asm__ __volatile__ ("csrw mstatus, %0" : : "r" (mstatus));
+
+  if (__bsg_id == 0)
+  {
+    // read histogram
+    read_histogram();
+  }
+  
+  bsg_wait_while(1);
+}

--- a/software/spmd/pc_profiler/main.c
+++ b/software/spmd/pc_profiler/main.c
@@ -60,19 +60,13 @@ void main()
 
 
   // Start profiling code, enable interrupts
-  int mie, mstatus;
-  mie = 0x20000;
-  mstatus = 0x8;
-  __asm__ __volatile__ ("csrw mie, %0": : "r" (mie));
-  __asm__ __volatile__ ("csrw mstatus, %0" : : "r" (mstatus));
+  bsg_pc_profiler_start();
 
   // Code to be profiled
   fibonacci();
 
   // Reading histogram, disable interrupts
-  mie = mstatus = 0;
-  __asm__ __volatile__ ("csrw mie, %0": : "r" (mie));
-  __asm__ __volatile__ ("csrw mstatus, %0" : : "r" (mstatus));
+  bsg_pc_profiler_end();
 
   if (__bsg_id == 0)
   {

--- a/software/spmd/pc_profiler/profiler.S
+++ b/software/spmd/pc_profiler/profiler.S
@@ -10,6 +10,7 @@
   The profiler uses the following registers - 
   t0 --> Base address of the histogram array (actual value stored in dmem[1])
   t1 --> Scratchpad (actual value stored in dmem[0])
+  t2 --> Scratchpad (actual value stored in dmem[2])
 */
 
 #include "bsg_manycore_arch.h"
@@ -31,9 +32,10 @@
   Defines a 2 element (8 byte) array to store the base pointer of the histogram array and for use by the interrupt handler to spill some registers
   dmem[0] = histogram base pointer, temporary storage
   dmem[1] = temporary storage
+  dmem[2] = temporary storage
 */
 .section .dmem.interrupt, "aw"
-  _interrupt_arr: .space 8, 0x0
+  _interrupt_arr: .space 12, 0x0
 
 /*
   DRAM section:
@@ -85,31 +87,30 @@ _trace_interrupt:
   lw t0, 0(zero)
   // Store another register to dmem[0]
   sw t1, 0(zero)
+  // Store a register to dmem[2]
+  sw t2, 8(zero)
 
   // read the mepc register
   csrr t1, mepc
   // find the correct index in the histogram array
-  add t0, t0, t1
+  add t1, t0, t1
 
   // atomically increment the value at the computed index
-  li t1, 1
+  li t2, 1
   // We don't care about the result hence assigned to zero register
-  amoadd.w.aq zero, t1, (t0)
-
-  // remap t0 to histogram array base address
-  csrr t1, mepc
-  sub t0, t0, t1
+  amoadd.w zero, t2, (t1)
 
   // Restore registers and store base ptr back to dmem[0]
   lw t1, 0(zero)
   sw t0, 0(zero)
   lw t0, 4(zero)
+  lw t2, 8(zero)
 
   mret
 
 _remote_interrupt_handler:
   // Add code here when using in actual programs, for now these are turned off
-  j fail
+  bsg_asm_fail(IO_X_INDEX, 0)
 #endif
 
 /*
@@ -226,7 +227,3 @@ _start:
 2:
   // Should never reach this point
   j 2b
-
-  // Must not come here
-fail:
-  j fail

--- a/software/spmd/pc_profiler/profiler.S
+++ b/software/spmd/pc_profiler/profiler.S
@@ -44,6 +44,7 @@
   2. Base pointer in DRAM (for now it is mapped to start of DRAM) [Consider static assignment in linker]
 */
 .section .dram, "aw"
+.globl _histogram_arr
   _histogram_arr: .space HIST_SPACE, 0x0
 #endif
 

--- a/software/spmd/pc_profiler/profiler.S
+++ b/software/spmd/pc_profiler/profiler.S
@@ -9,8 +9,7 @@
   The program being profiled is free to use any registers within if there are no other imposed constraints.
   The profiler uses the following registers - 
   t0 --> Base address of the histogram array (actual value stored in dmem[1])
-  t1 --> Scratchpad (actual value stored in dmem[0])
-  t2 --> Scratchpad (actual value stored in dmem[2])
+  t1 --> Scratchpad (actual value stored in dmem[2])
 */
 
 #include "bsg_manycore_arch.h"
@@ -30,7 +29,7 @@
 /* 
   Data section:
   Defines a 2 element (8 byte) array to store the base pointer of the histogram array and for use by the interrupt handler to spill some registers
-  dmem[0] = histogram base pointer, temporary storage
+  dmem[0] = histogram base pointer
   dmem[1] = temporary storage
   dmem[2] = temporary storage
 */
@@ -71,9 +70,7 @@ _remote_interrupt:
   The bin index in the histogram can be found using the following equation index = base ptr + EPC
   (Although EPC is 4-byte aligned, we are assigning 4 bytes per bin, so we don't need to do EPC >> 2)
 
-  Lingering concerns:
-  Since we are using the MEPC, we don't have the PC of the first instruction in the program. 
-  (Probably does not matter because it's just 1 datapoint)
+  Since we are using the MEPC, we don't have the PC of the first instruction in the program (this is usually the call to the main function for non-inlined functions)
 */
 _trace_interrupt:
   // Save a register to dmem[1]
@@ -85,26 +82,22 @@ _trace_interrupt:
 
   // load address of histogram array
   lw t0, 0(zero)
-  // Store another register to dmem[0]
-  sw t1, 0(zero)
-  // Store a register to dmem[2]
-  sw t2, 8(zero)
+  // Store another register to dmem[2]
+  sw t1, 8(zero)
 
   // read the mepc register
   csrr t1, mepc
   // find the correct index in the histogram array
-  add t1, t0, t1
+  add t0, t0, t1
 
   // atomically increment the value at the computed index
-  li t2, 1
+  li t1, 1
   // We don't care about the result hence assigned to zero register
-  amoadd.w zero, t2, (t1)
+  amoadd.w zero, t1, (t0)
 
   // Restore registers and store base ptr back to dmem[0]
-  lw t1, 0(zero)
-  sw t0, 0(zero)
   lw t0, 4(zero)
-  lw t2, 8(zero)
+  lw t1, 8(zero)
 
   mret
 

--- a/software/spmd/pc_profiler/profiler.S
+++ b/software/spmd/pc_profiler/profiler.S
@@ -1,0 +1,231 @@
+/* 
+  Description:
+  A software-based PC profiler which builds a histogram of PCs encountered by the program
+
+  Memory layout:
+  DRAM --> 16MB (configurable) for maintaing a histogram for N tiles. 
+
+  Registers used:
+  The program being profiled is free to use any registers within if there are no other imposed constraints.
+  The profiler uses the following registers - 
+  t0 --> Base address of the histogram array (actual value stored in dmem[1])
+  t1 --> Scratchpad (actual value stored in dmem[0])
+*/
+
+#include "bsg_manycore_arch.h"
+#include "bsg_manycore_asm.h"
+
+// Useful to control the amount of space required to simulate the use of the profiler.
+// We want 16MB when running on actual hardware.
+#ifndef HIST_SPACE
+#define HIST_SPACE 16777216
+#endif
+
+#ifndef PROFILE
+#define PROFILE 0
+#endif
+
+#if PROFILE > 0
+/* 
+  Data section:
+  Defines a 2 element (8 byte) array to store the base pointer of the histogram array and for use by the interrupt handler to spill some registers
+  dmem[0] = histogram base pointer, temporary storage
+  dmem[1] = temporary storage
+*/
+.section .dmem.interrupt, "aw"
+  _interrupt_arr: .space 8, 0x0
+
+/*
+  DRAM section:
+  Defines a 16MB (array size is configurable) chunk in DRAM to store the histogram.
+
+  Lingering question(s):
+  1. Assigned space per PC (i.e bin capacity) as 32-bits. Is this enough, too much or too less?
+  2. Base pointer in DRAM (for now it is mapped to start of DRAM) [Consider static assignment in linker]
+*/
+.section .dram, "aw"
+  _histogram_arr: .space HIST_SPACE, 0x0
+#endif
+
+/*
+  Startup:
+  This is very similar to the code in software/spmd/common/crt.S and adds only the interrupt service routine (ISR) and sets up the DMEM with the histogram base address. 
+*/
+.section .crtbegin
+.globl _start
+
+#if PROFILE > 0
+/*
+  Remote interrupt handler (should map to address 0)
+*/
+_remote_interrupt:
+  j _remote_interrupt_handler
+
+/*
+  Trace interrupt handler (should map to address 4)
+  Clears the pending trace interrupt bit in the MIP CSR and atomically increments the histogram bin count based on the MEPC CSR value
+
+  The bin index in the histogram can be found using the following equation index = base ptr + EPC
+  (Although EPC is 4-byte aligned, we are assigning 4 bytes per bin, so we don't need to do EPC >> 2)
+
+  Lingering concerns:
+  Since we are using the MEPC, we don't have the PC of the first instruction in the program. 
+  (Probably does not matter because it's just 1 datapoint)
+*/
+_trace_interrupt:
+  // Save a register to dmem[1]
+  sw t0, 4(zero)
+
+  // clear mip.trace
+  li t0, 0x20000
+  csrrc zero, mip, t0
+
+  // load address of histogram array
+  lw t0, 0(zero)
+  // Store another register to dmem[0]
+  sw t1, 0(zero)
+
+  // read the mepc register
+  csrr t1, mepc
+  // find the correct index in the histogram array
+  add t0, t0, t1
+
+  // atomically increment the value at the computed index
+  li t1, 1
+  // We don't care about the result hence assigned to zero register
+  amoadd.w.aq zero, t1, (t0)
+
+  // remap t0 to histogram array base address
+  csrr t1, mepc
+  sub t0, t0, t1
+
+  // Restore registers and store base ptr back to dmem[0]
+  lw t1, 0(zero)
+  sw t0, 0(zero)
+  lw t0, 4(zero)
+
+  mret
+
+_remote_interrupt_handler:
+  // Add code here when using in actual programs, for now these are turned off
+  j fail
+#endif
+
+/*
+  Start code
+*/
+_start:
+  li  x1, 0
+  // li  x2, 0
+  li  x3, 0
+  li  x4, 0
+  li  x5, 0
+  li  x6, 0
+  li  x7, 0
+  li  x8, 0
+  li  x9, 0
+  li  x10,0
+  li  x11,0
+  li  x12,0
+  li  x13,0
+  li  x14,0
+  li  x15,0
+  li  x16,0
+  li  x17,0
+  li  x18,0
+  li  x19,0
+  li  x20,0
+  li  x21,0
+  li  x22,0
+  li  x23,0
+  li  x24,0
+  li  x25,0
+  li  x26,0
+  li  x27,0
+  li  x28,0
+  li  x29,0
+  li  x30,0
+  li  x31,0
+
+  // Enable FPU and FCSR
+  // These are ignored by manycore hardware but might be
+  // required by execution environments supporting 
+  // exceptions (such as Spike).
+  li t0, 0x00003000
+  csrs mstatus, t0
+  fscsr x0
+  li t0, 0
+
+  fcvt.s.w f0, x0 
+  fcvt.s.w f1, x0 
+  fcvt.s.w f2, x0 
+  fcvt.s.w f3, x0 
+  fcvt.s.w f4, x0 
+  fcvt.s.w f5, x0 
+  fcvt.s.w f6, x0 
+  fcvt.s.w f7, x0 
+  fcvt.s.w f8, x0 
+  fcvt.s.w f9, x0 
+  fcvt.s.w f10,x0 
+  fcvt.s.w f11,x0 
+  fcvt.s.w f12,x0 
+  fcvt.s.w f13,x0 
+  fcvt.s.w f14,x0 
+  fcvt.s.w f15,x0 
+  fcvt.s.w f16,x0 
+  fcvt.s.w f17,x0 
+  fcvt.s.w f18,x0 
+  fcvt.s.w f19,x0 
+  fcvt.s.w f20,x0 
+  fcvt.s.w f21,x0 
+  fcvt.s.w f22,x0 
+  fcvt.s.w f23,x0 
+  fcvt.s.w f24,x0 
+  fcvt.s.w f25,x0 
+  fcvt.s.w f26,x0 
+  fcvt.s.w f27,x0 
+  fcvt.s.w f28,x0 
+  fcvt.s.w f29,x0 
+  fcvt.s.w f30,x0 
+  fcvt.s.w f31,x0 
+
+  // initialize global pointer
+  la gp, _gp
+
+  la  tp, _bsg_data_end_addr + 63
+  and tp, tp, -64
+
+  // mbt: put stack at top of local memory
+  // mbt fix for 4KB IMEM / 4KB DMEM
+  la sp, _sp
+
+#if PROFILE > 0
+  /*
+    Profiler setup:
+    This needs to be completed before the actual program starts if profiling needs to be enabled. 
+    This snippet puts the base pointer for the histogram in dmem[0]
+  */
+  la t0, _histogram_arr
+  sw t0, 0(zero)
+  li t0, 0
+#endif
+
+#ifdef __bsg_newlib
+  call dramfs_init
+  call set_cmd_args
+  lw a0, 0(sp)     // argc
+  lw a1, -4(sp)    // argv
+  li a2, 0         // envp = NULL
+  call main
+  tail exit
+#else
+  j main
+#endif
+
+2:
+  // Should never reach this point
+  j 2b
+
+  // Must not come here
+fail:
+  j fail


### PR DESCRIPTION
This PR adds a software-based PC Profiler that uses the trace interrupt handler to build a PC histogram in DRAM.

There are 2 main files - 
1. profiler.S --> This is a C runtime file that does most of the initialization but in addition has the trace interrupt handler defined that updates the histogram. The profiler (i.e trace interrupt handler) uses the first 2 entries in DMEM to spill any registers before performing any action. It computes the index into the histogram based on the EPC and then atomically increments that location in memory. This depends on #476 to work correctly. Each PC has a 4 byte bin assigned to it at HISTOGRAM_BASE_ADDR + EPC.

2. main.c --> This contains a C program that sets up the tile and computes the first 10 fibonacci numbers (just a sample, could ideally be anything you want here). This program gets profiled by the profiler. It also includes a function that reads out this histogram and prints the data to the console and compares this against a statically generated expectation of what the number of hits for that PC should be. 

Testing: 
I tested this to work with a histogram array of size 4KB (simulation was taking too long at 16MB even for 1 tile) and used 16 tiles. There is a parameter that can be configured to alter the histogram array size as well. 

PS: This shows only a first, preliminary version of what the profiler should look like. I have listed some questions I had (there are probably more things I may not have thought about) about different parts of this exercise in the comments near the relevant piece of code (which will be removed before merge once answered).