### PR TITLE
Pulled hetero_type_vec to top level of common testbench

### DIFF
--- a/testbenches/common/v/bsg_nonsynth_manycore_testbench.v
+++ b/testbenches/common/v/bsg_nonsynth_manycore_testbench.v
@@ -52,6 +52,12 @@ module bsg_nonsynth_manycore_testbench
     , parameter cache_bank_addr_width_lp = `BSG_SAFE_CLOG2(bsg_dram_size_p/(2*num_tiles_x_p)*4) // byte addr
     , parameter link_sif_width_lp =
       `bsg_manycore_link_sif_width(addr_width_p,data_width_p,x_cord_width_p,y_cord_width_p)
+
+    // This is used to define heterogeneous arrays. Each index defines
+    // the type of an X/Y coordinate in the array. This is a vector of
+    // num_tiles_x_p*num_tiles_y_p ints; type "0" is the
+    // default. See bsg_manycore_hetero_socket.v for more types.
+    , parameter int hetero_type_vec_p [0:(num_tiles_y_p*num_tiles_x_p) - 1]  = '{default:0}
   )
   (
     input clk_i
@@ -167,6 +173,7 @@ module bsg_nonsynth_manycore_testbench
     ,.num_pods_x_p(num_pods_x_p)
 
     ,.reset_depth_p(reset_depth_p)
+    ,.hetero_type_vec_p(hetero_type_vec_p)
   ) DUT (
     .clk_i(clk_i)
 

--- a/v/bsg_manycore_pod_ruche_array.v
+++ b/v/bsg_manycore_pod_ruche_array.v
@@ -60,6 +60,12 @@ module bsg_manycore_pod_ruche_array
       `bsg_ready_and_link_sif_width(wh_flit_width_p)
     , parameter ruche_x_link_sif_width_lp = 
       `bsg_manycore_ruche_x_link_sif_width(addr_width_p,data_width_p,x_cord_width_p,y_cord_width_p)
+
+    // This is used to define heterogeneous arrays. Each index defines
+    // the type of an X/Y coordinate in the array. This is a vector of
+    // num_tiles_x_p*num_tiles_y_p ints; type "0" is the
+    // default. See bsg_manycore_hetero_socket.v for more types.
+    , parameter int hetero_type_vec_p [0:(num_tiles_y_p*num_tiles_x_p) - 1]  = '{default:0}
   )
   (
     input clk_i
@@ -146,6 +152,7 @@ module bsg_manycore_pod_ruche_array
         ,.wh_len_width_p(wh_len_width_p)
 
         ,.reset_depth_p(reset_depth_p)
+        ,.hetero_type_vec_p(hetero_type_vec_p)
       ) pod (
         .clk_i(clk_i)
 


### PR DESCRIPTION
As title describes, pulled this out for network simulation and as a feature request by Cornell.

When the pod is split into two X and two Y subarrays, this is printed out: 

```
## MANYCORE HETERO TYPE CONFIGURATIONS
## ----------------------------------------------------------------
## 9,9,9,9,9,9,9,9,
## 9,9,9,9,9,9,9,9,
## 9,9,9,9,9,9,9,9,
## 9,9,9,9,9,9,9,9,
## ----------------------------------------------------------------
## ----------------------------------------------------------------
## MANYCORE HETERO TYPE CONFIGURATIONS
## ----------------------------------------------------------------
## 9,9,9,9,9,9,9,9,
## 9,9,9,9,9,9,9,9,
## 9,9,9,9,9,9,9,9,
## 9,9,9,9,9,9,9,9,
## ----------------------------------------------------------------
## ----------------------------------------------------------------
## MANYCORE HETERO TYPE CONFIGURATIONS
## ----------------------------------------------------------------
## 9,9,9,9,9,9,9,9,
## 9,9,9,9,9,9,9,9,
## 9,9,9,9,9,9,9,9,
## 9,9,9,9,9,9,9,9,
## ----------------------------------------------------------------
## ----------------------------------------------------------------
## MANYCORE HETERO TYPE CONFIGURATIONS
## ----------------------------------------------------------------
## 9,9,9,9,9,9,9,9,
## 9,9,9,9,9,9,9,9,
## 9,9,9,9,9,9,9,9,
## 9,9,9,9,9,9,9,9,
## ----------------------------------------------------------------
```

(NB: 9 is the type for my DPI tile. I also tested with 0.)