### PR TITLE
Reducing runtime of simulation execution

### DIFF
--- a/software/spmd/Makefile
+++ b/software/spmd/Makefile
@@ -150,7 +150,7 @@ SCRAPE-TAIL=/usr/bin/sed 's@.*/@@g' | /usr/bin/sed 's@-run.log@@g' | /usr/bin/co
 
 summary: BSG_FINISH.scrape BSG_FINISH.scrape.i BSG_TIMEOUT.scrape BSG_FAIL.scrape BSG_ERROR.scrape
 	@echo -n "Free disk:"; df .
-	@echo -n "SIMVs running:"; /usr/bin/ps a | /usr/bin/grep simv
+	@echo  "SIMVs running:"; /usr/bin/ps a | /usr/bin/grep simv
 
 watch-summary:
 	watch make summary

--- a/software/spmd/amoadd_test/main.c
+++ b/software/spmd/amoadd_test/main.c
@@ -44,8 +44,11 @@ void atomic_add()
 
   if (__bsg_id == 0)
   {
-    bsg_printf("%d\n", data[0]);
-    bsg_printf("%d\n", data[1]);
+    // bsg_printf("%d\n", data[0]);
+    // bsg_printf("%d\n", data[1]);
+    // Replaced to reduce runtime
+    bsg_print_int(data[0]);
+    bsg_print_int(data[1]);
 
     int expected = 0;
     int sum = 0;

--- a/software/spmd/bsg_outbuf_full2/main.c
+++ b/software/spmd/bsg_outbuf_full2/main.c
@@ -14,7 +14,9 @@ void proc (int id)
   {
     if (valid == 1) break;
   }
-  bsg_printf("I am awake. id=%d\n", id);
+  bsg_heartbeat_iter(id);
+  // Replaced to reduce simulation runtime and remove printf from binary
+  // bsg_printf("I am awake. id=%d\n", id);
 
   // copy from buf0 to buf1
   for (int i = 0; i < N; i++)

--- a/software/spmd/perf_test_conv3x3/main.cpp
+++ b/software/spmd/perf_test_conv3x3/main.cpp
@@ -90,7 +90,9 @@ int main()
   // validate
   #define hex(x) (*(int*)&x)
   if (sum != mydata*22.0f) {
-    bsg_printf("%x\n", hex(sum));
+    // bsg_printf("%x\n", hex(sum));
+    // Replaced to reduce simulation runtime and remove printf from binary
+    bsg_print_hexadecimal(sum);
     bsg_fail();
   }
 

--- a/software/spmd/perf_test_reduction/main.cpp
+++ b/software/spmd/perf_test_reduction/main.cpp
@@ -56,7 +56,9 @@ int main()
   if (__bsg_id == 0) bsg_cuda_print_stat_start(0);
 
   if (sum != 8128.0f) {
-    bsg_printf("%x\n", hex(sum));
+    // bsg_printf("%x\n", hex(sum));
+    // Replaced to reduce simulation runtime by removing printf from binary
+    bsg_print_hexadecimal(sum);
     bsg_fail();
   }
 

--- a/software/spmd/vcache_atomic_inc/main.c
+++ b/software/spmd/vcache_atomic_inc/main.c
@@ -17,8 +17,10 @@ void atomic_inc()
 
   // critical region
   int local_data = data;
-  data = local_data+1; 
-  bsg_printf("%d\n",local_data);
+  data = local_data+1;
+  bsg_print_int(local_data);
+  // Replaced with printf to reduce runtime of simulation
+  // bsg_printf("%d\n",local_data);
 
   //bsg_printf("I'm releasing the lock... x=%d y=%d\n", __bsg_x, __bsg_y);
 

--- a/testbenches/common/v/bsg_nonsynth_manycore_spmd_loader.v
+++ b/testbenches/common/v/bsg_nonsynth_manycore_spmd_loader.v
@@ -124,7 +124,7 @@ module bsg_nonsynth_manycore_spmd_loader
       if (loader_done)
         $display("[BSG_INFO][SPMD_LOADER] SPMD loader finished loading. t=%0t", $time);
   
-      if (v_o & ready_i & verbose_p)
+      if (v_o & ready_i & (verbose_p | (nbf_addr_r[9:0] == '0)))
         $display("[BSG_INFO][SPMD_LOADER] sending packet #%0d. x,y=%0d,%0d, addr=%x, data=%x, t=%0t",
           nbf_addr_r,
           packet.x_cord, packet.y_cord,


### PR DESCRIPTION
* Replace printf with bsg_print_hexadecimal/int or heartbeats
* make SPMD loader print once every 1024 packets when !verbose_p

In the RC-ALPHA-RTLFREEZE-0 RTL the following tests were the longest of the SPMD suite: 

* quicksort 12961 sec
* vcache_atomic_histogram 17486 sec
* vcache_atomic_histogram2 17739 sec
* perf_test_reduction 20072 sec
* perf_test_conv3x3 21529 sec
* test_credit_limit_csr_multi 22100 sec
* amoadd_test 24099 sec
* bsg_barrier 24771 sec
* bsg_tile_group_barrier 26798 sec
* jal_rv32 28044 sec
* vcache_atomic_inc 28875 sec
* bsg_outbuf_full2 42535 sec

Of these, quicksort (fixed in #530), perf_test_reduction, perf_test_conv3x3, amoadd_test, bsg_barrier, bsg_tile_group_barrier, vcache_atomic_inc, bsg_outbuf_full2 use bsg_printf. Most of these can be replaced with print_hex, print_int, or heartbeat -- which actually provides better debugging, too, since it prints out the source of the integer/hex/heartbeat.

bsg_printf has a high cost in full-chip testing. When executing, tiles try to grab the spinlock at the host, which increases congestion and slows down outgoing print packets, which slows down the progress even more. On top of that, when printf is in the compiled binary the NBF size can double (or more). 

bsg_printf is tested in other tests that are shorter and faster: (nprimes, hello, kmean, fib, striped_hello, etc) that are significantly faster AND not in the tail of the distribution.

Therefore, I propose that we remove printf from these tests. 

Since stdout on linux can slow down simulation, but is a useful heartbeat, I also added a feature to the SPMD loader that prints out the address every 1000 packets when simulating instead of every packet. 
