### PR TITLE
Add heartbeat to beebs, and macros and definitions for reuse

### DIFF
--- a/software/bsg_manycore_lib/bsg_manycore.h
+++ b/software/bsg_manycore_lib/bsg_manycore.h
@@ -79,6 +79,10 @@ typedef volatile void *bsg_remote_void_ptr;
 #define bsg_putchar( c )       do {  bsg_remote_uint8_ptr ptr = (bsg_remote_uint8_ptr) bsg_remote_ptr_io(IO_X_INDEX,0xEADC); *ptr = c; } while(0)
 #define bsg_putchar_err( c )       do {  bsg_remote_uint8_ptr ptr = (bsg_remote_uint8_ptr) bsg_remote_ptr_io(IO_X_INDEX,0xEEE0); *ptr = c; } while(0)
 
+#define bsg_heartbeat_init()       do {  bsg_remote_int_ptr ptr = bsg_remote_ptr_io(IO_X_INDEX,0xBEA0); *ptr = 0; } while(0)
+#define bsg_heartbeat_iter( itr )       do {  bsg_remote_int_ptr ptr = bsg_remote_ptr_io(IO_X_INDEX,0xBEA4); *ptr = itr; } while(0)
+#define bsg_heartbeat_end()       do {  bsg_remote_int_ptr ptr = bsg_remote_ptr_io(IO_X_INDEX,0xBEA8); *ptr = 0; } while(0)
+
 static inline void bsg_print_int(int i)
 {
         bsg_remote_int_ptr ptr = (bsg_remote_int_ptr)bsg_remote_ptr_io(IO_X_INDEX,0xEAE0);

--- a/software/spmd/beebs/Makefile
+++ b/software/spmd/beebs/Makefile
@@ -60,7 +60,7 @@ include $(BSG_MANYCORE_DIR)/software/mk/Makefile.tail_rules
 #########################
 
 BEEBS_CC      = "$(RISCV_GCC)"
-BEEBS_CFLAGS  = "$(RISCV_GCC_OPTS) -DBOARD_REPEAT_FACTOR=$(REPEAT_FACTOR) -D__bsg_argc=1 -D__bsg_argv=0"
+BEEBS_CFLAGS  = "$(RISCV_GCC_OPTS) -DBOARD_REPEAT_FACTOR=$(REPEAT_FACTOR) -D__bsg_argc=1 -D__bsg_argv=0 -I$(BSG_MANYCORE_DIR)/software/bsg_manycore_lib"
 COMMON_SRCS   = $(RUN_DIR)/../common/args.c \
                 $(RUN_DIR)/../common/crt.S \
                 $(RUN_DIR)/../../bsg_manycore_lib/bsg_newlib_intf.c \

--- a/testbenches/common/v/bsg_nonsynth_manycore_monitor.v
+++ b/testbenches/common/v/bsg_nonsynth_manycore_monitor.v
@@ -186,6 +186,18 @@ module bsg_nonsynth_manycore_monitor
             $display("[INFO][MONITOR] RECEIVED TIME BSG_PACKET from tile y,x=%2d,%2d, data=%x, time=%0t",
               src_y_cord_i, src_x_cord_i, data_i, $time);
           end
+          else if (epa_addr == bsg_heartbeat_init_epa_gp) begin
+            $display("[INFO][MONITOR] RECEIVED HEARTBEAT START from tile y,x=%2d,%2d, data=%x, time=%0t",
+              src_y_cord_i, src_x_cord_i, data_i, $time);
+          end
+          else if (epa_addr == bsg_heartbeat_iter_epa_gp) begin
+            $display("[INFO][MONITOR] RECEIVED HEARTBEAT ITER from tile y,x=%2d,%2d, data=%x, time=%0t",
+              src_y_cord_i, src_x_cord_i, data_i, $time);
+          end
+          else if (epa_addr == bsg_heartbeat_end_epa_gp) begin
+            $display("[INFO][MONITOR] RECEIVED HEARTBEAT END from tile y,x=%2d,%2d, data=%x, time=%0t",
+              src_y_cord_i, src_x_cord_i, data_i, $time);
+          end
           else if (epa_addr == bsg_fail_epa_gp) begin
             $display("[INFO][MONITOR] RECEIVED BSG_FAIL PACKET from tile y,x=%2d,%2d, data=%x, time=%0t",
               src_y_cord_i, src_x_cord_i, data_i, $time);

--- a/v/bsg_manycore_addr_pkg.v
+++ b/v/bsg_manycore_addr_pkg.v
@@ -23,10 +23,6 @@ package bsg_manycore_addr_pkg;
   parameter bsg_branch_trace_epa_gp = 16'heee4;
   parameter bsg_print_stat_epa_gp   = 16'h0d0c;
 
-  parameter bsg_heartbeat_init_npa_gp = bsg_io_npa_prefix_gp | 32'(bsg_heartbeat_init_epa_gp );
-  parameter bsg_heartbeat_iter_npa_gp = bsg_io_npa_prefix_gp | 32'(bsg_heartbeat_iter_epa_gp );
-  parameter bsg_heartbeat_end_npa_gp = bsg_io_npa_prefix_gp | 32'(bsg_heartbeat_end_epa_gp  );
-
   parameter bsg_finish_npa_gp       = bsg_io_npa_prefix_gp | 32'(bsg_finish_epa_gp      );
   parameter bsg_time_npa_gp         = bsg_io_npa_prefix_gp | 32'(bsg_time_epa_gp        );
   parameter bsg_fail_npa_gp         = bsg_io_npa_prefix_gp | 32'(bsg_fail_epa_gp        );

--- a/v/bsg_manycore_addr_pkg.v
+++ b/v/bsg_manycore_addr_pkg.v
@@ -11,6 +11,10 @@ package bsg_manycore_addr_pkg;
   parameter bsg_io_npa_prefix_gp   = 32'h4000_0000;
 
   // IO EPA (word address)
+  parameter bsg_heartbeat_init_epa_gp = 16'hbea0;
+  parameter bsg_heartbeat_iter_epa_gp = 16'hbea4;
+  parameter bsg_heartbeat_end_epa_gp = 16'hbea8;
+
   parameter bsg_finish_epa_gp       = 16'head0;
   parameter bsg_time_epa_gp         = 16'head4;
   parameter bsg_fail_epa_gp         = 16'head8;
@@ -18,6 +22,10 @@ package bsg_manycore_addr_pkg;
   parameter bsg_stderr_epa_gp       = 16'heee0;
   parameter bsg_branch_trace_epa_gp = 16'heee4;
   parameter bsg_print_stat_epa_gp   = 16'h0d0c;
+
+  parameter bsg_heartbeat_init_npa_gp = bsg_io_npa_prefix_gp | 32'(bsg_heartbeat_init_epa_gp );
+  parameter bsg_heartbeat_iter_npa_gp = bsg_io_npa_prefix_gp | 32'(bsg_heartbeat_iter_epa_gp );
+  parameter bsg_heartbeat_end_npa_gp = bsg_io_npa_prefix_gp | 32'(bsg_heartbeat_end_epa_gp  );
 
   parameter bsg_finish_npa_gp       = bsg_io_npa_prefix_gp | 32'(bsg_finish_epa_gp      );
   parameter bsg_time_npa_gp         = bsg_io_npa_prefix_gp | 32'(bsg_time_epa_gp        );


### PR DESCRIPTION
* Added start/iter/end heartbeat macros
* Updated submodule to new branch

I added three macros for a heartbeat. I figured most code would have initialization code, and some might have checking code at the end. Since errors can still happen in these regions, I wanted to provide a way to annotate setup and teardown code.

I also wanted this to be reusable and light weight, hence why i added it to manycore and not just adding a bsg_printf macro.


Example output:

```
[BSG_INFO][SPMD_LOADER] SPMD loader finished loading. t=10619000
[INFO][RX] Unfreezing tile t=10622000, x= 16, y=  8
[INFO][MONITOR] RECEIVED HEARTBEAT START from tile y,x= 8,16, data=00000000, time=489063000
[INFO][MONITOR] RECEIVED HEARTBEAT ITER from tile y,x= 8,16, data=00000000, time=508000000
[INFO][MONITOR] RECEIVED HEARTBEAT ITER from tile y,x= 8,16, data=00000001, time=525690000
[INFO][MONITOR] RECEIVED HEARTBEAT END from tile y,x= 8,16, data=00000000, time=526233000
[INFO][MONITOR] RECEIVED a finish packet from tile y,x= 8,16, data=00000000, time=541189000
[INFO][MONITOR] RECEIVED BSG_FINISH PACKET from all pods, time=541190000
```