### PR TITLE
quick fix for abs cycle count with mult. tags

### DIFF
--- a/software/py/vanilla_parser/stats_parser.py
+++ b/software/py/vanilla_parser/stats_parser.py
@@ -1399,12 +1399,12 @@ class VanillaStatsParser:
         # For calculating manycore stats, all tiles are considerd to be involved
         # For calculating tile group stats, only tiles inside the tile group are considered
         # For manycore (all tiles that participate in tag are included)
-        manycore_cycle_parallel_earliest_start = {tag: traces[0]["global_ctr"] for tag in tags}
+        manycore_cycle_parallel_earliest_start = {tag: traces[-1]["global_ctr"] for tag in tags}
         manycore_cycle_parallel_latest_end     = {tag: traces[0]["global_ctr"] for tag in tags}
         manycore_cycle_parallel_cnt       = {tag: 0 for tag in tags}
 
         # For each tile group (only tiles in a tile group that participate in a tag are included)
-        tile_group_cycle_parallel_earliest_start = {tag: [traces[0]["global_ctr"] for tg_id in range(self.max_tile_groups)] for tag in tags}
+        tile_group_cycle_parallel_earliest_start = {tag: [traces[-1]["global_ctr"] for tg_id in range(self.max_tile_groups)] for tag in tags}
         tile_group_cycle_parallel_latest_end     = {tag: [traces[0]["global_ctr"] for tg_id in range(self.max_tile_groups)] for tag in tags}
         tile_group_cycle_parallel_cnt            = {tag: [traces[0]["global_ctr"] for tg_id in range(self.max_tile_groups)] for tag in tags}
 


### PR DESCRIPTION
When using multiple tags the previous code was not correctly calculating the start/min cycle for each tag.
This PR instead initializes `manycore_cycle_parallel_earliest_start` to be the maximum event found in `traces` so that each tag is able to find the minimum event/cycle associated with that tag. 
These values are then updated in lines 1437/1438 and 1474/1475 to the minimum cycle.