### PR TITLE
Added print_stat wires to DRAMSim3

### DIFF
--- a/testbenches/common/v/bsg_nonsynth_manycore_testbench.v
+++ b/testbenches/common/v/bsg_nonsynth_manycore_testbench.v
@@ -410,6 +410,9 @@ module bsg_nonsynth_manycore_testbench
         ,.data_o              (dramsim3_data_lo[hbm2_num_channels_p*i+:hbm2_num_channels_p])
         ,.read_done_ch_addr_o (dramsim3_read_done_ch_addr_lo[hbm2_num_channels_p*i+:hbm2_num_channels_p])
 
+        ,.print_stat_v_i      ($root.`HOST_MODULE_PATH.print_stat_v)
+        ,.print_stat_tag_i    ($root.`HOST_MODULE_PATH.print_stat_tag)
+
         ,.write_done_o        ()
         ,.write_done_ch_addr_o()
       );


### PR DESCRIPTION
Adds the two ports to the DRAMSim3 Module instantiation. Uses $root to pull from the top level, so this solution works for both spmd_loader, and replicant.

Merge after https://github.com/bespoke-silicon-group/basejump_stl/pull/367