### PR TITLE
Add e_remote_sw to link_to_cache case statement

### DIFF
--- a/v/bsg_manycore_link_to_cache.v
+++ b/v/bsg_manycore_link_to_cache.v
@@ -272,7 +272,7 @@ module bsg_manycore_link_to_cache
         // for extra debugging capability.
         else if (packet_lo.addr[link_addr_width_p-1]) begin
           case (packet_lo.op_v2)
-            e_remote_store: cache_pkt.opcode = TAGST;
+            e_remote_store, e_remote_sw: cache_pkt.opcode = TAGST;
             e_remote_load:  cache_pkt.opcode = TAGLA;
             e_cache_op:     cache_pkt.opcode = TAGFL;
             default:        cache_pkt.opcode = TAGLA;


### PR DESCRIPTION
* e_remote_store can be used to clear a tag, e_remote_sw cannot. This
  fixes the issue

Don't merge yet, I still need to understand why this isn't showing up in our regression in replicant, but is in PyTorch