### PR TITLE
Adds BSG_INV_PARAM and BSG_ABSTRACT_MODULES

### DIFF
--- a/v/bsg_cache_dma_to_wormhole.v
+++ b/v/bsg_cache_dma_to_wormhole.v
@@ -7,6 +7,7 @@
  *    for read dma packets, it sends the read header flit, and receives the fill data asynchronously.
  */
 
+`include "bsg_defines.v"
 `include "bsg_noc_links.vh"
 
 

--- a/v/bsg_cache_dma_to_wormhole.v
+++ b/v/bsg_cache_dma_to_wormhole.v
@@ -14,16 +14,16 @@
 module bsg_cache_dma_to_wormhole
   import bsg_cache_pkg::*;
   import bsg_manycore_pkg::*;
-  #(parameter vcache_addr_width_p="inv"
-    , parameter vcache_data_width_p="inv"
-    , parameter vcache_dma_data_width_p="inv"
-    , parameter vcache_block_size_in_words_p="inv"
+  #(`BSG_INV_PARAM(vcache_addr_width_p)
+    , `BSG_INV_PARAM(vcache_data_width_p)
+    , `BSG_INV_PARAM(vcache_dma_data_width_p)
+    , `BSG_INV_PARAM(vcache_block_size_in_words_p)
     
     // flit width should match the vcache dma width.
-    , parameter wh_flit_width_p="inv"
-    , parameter wh_cid_width_p="inv"
-    , parameter wh_len_width_p="inv"
-    , parameter wh_cord_width_p = "inv"
+    , `BSG_INV_PARAM(wh_flit_width_p)
+    , `BSG_INV_PARAM(wh_cid_width_p)
+    , `BSG_INV_PARAM(wh_len_width_p)
+    , `BSG_INV_PARAM(wh_cord_width_p)
     
     , parameter data_len_lp = (vcache_data_width_p*vcache_block_size_in_words_p/vcache_dma_data_width_p)
 
@@ -289,3 +289,5 @@ module bsg_cache_dma_to_wormhole
 
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_cache_dma_to_wormhole)

--- a/v/bsg_manycore_accel_default.v
+++ b/v/bsg_manycore_accel_default.v
@@ -1,3 +1,6 @@
+
+`include "bsg_defines.v"
+
 module bsg_manycore_accel_default 
   import bsg_manycore_pkg::*;
   import bsg_vanilla_pkg::*;

--- a/v/bsg_manycore_accel_default.v
+++ b/v/bsg_manycore_accel_default.v
@@ -4,30 +4,30 @@
 module bsg_manycore_accel_default 
   import bsg_manycore_pkg::*;
   import bsg_vanilla_pkg::*;
-   #(parameter x_cord_width_p   = "inv"
-     , parameter y_cord_width_p = "inv"
-     , parameter pod_x_cord_width_p = "inv"
-     , parameter pod_y_cord_width_p = "inv"
+   #(`BSG_INV_PARAM(x_cord_width_p   )
+     , `BSG_INV_PARAM(y_cord_width_p )
+     , `BSG_INV_PARAM(pod_x_cord_width_p )
+     , `BSG_INV_PARAM(pod_y_cord_width_p )
      , parameter data_width_p   = 32
-     , parameter addr_width_p   = "inv"
+     , `BSG_INV_PARAM(addr_width_p   )
 
-     , parameter icache_entries_p = "inv"
-     , parameter icache_tag_width_p = "inv"
+     , `BSG_INV_PARAM(icache_entries_p )
+     , `BSG_INV_PARAM(icache_tag_width_p )
 
-     , parameter dmem_size_p = "inv" 
-     , parameter num_vcache_rows_p = "inv"
-     , parameter vcache_size_p = "inv"
-     , parameter vcache_block_size_in_words_p = "inv"
-     , parameter vcache_sets_p = "inv"
+     , `BSG_INV_PARAM(dmem_size_p ) 
+     , `BSG_INV_PARAM(num_vcache_rows_p )
+     , `BSG_INV_PARAM(vcache_size_p )
+     , `BSG_INV_PARAM(vcache_block_size_in_words_p )
+     , `BSG_INV_PARAM(vcache_sets_p )
 
-     , parameter num_tiles_x_p = "inv"
-     , parameter num_tiles_y_p = "inv"
+     , `BSG_INV_PARAM(num_tiles_x_p )
+     , `BSG_INV_PARAM(num_tiles_y_p )
 
      , parameter x_subcord_width_lp = `BSG_SAFE_CLOG2(num_tiles_x_p)
      , parameter y_subcord_width_lp = `BSG_SAFE_CLOG2(num_tiles_y_p)
 
-     , parameter rev_fifo_els_p="inv" // for FIFO credit counting.
-     , parameter fwd_fifo_els_p="inv" // for FIFO credit counting.
+     , `BSG_INV_PARAM(rev_fifo_els_p) // for FIFO credit counting.
+     , `BSG_INV_PARAM(fwd_fifo_els_p) // for FIFO credit counting.
 
      , parameter credit_counter_width_lp = `BSG_WIDTH(32)
      , parameter proc_fifo_els_p = 4
@@ -252,3 +252,5 @@ module bsg_manycore_accel_default
 
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_manycore_accel_default)

--- a/v/bsg_manycore_dram_hash_function.v
+++ b/v/bsg_manycore_dram_hash_function.v
@@ -13,19 +13,19 @@
 `include "bsg_defines.v"
 
 module bsg_manycore_dram_hash_function 
-  #(parameter data_width_p="inv"
-    , parameter addr_width_p="inv"
-    , parameter x_cord_width_p="inv"
-    , parameter y_cord_width_p="inv"
+  #(`BSG_INV_PARAM(data_width_p)
+    , `BSG_INV_PARAM(addr_width_p)
+    , `BSG_INV_PARAM(x_cord_width_p)
+    , `BSG_INV_PARAM(y_cord_width_p)
 
-    , parameter pod_x_cord_width_p="inv"
-    , parameter pod_y_cord_width_p="inv"
+    , `BSG_INV_PARAM(pod_x_cord_width_p)
+    , `BSG_INV_PARAM(pod_y_cord_width_p)
 
-    , parameter x_subcord_width_p="inv"
-    , parameter y_subcord_width_p="inv"
+    , `BSG_INV_PARAM(x_subcord_width_p)
+    , `BSG_INV_PARAM(y_subcord_width_p)
 
-    , parameter num_vcache_rows_p="inv"
-    , parameter vcache_block_size_in_words_p="inv"
+    , `BSG_INV_PARAM(num_vcache_rows_p)
+    , `BSG_INV_PARAM(vcache_block_size_in_words_p)
   )
   (
     input [data_width_p-1:0] eva_i // 32-bit byte address
@@ -76,3 +76,5 @@ module bsg_manycore_dram_hash_function
 
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_manycore_dram_hash_function)

--- a/v/bsg_manycore_dram_hash_function.v
+++ b/v/bsg_manycore_dram_hash_function.v
@@ -10,6 +10,8 @@
 
   // ungroup this module for synthesis.
 
+`include "bsg_defines.v"
+
 module bsg_manycore_dram_hash_function 
   #(parameter data_width_p="inv"
     , parameter addr_width_p="inv"

--- a/v/bsg_manycore_endpoint.v
+++ b/v/bsg_manycore_endpoint.v
@@ -7,11 +7,11 @@
 
 module bsg_manycore_endpoint
   import bsg_manycore_pkg::*;
-  #(parameter x_cord_width_p = "inv"
-    , parameter y_cord_width_p = "inv"
-    , parameter fifo_els_p = "inv"
+  #(`BSG_INV_PARAM(x_cord_width_p )
+    , `BSG_INV_PARAM(y_cord_width_p )
+    , `BSG_INV_PARAM(fifo_els_p )
     , parameter data_width_p = 32
-    , parameter addr_width_p = "inv"
+    , `BSG_INV_PARAM(addr_width_p )
     
     , parameter packet_width_lp = 
       `bsg_manycore_packet_width(addr_width_p,data_width_p,x_cord_width_p,y_cord_width_p)
@@ -140,5 +140,7 @@ module bsg_manycore_endpoint
 
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_manycore_endpoint)
 
 

--- a/v/bsg_manycore_endpoint.v
+++ b/v/bsg_manycore_endpoint.v
@@ -3,6 +3,8 @@
  *
  */
 
+`include "bsg_defines.v"
+
 module bsg_manycore_endpoint
   import bsg_manycore_pkg::*;
   #(parameter x_cord_width_p = "inv"

--- a/v/bsg_manycore_endpoint_fc.v
+++ b/v/bsg_manycore_endpoint_fc.v
@@ -14,11 +14,11 @@
 
 module bsg_manycore_endpoint_fc
   import bsg_manycore_pkg::*;
-  #(parameter x_cord_width_p          = "inv"
-    , parameter y_cord_width_p         = "inv"
-    , parameter fifo_els_p             = "inv"
+  #(`BSG_INV_PARAM(x_cord_width_p          )
+    , `BSG_INV_PARAM(y_cord_width_p         )
+    , `BSG_INV_PARAM(fifo_els_p             )
     , parameter data_width_p           = 32
-    , parameter addr_width_p           = "inv"
+    , `BSG_INV_PARAM(addr_width_p           )
 
     , parameter credit_counter_width_p = `BSG_WIDTH(32)
     , parameter warn_out_of_credits_p  = 1
@@ -165,5 +165,7 @@ module bsg_manycore_endpoint_fc
 
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_manycore_endpoint_fc)
 
 

--- a/v/bsg_manycore_endpoint_fc.v
+++ b/v/bsg_manycore_endpoint_fc.v
@@ -10,6 +10,8 @@
 //   for more details on the endpoint standard interface
 //
 
+`include "bsg_defines.v"
+
 module bsg_manycore_endpoint_fc
   import bsg_manycore_pkg::*;
   #(parameter x_cord_width_p          = "inv"

--- a/v/bsg_manycore_endpoint_standard.v
+++ b/v/bsg_manycore_endpoint_standard.v
@@ -27,11 +27,11 @@
 
 module bsg_manycore_endpoint_standard 
   import bsg_manycore_pkg::*; 
-  #(parameter x_cord_width_p          = "inv"
-    , parameter y_cord_width_p         = "inv"
-    , parameter fifo_els_p             = "inv"
+  #(`BSG_INV_PARAM(x_cord_width_p          )
+    , `BSG_INV_PARAM(y_cord_width_p         )
+    , `BSG_INV_PARAM(fifo_els_p             )
     , parameter data_width_p           = 32
-    , parameter addr_width_p           = "inv"
+    , `BSG_INV_PARAM(addr_width_p           )
 
     , parameter credit_counter_width_p = `BSG_WIDTH(32)
     , parameter warn_out_of_credits_p  = 1
@@ -393,5 +393,7 @@ module bsg_manycore_endpoint_standard
   // synopsys translate_on
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_manycore_endpoint_standard)
 
 

--- a/v/bsg_manycore_endpoint_standard.v
+++ b/v/bsg_manycore_endpoint_standard.v
@@ -23,6 +23,8 @@
 //              |  <------------------- |               |          |         |
 //--------------                        |---------------|          |---------|
 
+`include "bsg_defines.v"
+
 module bsg_manycore_endpoint_standard 
   import bsg_manycore_pkg::*; 
   #(parameter x_cord_width_p          = "inv"

--- a/v/bsg_manycore_eva_to_npa.v
+++ b/v/bsg_manycore_eva_to_npa.v
@@ -20,22 +20,22 @@
 
 module bsg_manycore_eva_to_npa
   import bsg_manycore_pkg::*;
-  #(parameter data_width_p="inv" // 32
-    , parameter addr_width_p="inv"
-    , parameter x_cord_width_p="inv"
-    , parameter y_cord_width_p="inv"
-    , parameter pod_x_cord_width_p="inv"
-    , parameter pod_y_cord_width_p="inv"
+  #(`BSG_INV_PARAM(data_width_p) // 32
+    , `BSG_INV_PARAM(addr_width_p)
+    , `BSG_INV_PARAM(x_cord_width_p)
+    , `BSG_INV_PARAM(y_cord_width_p)
+    , `BSG_INV_PARAM(pod_x_cord_width_p)
+    , `BSG_INV_PARAM(pod_y_cord_width_p)
  
-    , parameter num_tiles_x_p="inv"
-    , parameter num_tiles_y_p="inv"
+    , `BSG_INV_PARAM(num_tiles_x_p)
+    , `BSG_INV_PARAM(num_tiles_y_p)
     , parameter x_subcord_width_lp=`BSG_SAFE_CLOG2(num_tiles_x_p)
     , parameter y_subcord_width_lp=`BSG_SAFE_CLOG2(num_tiles_y_p)
 
-    , parameter num_vcache_rows_p = "inv"
-    , parameter vcache_block_size_in_words_p="inv"  // block size in vcache
-    , parameter vcache_size_p="inv" // vcache capacity in words
-    , parameter vcache_sets_p="inv" // number of sets in vcache
+    , `BSG_INV_PARAM(num_vcache_rows_p )
+    , `BSG_INV_PARAM(vcache_block_size_in_words_p)  // block size in vcache
+    , `BSG_INV_PARAM(vcache_size_p) // vcache capacity in words
+    , `BSG_INV_PARAM(vcache_sets_p) // number of sets in vcache
   )
   (
     // EVA 32-bit virtual address used by vanilla core
@@ -141,3 +141,5 @@ module bsg_manycore_eva_to_npa
 
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_manycore_eva_to_npa)

--- a/v/bsg_manycore_eva_to_npa.v
+++ b/v/bsg_manycore_eva_to_npa.v
@@ -16,6 +16,7 @@
  *    https://github.com/bespoke-silicon-group/bsg_manycore/blob/master/software/py/nbf.py
  */
 
+`include "bsg_defines.v"
 
 module bsg_manycore_eva_to_npa
   import bsg_manycore_pkg::*;

--- a/v/bsg_manycore_gather_scatter.v
+++ b/v/bsg_manycore_gather_scatter.v
@@ -28,6 +28,7 @@
  *
  */
 
+`include "bsg_defines.v"
 
 module bsg_manycore_gather_scatter
   import bsg_manycore_pkg::*;

--- a/v/bsg_manycore_gather_scatter.v
+++ b/v/bsg_manycore_gather_scatter.v
@@ -33,30 +33,30 @@
 module bsg_manycore_gather_scatter
   import bsg_manycore_pkg::*;
   import bsg_vanilla_pkg::*;
-  #(parameter x_cord_width_p = "inv"
-    , parameter y_cord_width_p = "inv"
-    , parameter pod_x_cord_width_p = "inv"
-    , parameter pod_y_cord_width_p = "inv"
-    , parameter data_width_p = "inv"
-    , parameter addr_width_p = "inv"
+  #(`BSG_INV_PARAM(x_cord_width_p )
+    , `BSG_INV_PARAM(y_cord_width_p )
+    , `BSG_INV_PARAM(pod_x_cord_width_p )
+    , `BSG_INV_PARAM(pod_y_cord_width_p )
+    , `BSG_INV_PARAM(data_width_p )
+    , `BSG_INV_PARAM(addr_width_p )
 
-    , parameter icache_entries_p = "inv"
-    , parameter icache_tag_width_p = "inv"
+    , `BSG_INV_PARAM(icache_entries_p )
+    , `BSG_INV_PARAM(icache_tag_width_p )
 
-    , parameter dmem_size_p = "inv" 
-    , parameter num_vcache_rows_p = "inv"
-    , parameter vcache_size_p = "inv"
-    , parameter vcache_block_size_in_words_p = "inv"
-    , parameter vcache_sets_p = "inv"
+    , `BSG_INV_PARAM(dmem_size_p ) 
+    , `BSG_INV_PARAM(num_vcache_rows_p )
+    , `BSG_INV_PARAM(vcache_size_p )
+    , `BSG_INV_PARAM(vcache_block_size_in_words_p )
+    , `BSG_INV_PARAM(vcache_sets_p )
 
-    , parameter num_tiles_x_p = "inv"
-    , parameter num_tiles_y_p = "inv"
+    , `BSG_INV_PARAM(num_tiles_x_p )
+    , `BSG_INV_PARAM(num_tiles_y_p )
 
     , parameter x_subcord_width_lp = `BSG_SAFE_CLOG2(num_tiles_x_p)
     , parameter y_subcord_width_lp = `BSG_SAFE_CLOG2(num_tiles_y_p)
 
-    , parameter rev_fifo_els_p="inv" // for FIFO credit counting.
-    , parameter fwd_fifo_els_p="inv" // for FIFO credit counting.
+    , `BSG_INV_PARAM(rev_fifo_els_p) // for FIFO credit counting.
+    , `BSG_INV_PARAM(fwd_fifo_els_p) // for FIFO credit counting.
 
     , parameter credit_counter_width_lp = `BSG_WIDTH(32)
     , parameter proc_fifo_els_p = 4
@@ -646,3 +646,5 @@ module bsg_manycore_gather_scatter
 
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_manycore_gather_scatter)

--- a/v/bsg_manycore_hetero_socket.v
+++ b/v/bsg_manycore_hetero_socket.v
@@ -49,27 +49,27 @@
 
 module bsg_manycore_hetero_socket
   import bsg_manycore_pkg::*;
-  #(parameter x_cord_width_p = "inv"
-    , parameter y_cord_width_p = "inv"
-    , parameter data_width_p = "inv"
-    , parameter addr_width_p = "inv"
-    , parameter dmem_size_p = "inv"
-    , parameter icache_entries_p = "inv" // in words
-    , parameter icache_tag_width_p = "inv"
-    , parameter num_vcache_rows_p = "inv"
-    , parameter vcache_size_p = "inv"
+  #(`BSG_INV_PARAM(x_cord_width_p )
+    , `BSG_INV_PARAM(y_cord_width_p )
+    , `BSG_INV_PARAM(data_width_p )
+    , `BSG_INV_PARAM(addr_width_p )
+    , `BSG_INV_PARAM(dmem_size_p )
+    , `BSG_INV_PARAM(icache_entries_p ) // in words
+    , `BSG_INV_PARAM(icache_tag_width_p )
+    , `BSG_INV_PARAM(num_vcache_rows_p )
+    , `BSG_INV_PARAM(vcache_size_p )
     , parameter debug_p = 0
     , parameter int hetero_type_p = 0
-    , parameter pod_x_cord_width_p="inv"
-    , parameter pod_y_cord_width_p="inv"
-    , parameter num_tiles_x_p="inv"
-    , parameter num_tiles_y_p="inv"
+    , `BSG_INV_PARAM(pod_x_cord_width_p)
+    , `BSG_INV_PARAM(pod_y_cord_width_p)
+    , `BSG_INV_PARAM(num_tiles_x_p)
+    , `BSG_INV_PARAM(num_tiles_y_p)
     , parameter x_subcord_width_lp = `BSG_SAFE_CLOG2(num_tiles_x_p)
     , parameter y_subcord_width_lp = `BSG_SAFE_CLOG2(num_tiles_y_p)
-    , parameter vcache_block_size_in_words_p="inv"
-    , parameter vcache_sets_p="inv"
-    , parameter fwd_fifo_els_p = "inv"
-    , parameter rev_fifo_els_p = "inv"
+    , `BSG_INV_PARAM(vcache_block_size_in_words_p)
+    , `BSG_INV_PARAM(vcache_sets_p)
+    , `BSG_INV_PARAM(fwd_fifo_els_p )
+    , `BSG_INV_PARAM(rev_fifo_els_p )
 
     , parameter bsg_manycore_link_sif_width_lp =
       `bsg_manycore_link_sif_width(addr_width_p,data_width_p,x_cord_width_p,y_cord_width_p)
@@ -110,3 +110,5 @@ module bsg_manycore_hetero_socket
   end
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_manycore_hetero_socket)

--- a/v/bsg_manycore_hetero_socket.v
+++ b/v/bsg_manycore_hetero_socket.v
@@ -45,6 +45,8 @@
            );                                                                          \
      end
 
+`include "bsg_defines.v"
+
 module bsg_manycore_hetero_socket
   import bsg_manycore_pkg::*;
   #(parameter x_cord_width_p = "inv"

--- a/v/bsg_manycore_hor_io_router.v
+++ b/v/bsg_manycore_hor_io_router.v
@@ -10,6 +10,7 @@
  *    use tieoff_east_p, if this router is attaching to the east side of the pod.
  */
 
+`include "bsg_defines.v"
 
 module bsg_manycore_hor_io_router
   import bsg_noc_pkg::*;

--- a/v/bsg_manycore_hor_io_router.v
+++ b/v/bsg_manycore_hor_io_router.v
@@ -16,15 +16,15 @@ module bsg_manycore_hor_io_router
   import bsg_noc_pkg::*;
   import bsg_manycore_pkg::*;
   import bsg_mesh_router_pkg::*;
-  #(parameter addr_width_p="inv"
-    , parameter data_width_p="inv"
-    , parameter x_cord_width_p="inv"
-    , parameter y_cord_width_p="inv"
+  #(`BSG_INV_PARAM(addr_width_p)
+    , `BSG_INV_PARAM(data_width_p)
+    , `BSG_INV_PARAM(x_cord_width_p)
+    , `BSG_INV_PARAM(y_cord_width_p)
    
-    , parameter ruche_factor_X_p="inv"
+    , `BSG_INV_PARAM(ruche_factor_X_p)
  
-    , parameter tieoff_west_p="inv"
-    , parameter tieoff_east_p="inv"
+    , `BSG_INV_PARAM(tieoff_west_p)
+    , `BSG_INV_PARAM(tieoff_east_p)
     , parameter tieoff_proc_p=0
 
     , parameter dims_lp=3 // only support 3
@@ -173,3 +173,5 @@ module bsg_manycore_hor_io_router
 
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_manycore_hor_io_router)

--- a/v/bsg_manycore_hor_io_router_column.v
+++ b/v/bsg_manycore_hor_io_router_column.v
@@ -5,6 +5,7 @@
  *    which can attach to the side of the pods to provide accelerator connectivity.
  */
 
+`include "bsg_defines.v"
 
 module bsg_manycore_hor_io_router_column
   import bsg_noc_pkg::*;

--- a/v/bsg_manycore_hor_io_router_column.v
+++ b/v/bsg_manycore_hor_io_router_column.v
@@ -10,15 +10,15 @@
 module bsg_manycore_hor_io_router_column
   import bsg_noc_pkg::*;
   import bsg_manycore_pkg::*;
-  #(parameter addr_width_p="inv"
-    , parameter data_width_p="inv"
-    , parameter x_cord_width_p="inv"
-    , parameter y_cord_width_p="inv"
-    , parameter ruche_factor_X_p="inv"
+  #(`BSG_INV_PARAM(addr_width_p)
+    , `BSG_INV_PARAM(data_width_p)
+    , `BSG_INV_PARAM(x_cord_width_p)
+    , `BSG_INV_PARAM(y_cord_width_p)
+    , `BSG_INV_PARAM(ruche_factor_X_p)
     
-    , parameter num_row_p="inv"
-    , parameter bit [num_row_p-1:0] tieoff_west_p="inv"
-    , parameter bit [num_row_p-1:0] tieoff_east_p ="inv"
+    , `BSG_INV_PARAM(num_row_p)
+    , `BSG_INV_PARAM(bit [num_row_p-1:0] tieoff_west_p)
+    , `BSG_INV_PARAM(bit [num_row_p-1:0] tieoff_east_p )
 
 
     , parameter link_sif_width_lp =
@@ -104,3 +104,5 @@ module bsg_manycore_hor_io_router_column
 
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_manycore_hor_io_router_column)

--- a/v/bsg_manycore_link_async_to_wormhole.v
+++ b/v/bsg_manycore_link_async_to_wormhole.v
@@ -9,6 +9,8 @@
 //
 //
 
+`include "bsg_defines.v"
+
 module bsg_manycore_link_async_to_wormhole
  import bsg_manycore_pkg::*;
 

--- a/v/bsg_manycore_link_async_to_wormhole.v
+++ b/v/bsg_manycore_link_async_to_wormhole.v
@@ -15,16 +15,16 @@ module bsg_manycore_link_async_to_wormhole
  import bsg_manycore_pkg::*;
 
  #(// Manycore link parameters
-   parameter addr_width_p="inv"
-  ,parameter data_width_p="inv"
-  ,parameter x_cord_width_p="inv"
-  ,parameter y_cord_width_p="inv"
+   `BSG_INV_PARAM(addr_width_p)
+  ,`BSG_INV_PARAM(data_width_p)
+  ,`BSG_INV_PARAM(x_cord_width_p)
+  ,`BSG_INV_PARAM(y_cord_width_p)
   
   // Wormhole link parameters
-  ,parameter flit_width_p                     = "inv"
+  ,`BSG_INV_PARAM(flit_width_p                     )
   ,parameter dims_p                           = 2
   ,parameter int cord_markers_pos_p[dims_p:0] = '{5, 4, 0}
-  ,parameter len_width_p                      = "inv"
+  ,`BSG_INV_PARAM(len_width_p                      )
 
   // The number of registers between reset_i and reset sinks.
   ,parameter mc_reset_depth_p = 3
@@ -132,3 +132,5 @@ module bsg_manycore_link_async_to_wormhole
   );
   
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_manycore_link_async_to_wormhole)

--- a/v/bsg_manycore_link_sif_async_buffer.v
+++ b/v/bsg_manycore_link_sif_async_buffer.v
@@ -12,8 +12,8 @@ module bsg_manycore_link_sif_async_buffer
   import bsg_manycore_pkg::*;
    #(   addr_width_p  = 32
       , data_width_p  = 32
-      , x_cord_width_p = "inv"
-      , y_cord_width_p = "inv"
+      , `BSG_INV_PARAM(x_cord_width_p)
+      , `BSG_INV_PARAM(y_cord_width_p)
       , fifo_els_p    = 2
       , bsg_manycore_link_sif_width_lp = `bsg_manycore_link_sif_width(addr_width_p, data_width_p, x_cord_width_p, y_cord_width_p)
     )(
@@ -195,3 +195,5 @@ module bsg_manycore_link_sif_async_buffer
     assign L_link_sif_o_cast.fwd.v            = r2l_fwd_r_valid                 ;
     assign L_link_sif_o_cast.fwd.data         = r2l_fwd_r_data                  ;
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_manycore_link_sif_async_buffer)

--- a/v/bsg_manycore_link_sif_async_buffer.v
+++ b/v/bsg_manycore_link_sif_async_buffer.v
@@ -6,6 +6,8 @@
 //This module converts the bsg_manycore_link_sif signals between different
 //clock domains.
 
+`include "bsg_defines.v"
+
 module bsg_manycore_link_sif_async_buffer
   import bsg_manycore_pkg::*;
    #(   addr_width_p  = 32

--- a/v/bsg_manycore_link_sif_tieoff.v
+++ b/v/bsg_manycore_link_sif_tieoff.v
@@ -10,10 +10,10 @@
 
 module bsg_manycore_link_sif_tieoff
   import bsg_manycore_pkg::*;
-  #(parameter addr_width_p = "inv"
-    , parameter data_width_p = "inv"
-    , parameter x_cord_width_p = "inv"
-    , parameter y_cord_width_p = "inv"
+  #(`BSG_INV_PARAM(addr_width_p )
+    , `BSG_INV_PARAM(data_width_p )
+    , `BSG_INV_PARAM(x_cord_width_p )
+    , `BSG_INV_PARAM(y_cord_width_p )
     , parameter link_sif_width_lp =
     `bsg_manycore_link_sif_width(addr_width_p, data_width_p, x_cord_width_p, y_cord_width_p)
   )
@@ -56,3 +56,5 @@ module bsg_manycore_link_sif_tieoff
   // synopsys translate_on
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_manycore_link_sif_tieoff)

--- a/v/bsg_manycore_link_sif_tieoff.v
+++ b/v/bsg_manycore_link_sif_tieoff.v
@@ -6,6 +6,7 @@
  *
  */
 
+`include "bsg_defines.v"
 
 module bsg_manycore_link_sif_tieoff
   import bsg_manycore_pkg::*;

--- a/v/bsg_manycore_link_to_cache.v
+++ b/v/bsg_manycore_link_to_cache.v
@@ -10,14 +10,14 @@
 module bsg_manycore_link_to_cache
   import bsg_manycore_pkg::*;
   import bsg_cache_pkg::*;
-  #(parameter link_addr_width_p="inv"
-    , parameter data_width_p="inv"
-    , parameter x_cord_width_p="inv"
-    , parameter y_cord_width_p="inv"
+  #(`BSG_INV_PARAM(link_addr_width_p)
+    , `BSG_INV_PARAM(data_width_p)
+    , `BSG_INV_PARAM(x_cord_width_p)
+    , `BSG_INV_PARAM(y_cord_width_p)
 
-    , parameter sets_p="inv"
-    , parameter ways_p="inv"
-    , parameter block_size_in_words_p="inv"
+    , `BSG_INV_PARAM(sets_p)
+    , `BSG_INV_PARAM(ways_p)
+    , `BSG_INV_PARAM(block_size_in_words_p)
 
     , parameter fifo_els_p=4
 
@@ -382,3 +382,5 @@ module bsg_manycore_link_to_cache
 
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_manycore_link_to_cache)

--- a/v/bsg_manycore_link_to_cache.v
+++ b/v/bsg_manycore_link_to_cache.v
@@ -5,6 +5,8 @@
  *
  */
 
+`include "bsg_defines.v"
+
 module bsg_manycore_link_to_cache
   import bsg_manycore_pkg::*;
   import bsg_cache_pkg::*;

--- a/v/bsg_manycore_link_to_cache_non_blocking.v
+++ b/v/bsg_manycore_link_to_cache_non_blocking.v
@@ -5,6 +5,7 @@
  *
  */
 
+`include "bsg_defines.v"
 
 module bsg_manycore_link_to_cache_non_blocking 
   import bsg_manycore_pkg::*;

--- a/v/bsg_manycore_link_to_cache_non_blocking.v
+++ b/v/bsg_manycore_link_to_cache_non_blocking.v
@@ -10,19 +10,19 @@
 module bsg_manycore_link_to_cache_non_blocking 
   import bsg_manycore_pkg::*;
   import bsg_cache_non_blocking_pkg::*;
-  #(parameter addr_width_p="inv"
-    , parameter data_width_p="inv"
-    , parameter x_cord_width_p="inv"
-    , parameter y_cord_width_p="inv"
+  #(`BSG_INV_PARAM(addr_width_p)
+    , `BSG_INV_PARAM(data_width_p)
+    , `BSG_INV_PARAM(x_cord_width_p)
+    , `BSG_INV_PARAM(y_cord_width_p)
 
     , parameter link_sif_width_lp=
       `bsg_manycore_link_sif_width(addr_width_p,data_width_p,x_cord_width_p,y_cord_width_p)
 
     // cache parmeters
-    , parameter sets_p="inv"
-    , parameter ways_p="inv"
-    , parameter block_size_in_words_p="inv"
-    , parameter miss_fifo_els_p="inv"
+    , `BSG_INV_PARAM(sets_p)
+    , `BSG_INV_PARAM(ways_p)
+    , `BSG_INV_PARAM(block_size_in_words_p)
+    , `BSG_INV_PARAM(miss_fifo_els_p)
 
     , parameter byte_offset_width_lp=`BSG_SAFE_CLOG2(data_width_p>>3)
     , parameter cache_addr_width_lp=(addr_width_p-1+byte_offset_width_lp)
@@ -282,3 +282,5 @@ module bsg_manycore_link_to_cache_non_blocking
 
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_manycore_link_to_cache_non_blocking)

--- a/v/bsg_manycore_link_to_fifo.v
+++ b/v/bsg_manycore_link_to_fifo.v
@@ -11,10 +11,10 @@
 `include "bsg_manycore_packet.vh"
 
 module  bsg_manycore_link_to_fifo
-  #(  parameter addr_width_p="inv"
-    , parameter data_width_p="inv"
-    , parameter x_cord_width_p="inv"
-    , parameter y_cord_width_p="inv"
+  #(  `BSG_INV_PARAM(addr_width_p)
+    , `BSG_INV_PARAM(data_width_p)
+    , `BSG_INV_PARAM(x_cord_width_p)
+    , `BSG_INV_PARAM(y_cord_width_p)
 
     //The output fifo width must be multiple times of data_width_p
     , parameter out_fifo_width_scale_p  = 2
@@ -232,4 +232,6 @@ module  bsg_manycore_link_to_fifo
  assign rr_yumi = rr_v & rr_ready ;
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_manycore_link_to_fifo)
 

--- a/v/bsg_manycore_link_to_fifo.v
+++ b/v/bsg_manycore_link_to_fifo.v
@@ -7,6 +7,7 @@
 //
 // Pleas contact Prof Taylor for the document.
 //
+`include "bsg_defines.v"
 `include "bsg_manycore_packet.vh"
 
 module  bsg_manycore_link_to_fifo

--- a/v/bsg_manycore_link_to_rocc.v
+++ b/v/bsg_manycore_link_to_rocc.v
@@ -12,10 +12,10 @@
 `include "bsg_manycore_packet.vh"
 
 module  bsg_manycore_link_to_rocc
-  #(  parameter addr_width_p="inv"
-    , parameter data_width_p="inv"
-    , parameter x_cord_width_p="inv"
-    , parameter y_cord_width_p="inv"
+  #(  `BSG_INV_PARAM(addr_width_p)
+    , `BSG_INV_PARAM(data_width_p)
+    , `BSG_INV_PARAM(x_cord_width_p)
+    , `BSG_INV_PARAM(y_cord_width_p)
     , parameter load_id_width_p = 5
     , parameter fifo_els_p    = 4
     , parameter bsg_manycore_link_sif_width_lp=`bsg_manycore_link_sif_width(addr_width_p,data_width_p,x_cord_width_p,y_cord_width_p,load_id_width_p)
@@ -403,4 +403,6 @@ bsg_manycore_rocc_dma #(
 
   assign    reset_manycore_r_o  = reset_manycore_r     ;
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_manycore_link_to_rocc)
 

--- a/v/bsg_manycore_link_to_rocc.v
+++ b/v/bsg_manycore_link_to_rocc.v
@@ -7,6 +7,7 @@
 //
 // Pleas contact Prof Taylor for the document.
 //
+`include "bsg_defines.v"
 `include "bsg_rocc.v"
 `include "bsg_manycore_packet.vh"
 

--- a/v/bsg_manycore_links_to_fsb.v
+++ b/v/bsg_manycore_links_to_fsb.v
@@ -9,20 +9,20 @@
 `include "bsg_fsb_pkg.v"
 
 module  bsg_manycore_links_to_fsb
-  #(parameter ring_width_p="inv"
-    , parameter id_width_p="inv"
-    , parameter dest_id_p="inv"
-    , parameter num_links_p="inv"
-    , parameter addr_width_p="inv"
-    , parameter data_width_p="inv"
+  #(`BSG_INV_PARAM(ring_width_p)
+    , `BSG_INV_PARAM(id_width_p)
+    , `BSG_INV_PARAM(dest_id_p)
+    , `BSG_INV_PARAM(num_links_p)
+    , `BSG_INV_PARAM(addr_width_p)
+    , `BSG_INV_PARAM(data_width_p)
     , parameter load_id_width_p = 5
-    , parameter x_cord_width_p="inv"
-    , parameter y_cord_width_p="inv"
+    , `BSG_INV_PARAM(x_cord_width_p)
+    , `BSG_INV_PARAM(y_cord_width_p)
 
     // how many remote credits we have; see bsg_channel_tunnel for how to do this calculation.
     // typically this number is fairly large
 
-    , parameter remote_credits_p="inv"
+    , `BSG_INV_PARAM(remote_credits_p)
 
     , parameter use_pseudo_large_fifo_p = 0
     , parameter bsg_manycore_link_sif_width_lp=`bsg_manycore_link_sif_width(addr_width_p,data_width_p,x_cord_width_p,y_cord_width_p,load_id_width_p)
@@ -236,6 +236,8 @@ module  bsg_manycore_links_to_fsb
 
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_manycore_links_to_fsb)
 
 
 

--- a/v/bsg_manycore_links_to_fsb.v
+++ b/v/bsg_manycore_links_to_fsb.v
@@ -5,6 +5,7 @@
 // We make use of the bsg_channel_tunnel to virtualize the
 // links.
 //
+`include "bsg_defines.v"
 `include "bsg_fsb_pkg.v"
 
 module  bsg_manycore_links_to_fsb

--- a/v/bsg_manycore_mesh.v
+++ b/v/bsg_manycore_mesh.v
@@ -1,3 +1,5 @@
+
+`include "bsg_defines.v"
 `include "bsg_manycore_packet.vh"
 
 module bsg_manycore_mesh

--- a/v/bsg_manycore_mesh.v
+++ b/v/bsg_manycore_mesh.v
@@ -36,7 +36,7 @@ import bsg_noc_pkg::*; // {P=0, W, E, N, S}
    // obviously smaller values take up less die area.
    //
 
-   ,parameter addr_width_p      = "inv"
+   ,`BSG_INV_PARAM(addr_width_p      )
 
    ,parameter x_cord_width_lp   = `BSG_SAFE_CLOG2(num_tiles_x_p)
    ,parameter y_cord_width_lp   = `BSG_SAFE_CLOG2(num_tiles_y_p + extra_io_rows_p) // extra row for I/O at bottom of chip
@@ -138,3 +138,5 @@ import bsg_noc_pkg::*; // {P=0, W, E, N, S}
       );
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_manycore_mesh)

--- a/v/bsg_manycore_mesh_node.v
+++ b/v/bsg_manycore_mesh_node.v
@@ -8,10 +8,10 @@
 module bsg_manycore_mesh_node
   import bsg_manycore_pkg::*;
   import bsg_noc_pkg::*; // {P=0, W, E, N, S}
-  #(parameter x_cord_width_p="inv"
-    , parameter y_cord_width_p="inv"
-    , parameter data_width_p="inv"
-    , parameter addr_width_p="inv"
+  #(`BSG_INV_PARAM(x_cord_width_p)
+    , `BSG_INV_PARAM(y_cord_width_p)
+    , `BSG_INV_PARAM(data_width_p)
+    , `BSG_INV_PARAM(addr_width_p)
 
     , parameter dims_p=2
     , parameter dirs_lp=(dims_p*2)+1
@@ -147,4 +147,6 @@ module bsg_manycore_mesh_node
 
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_manycore_mesh_node)
 

--- a/v/bsg_manycore_mesh_node.v
+++ b/v/bsg_manycore_mesh_node.v
@@ -3,6 +3,7 @@
  *
  */
 
+`include "bsg_defines.v"
 
 module bsg_manycore_mesh_node
   import bsg_manycore_pkg::*;

--- a/v/bsg_manycore_packet_streamer.v
+++ b/v/bsg_manycore_packet_streamer.v
@@ -3,13 +3,13 @@
 
 module bsg_manycore_packet_streamer #(
                                       // maximum number of outstanding words
-                                       max_out_credits_p="inv"
-                                      , rom_words_p="inv"
+                                       max_out_credits_p)
+                                      , rom_words_p)
                                       , freeze_init_p=1'b1
-                                      , x_cord_width_p ="inv"
-                                      , y_cord_width_p ="inv"
-                                      , addr_width_p   ="inv"
-                                      , data_width_p   ="inv"
+                                      , `BSG_INV_PARAM(x_cord_width_p )
+                                      , `BSG_INV_PARAM(y_cord_width_p )
+                                      , `BSG_INV_PARAM(addr_width_p   )
+                                      , `BSG_INV_PARAM(data_width_p   )
                                       , debug_p = 1
                                       , packet_width_lp                = `bsg_manycore_packet_width(addr_width_p,data_width_p,x_cord_width_p,y_cord_width_p)
                                       , bsg_manycore_link_sif_width_lp = `bsg_manycore_link_sif_width(addr_width_p,data_width_p,x_cord_width_p,y_cord_width_p)
@@ -111,3 +111,5 @@ module bsg_manycore_packet_streamer #(
 	    $display("## bsg_manycore_packet_streamer finished transmission (%m)");
        end
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_manycore_packet_streamer)

--- a/v/bsg_manycore_packet_streamer.v
+++ b/v/bsg_manycore_packet_streamer.v
@@ -1,3 +1,6 @@
+
+`include "bsg_defines.v"
+
 module bsg_manycore_packet_streamer #(
                                       // maximum number of outstanding words
                                        max_out_credits_p="inv"

--- a/v/bsg_manycore_pod_ruche.v
+++ b/v/bsg_manycore_pod_ruche.v
@@ -14,18 +14,18 @@ module bsg_manycore_pod_ruche
   import bsg_tag_pkg::*;
   import bsg_manycore_pkg::*;
   #(// number of tiles in a pod
-    parameter num_tiles_x_p="inv"
-    , parameter num_tiles_y_p="inv"
-    , parameter pod_x_cord_width_p="inv"
-    , parameter pod_y_cord_width_p="inv"
-    , parameter x_cord_width_p="inv"
-    , parameter y_cord_width_p="inv"
-    , parameter addr_width_p="inv"
-    , parameter data_width_p="inv"
+    `BSG_INV_PARAM(num_tiles_x_p)
+    , `BSG_INV_PARAM(num_tiles_y_p)
+    , `BSG_INV_PARAM(pod_x_cord_width_p)
+    , `BSG_INV_PARAM(pod_y_cord_width_p)
+    , `BSG_INV_PARAM(x_cord_width_p)
+    , `BSG_INV_PARAM(y_cord_width_p)
+    , `BSG_INV_PARAM(addr_width_p)
+    , `BSG_INV_PARAM(data_width_p)
 
     // This determines how to divide the pod into smaller hierarchical blocks.
-    , parameter num_subarray_x_p="inv"
-    , parameter num_subarray_y_p="inv"
+    , `BSG_INV_PARAM(num_subarray_x_p)
+    , `BSG_INV_PARAM(num_subarray_y_p)
     // Number of tiles in a subarray
     , parameter subarray_num_tiles_x_lp = (num_tiles_x_p/num_subarray_x_p)
     , parameter subarray_num_tiles_y_lp = (num_tiles_y_p/num_subarray_y_p)
@@ -34,26 +34,26 @@ module bsg_manycore_pod_ruche
     , parameter x_subcord_width_lp=`BSG_SAFE_CLOG2(num_tiles_x_p)
     , parameter y_subcord_width_lp=`BSG_SAFE_CLOG2(num_tiles_y_p)
   
-    , parameter dmem_size_p="inv"
-    , parameter icache_entries_p="inv"
-    , parameter icache_tag_width_p="inv"
+    , `BSG_INV_PARAM(dmem_size_p)
+    , `BSG_INV_PARAM(icache_entries_p)
+    , `BSG_INV_PARAM(icache_tag_width_p)
  
-    , parameter num_vcache_rows_p="inv"  
-    , parameter vcache_addr_width_p="inv" 
-    , parameter vcache_data_width_p="inv" 
-    , parameter vcache_ways_p="inv"
-    , parameter vcache_sets_p="inv"
-    , parameter vcache_block_size_in_words_p="inv"
-    , parameter vcache_size_p="inv"
-    , parameter vcache_dma_data_width_p="inv"
+    , `BSG_INV_PARAM(num_vcache_rows_p)  
+    , `BSG_INV_PARAM(vcache_addr_width_p) 
+    , `BSG_INV_PARAM(vcache_data_width_p) 
+    , `BSG_INV_PARAM(vcache_ways_p)
+    , `BSG_INV_PARAM(vcache_sets_p)
+    , `BSG_INV_PARAM(vcache_block_size_in_words_p)
+    , `BSG_INV_PARAM(vcache_size_p)
+    , `BSG_INV_PARAM(vcache_dma_data_width_p)
 
-    , parameter ruche_factor_X_p="inv"
+    , `BSG_INV_PARAM(ruche_factor_X_p)
   
-    , parameter wh_ruche_factor_p="inv"
-    , parameter wh_cid_width_p="inv"
-    , parameter wh_flit_width_p="inv"
-    , parameter wh_cord_width_p="inv"
-    , parameter wh_len_width_p="inv"
+    , `BSG_INV_PARAM(wh_ruche_factor_p)
+    , `BSG_INV_PARAM(wh_cid_width_p)
+    , `BSG_INV_PARAM(wh_flit_width_p)
+    , `BSG_INV_PARAM(wh_cord_width_p)
+    , `BSG_INV_PARAM(wh_len_width_p)
     
     // number of clock ports on vcache/tile subarray
     , parameter num_clk_ports_p=1
@@ -426,3 +426,5 @@ module bsg_manycore_pod_ruche
 
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_manycore_pod_ruche)

--- a/v/bsg_manycore_pod_ruche.v
+++ b/v/bsg_manycore_pod_ruche.v
@@ -6,6 +6,7 @@
  */
 
 
+`include "bsg_defines.v"
 `include "bsg_noc_links.vh"
 
 module bsg_manycore_pod_ruche

--- a/v/bsg_manycore_pod_ruche_array.v
+++ b/v/bsg_manycore_pod_ruche_array.v
@@ -14,41 +14,41 @@ module bsg_manycore_pod_ruche_array
   import bsg_noc_pkg::*;
   import bsg_tag_pkg::*;
   import bsg_manycore_pkg::*;
-  #(parameter num_tiles_x_p="inv"
-    , parameter num_tiles_y_p="inv"
-    , parameter pod_x_cord_width_p="inv"
-    , parameter pod_y_cord_width_p="inv"
-    , parameter x_cord_width_p="inv"
-    , parameter y_cord_width_p="inv"
-    , parameter addr_width_p="inv"
-    , parameter data_width_p="inv"
+  #(`BSG_INV_PARAM(num_tiles_x_p)
+    , `BSG_INV_PARAM(num_tiles_y_p)
+    , `BSG_INV_PARAM(pod_x_cord_width_p)
+    , `BSG_INV_PARAM(pod_y_cord_width_p)
+    , `BSG_INV_PARAM(x_cord_width_p)
+    , `BSG_INV_PARAM(y_cord_width_p)
+    , `BSG_INV_PARAM(addr_width_p)
+    , `BSG_INV_PARAM(data_width_p)
     , parameter ruche_factor_X_p=3  // only support 3 for now
 
     , parameter num_subarray_x_p=1
     , parameter num_subarray_y_p=1
 
-    , parameter dmem_size_p="inv"
-    , parameter icache_entries_p="inv"
-    , parameter icache_tag_width_p="inv"
+    , `BSG_INV_PARAM(dmem_size_p)
+    , `BSG_INV_PARAM(icache_entries_p)
+    , `BSG_INV_PARAM(icache_tag_width_p)
 
     , parameter num_vcache_rows_p=1
-    , parameter vcache_addr_width_p="inv"
-    , parameter vcache_data_width_p="inv"
-    , parameter vcache_ways_p="inv"
-    , parameter vcache_sets_p="inv"
-    , parameter vcache_block_size_in_words_p="inv"
-    , parameter vcache_size_p="inv"
-    , parameter vcache_dma_data_width_p="inv"
+    , `BSG_INV_PARAM(vcache_addr_width_p)
+    , `BSG_INV_PARAM(vcache_data_width_p)
+    , `BSG_INV_PARAM(vcache_ways_p)
+    , `BSG_INV_PARAM(vcache_sets_p)
+    , `BSG_INV_PARAM(vcache_block_size_in_words_p)
+    , `BSG_INV_PARAM(vcache_size_p)
+    , `BSG_INV_PARAM(vcache_dma_data_width_p)
 
     , parameter wh_ruche_factor_p=2 // only support 2 for now
-    , parameter wh_cid_width_p="inv"
-    , parameter wh_flit_width_p="inv"
-    , parameter wh_cord_width_p="inv"
-    , parameter wh_len_width_p="inv"
+    , `BSG_INV_PARAM(wh_cid_width_p)
+    , `BSG_INV_PARAM(wh_flit_width_p)
+    , `BSG_INV_PARAM(wh_cord_width_p)
+    , `BSG_INV_PARAM(wh_len_width_p)
 
     // number of pods to instantiate
-    , parameter num_pods_y_p="inv"
-    , parameter num_pods_x_p="inv"
+    , `BSG_INV_PARAM(num_pods_y_p)
+    , `BSG_INV_PARAM(num_pods_x_p)
 
     , parameter reset_depth_p=3
 
@@ -253,3 +253,5 @@ module bsg_manycore_pod_ruche_array
 
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_manycore_pod_ruche_array)

--- a/v/bsg_manycore_pod_ruche_array.v
+++ b/v/bsg_manycore_pod_ruche_array.v
@@ -6,6 +6,7 @@
  */
 
 
+`include "bsg_defines.v"
 `include "bsg_noc_links.vh"
 
 

--- a/v/bsg_manycore_pod_ruche_row.v
+++ b/v/bsg_manycore_pod_ruche_row.v
@@ -13,40 +13,40 @@ module bsg_manycore_pod_ruche_row
   import bsg_noc_pkg::*;
   import bsg_tag_pkg::*;
   import bsg_manycore_pkg::*;
-  #(parameter num_tiles_x_p="inv"
-    , parameter num_tiles_y_p="inv"
-    , parameter pod_x_cord_width_p="inv"
-    , parameter pod_y_cord_width_p="inv"
-    , parameter x_cord_width_p="inv"
-    , parameter y_cord_width_p="inv"
-    , parameter addr_width_p="inv"
-    , parameter data_width_p="inv"
+  #(`BSG_INV_PARAM(num_tiles_x_p)
+    , `BSG_INV_PARAM(num_tiles_y_p)
+    , `BSG_INV_PARAM(pod_x_cord_width_p)
+    , `BSG_INV_PARAM(pod_y_cord_width_p)
+    , `BSG_INV_PARAM(x_cord_width_p)
+    , `BSG_INV_PARAM(y_cord_width_p)
+    , `BSG_INV_PARAM(addr_width_p)
+    , `BSG_INV_PARAM(data_width_p)
     , parameter ruche_factor_X_p=3  // only support 3 for now
 
     , parameter num_subarray_x_p=1
     , parameter num_subarray_y_p=1
 
-    , parameter dmem_size_p="inv"
-    , parameter icache_entries_p="inv"
-    , parameter icache_tag_width_p="inv"
+    , `BSG_INV_PARAM(dmem_size_p)
+    , `BSG_INV_PARAM(icache_entries_p)
+    , `BSG_INV_PARAM(icache_tag_width_p)
 
     , parameter num_vcache_rows_p=1
-    , parameter vcache_addr_width_p="inv"
-    , parameter vcache_data_width_p="inv"
-    , parameter vcache_ways_p="inv"
-    , parameter vcache_sets_p="inv"
-    , parameter vcache_block_size_in_words_p="inv"
-    , parameter vcache_size_p="inv"
-    , parameter vcache_dma_data_width_p="inv"
+    , `BSG_INV_PARAM(vcache_addr_width_p)
+    , `BSG_INV_PARAM(vcache_data_width_p)
+    , `BSG_INV_PARAM(vcache_ways_p)
+    , `BSG_INV_PARAM(vcache_sets_p)
+    , `BSG_INV_PARAM(vcache_block_size_in_words_p)
+    , `BSG_INV_PARAM(vcache_size_p)
+    , `BSG_INV_PARAM(vcache_dma_data_width_p)
 
     , parameter wh_ruche_factor_p=2 // only support 2 for now
-    , parameter wh_cid_width_p="inv"
-    , parameter wh_flit_width_p="inv"
-    , parameter wh_cord_width_p="inv"
-    , parameter wh_len_width_p="inv"
+    , `BSG_INV_PARAM(wh_cid_width_p)
+    , `BSG_INV_PARAM(wh_flit_width_p)
+    , `BSG_INV_PARAM(wh_cord_width_p)
+    , `BSG_INV_PARAM(wh_len_width_p)
 
     // number of pods to instantiate
-    , parameter num_pods_x_p="inv"
+    , `BSG_INV_PARAM(num_pods_x_p)
 
     , parameter x_subcord_width_lp=`BSG_SAFE_CLOG2(num_tiles_x_p)
     , parameter y_subcord_width_lp=`BSG_SAFE_CLOG2(num_tiles_y_p)
@@ -262,3 +262,5 @@ module bsg_manycore_pod_ruche_row
   end
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_manycore_pod_ruche_row)

--- a/v/bsg_manycore_pod_ruche_row.v
+++ b/v/bsg_manycore_pod_ruche_row.v
@@ -4,6 +4,7 @@
  */
 
 
+`include "bsg_defines.v"
 `include "bsg_noc_links.vh"
 
 

--- a/v/bsg_manycore_reg_id_decode.v
+++ b/v/bsg_manycore_reg_id_decode.v
@@ -1,3 +1,6 @@
+
+`include "bsg_defines.v"
+
 module bsg_manycore_reg_id_decode
   import bsg_manycore_pkg::*;
   #(parameter data_width_p=32

--- a/v/bsg_manycore_reg_id_decode.v
+++ b/v/bsg_manycore_reg_id_decode.v
@@ -21,3 +21,4 @@ module bsg_manycore_reg_id_decode
     | (data_i[24+:reg_id_width_p] & {reg_id_width_p{~mask_i[3]}});
 
 endmodule
+

--- a/v/bsg_manycore_reg_id_encode.v
+++ b/v/bsg_manycore_reg_id_encode.v
@@ -6,6 +6,8 @@
  *    data_i should be byte-selected for its access size.
  */
 
+`include "bsg_defines.v"
+
 module bsg_manycore_reg_id_encode
   import bsg_manycore_pkg::*;
   #(parameter data_width_p=32

--- a/v/bsg_manycore_reg_id_encode.v
+++ b/v/bsg_manycore_reg_id_encode.v
@@ -49,3 +49,4 @@ module bsg_manycore_reg_id_encode
   end
 
 endmodule
+

--- a/v/bsg_manycore_rocc_dma.v
+++ b/v/bsg_manycore_rocc_dma.v
@@ -15,6 +15,7 @@
 //    run_bytes register
 //    repeats   register
 //
+`include "bsg_defines.v"
 `include "bsg_rocc.v"
 
 module bsg_manycore_rocc_dma #(

--- a/v/bsg_manycore_rocc_dma.v
+++ b/v/bsg_manycore_rocc_dma.v
@@ -19,8 +19,8 @@
 `include "bsg_rocc.v"
 
 module bsg_manycore_rocc_dma #(
-        addr_width_p = "inv"  //the data width for manycore data
-       ,data_width_p = "inv"  //the addr width for manycore address
+        `BSG_INV_PARAM(addr_width_p )  //the data width for manycore data
+       ,`BSG_INV_PARAM(data_width_p )  //the addr width for manycore address
        ,cfg_width_p  =  16    //the configuration register width
     )(
        input        clk_i
@@ -279,3 +279,5 @@ module bsg_manycore_rocc_dma #(
   assign core_resp_s_o            =  'b0;
   assign core_cmd_ready_o         = (curr_stat_e_r != eRoCC_dma_busy);
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_manycore_rocc_dma)

--- a/v/bsg_manycore_rocc_streambuf_wrapper.v
+++ b/v/bsg_manycore_rocc_streambuf_wrapper.v
@@ -8,6 +8,7 @@
 //
 // Pleas contact Prof Taylor for the document.
 //
+`include "bsg_defines.v"
 `include "bsg_manycore_packet.vh"
 `include "bsg_rocc.v"
 

--- a/v/bsg_manycore_rocc_streambuf_wrapper.v
+++ b/v/bsg_manycore_rocc_streambuf_wrapper.v
@@ -17,7 +17,7 @@ module bsg_manycore_rocc_streambuf_wrapper
  #(
     //////////////////////////////////////////////////////
     //Parameters for RoCC interface
-    parameter               rocc_num_p      = "inv"
+    `BSG_INV_PARAM(              rocc_num_p      )
     //The distribution of the rocc interface.
     //1. Non-zero value is the index of the rocc interface,
     //   starting from 1.
@@ -28,7 +28,7 @@ module bsg_manycore_rocc_streambuf_wrapper
 
     //////////////////////////////////////////////////////
     //Parameters for out_fifo interface
-   ,parameter               out_fifo_num_p      = "inv"
+   ,`BSG_INV_PARAM(              out_fifo_num_p      )
     //The distribution of the out_fifo interface.
     //The same meaning with rocc_dist_vect_p
    ,parameter out_fifo_dist_vec_p = 0
@@ -39,9 +39,9 @@ module bsg_manycore_rocc_streambuf_wrapper
     //////////////////////////////////////////////////////
     //Parameters for manycore
     // tile params
-   ,parameter bank_size_p       = "inv"
-   ,parameter num_banks_p       = "inv"
-   ,parameter imem_size_p       = "inv" // in words
+   ,`BSG_INV_PARAM(bank_size_p       )
+   ,`BSG_INV_PARAM(num_banks_p       )
+   ,`BSG_INV_PARAM(imem_size_p       ) // in words
 
    // array params
    ,parameter num_tiles_x_p     = -1
@@ -51,7 +51,7 @@ module bsg_manycore_rocc_streambuf_wrapper
    // enable debugging
    ,parameter debug_p           = 0
    ,parameter extra_io_rows_p   = 1
-   ,parameter addr_width_p      = "inv"
+   ,`BSG_INV_PARAM(addr_width_p      )
 
    ,parameter x_cord_width_lp   = `BSG_SAFE_CLOG2(num_tiles_x_p)
    ,parameter y_cord_width_lp   = `BSG_SAFE_CLOG2(num_tiles_y_p + extra_io_rows_p) // extra row for I/O at bottom of chip
@@ -381,3 +381,5 @@ module bsg_manycore_rocc_streambuf_wrapper
    end
    // synopsys translate_on
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_manycore_rocc_streambuf_wrapper)

--- a/v/bsg_manycore_rocc_wrapper.v
+++ b/v/bsg_manycore_rocc_wrapper.v
@@ -18,7 +18,7 @@ module bsg_manycore_rocc_wrapper
  #(
     //////////////////////////////////////////////////////
     //Parameters for RoCC interface
-    parameter               rocc_num_p      = "inv"
+    `BSG_INV_PARAM(              rocc_num_p      )
     //The distribution of the rocc interface.
     //1. Non-zero value is the index of the rocc interface,
     //   starting from 1.
@@ -30,9 +30,9 @@ module bsg_manycore_rocc_wrapper
     //////////////////////////////////////////////////////
     //Parameters for manycore
     // tile params
-   ,parameter bank_size_p       = "inv"
-   ,parameter num_banks_p       = "inv"
-   ,parameter imem_size_p       = "inv" // in words
+   ,`BSG_INV_PARAM(bank_size_p       )
+   ,`BSG_INV_PARAM(num_banks_p       )
+   ,`BSG_INV_PARAM(imem_size_p       ) // in words
 
    // array params
    ,parameter num_tiles_x_p     = -1
@@ -42,7 +42,7 @@ module bsg_manycore_rocc_wrapper
    // enable debugging
    ,parameter debug_p           = 0
    ,parameter extra_io_rows_p   = 1
-   ,parameter addr_width_p      = "inv"
+   ,`BSG_INV_PARAM(addr_width_p      )
 
    ,parameter x_cord_width_lp   = `BSG_SAFE_CLOG2(num_tiles_x_p)
    ,parameter y_cord_width_lp   = `BSG_SAFE_CLOG2(num_tiles_y_p + extra_io_rows_p) // extra row for I/O at bottom of chip
@@ -305,3 +305,5 @@ module bsg_manycore_rocc_wrapper
    end
    // synopsys translate_on
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_manycore_rocc_wrapper)

--- a/v/bsg_manycore_rocc_wrapper.v
+++ b/v/bsg_manycore_rocc_wrapper.v
@@ -9,6 +9,7 @@
 //
 // Pleas contact Prof Taylor for the document.
 //
+`include "bsg_defines.v"
 `include "bsg_manycore_packet.vh"
 `include "bsg_rocc.v"
 

--- a/v/bsg_manycore_ruche_x_link_sif_tieoff.v
+++ b/v/bsg_manycore_ruche_x_link_sif_tieoff.v
@@ -12,14 +12,14 @@
 
 module bsg_manycore_ruche_x_link_sif_tieoff
   import bsg_manycore_pkg::*;
-  #(parameter addr_width_p="inv"
-    , parameter data_width_p="inv"
-    , parameter x_cord_width_p="inv"
-    , parameter y_cord_width_p="inv"
+  #(`BSG_INV_PARAM(addr_width_p)
+    , `BSG_INV_PARAM(data_width_p)
+    , `BSG_INV_PARAM(x_cord_width_p)
+    , `BSG_INV_PARAM(y_cord_width_p)
 
-    , parameter ruche_factor_X_p="inv"
-    , parameter ruche_stage_p="inv"
-    , parameter bit west_not_east_p="inv" // 1'b0 or 1'b1
+    , `BSG_INV_PARAM(ruche_factor_X_p)
+    , `BSG_INV_PARAM(ruche_stage_p)
+    , `BSG_INV_PARAM(bit west_not_east_p) // 1'b0 or 1'b1
   
     , parameter bit ruche_factor_even_lp = (ruche_factor_X_p % 2 == 0)
     , parameter bit ruche_stage_even_lp = (ruche_stage_p % 2 == 0)
@@ -93,3 +93,5 @@ module bsg_manycore_ruche_x_link_sif_tieoff
 
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_manycore_ruche_x_link_sif_tieoff)

--- a/v/bsg_manycore_ruche_x_link_sif_tieoff.v
+++ b/v/bsg_manycore_ruche_x_link_sif_tieoff.v
@@ -8,6 +8,7 @@
  *
  */
 
+`include "bsg_defines.v"
 
 module bsg_manycore_ruche_x_link_sif_tieoff
   import bsg_manycore_pkg::*;

--- a/v/bsg_manycore_tile_compute_array_mesh.v
+++ b/v/bsg_manycore_tile_compute_array_mesh.v
@@ -8,13 +8,13 @@
 module bsg_manycore_tile_compute_array_mesh
   import bsg_manycore_pkg::*;
   import bsg_noc_pkg::*; // {P=0, W,E,N,S }
-  #(parameter dmem_size_p = "inv" // number of words in DMEM
-    , parameter icache_entries_p = "inv" // in words
-    , parameter icache_tag_width_p = "inv"
+  #(`BSG_INV_PARAM(dmem_size_p ) // number of words in DMEM
+    , `BSG_INV_PARAM(icache_entries_p ) // in words
+    , `BSG_INV_PARAM(icache_tag_width_p )
 
-    , parameter vcache_size_p = "inv" // capacity per vcache in words
-    , parameter vcache_block_size_in_words_p ="inv"
-    , parameter vcache_sets_p = "inv"
+    , `BSG_INV_PARAM(vcache_size_p ) // capacity per vcache in words
+    , `BSG_INV_PARAM(vcache_block_size_in_words_p )
+    , `BSG_INV_PARAM(vcache_sets_p )
 
     // change the default values from "inv" back to -1
     // since num_tiles_x_p and num_tiles_y_p will be used to define the size of 2D array
@@ -31,8 +31,8 @@ module bsg_manycore_tile_compute_array_mesh
 
     // this is the addr width on the manycore network packet (word addr).
     // also known as endpoint physical address (EPA).
-    , parameter addr_width_p = "inv"
-    , parameter data_width_p = "inv" // 32
+    , `BSG_INV_PARAM(addr_width_p )
+    , `BSG_INV_PARAM(data_width_p ) // 32
 
     // Enable branch/jalr trace
     , parameter branch_trace_en_p = 0
@@ -202,3 +202,5 @@ module bsg_manycore_tile_compute_array_mesh
 
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_manycore_tile_compute_array_mesh)

--- a/v/bsg_manycore_tile_compute_array_mesh.v
+++ b/v/bsg_manycore_tile_compute_array_mesh.v
@@ -3,6 +3,7 @@
  *
  */
 
+`include "bsg_defines.v"
 
 module bsg_manycore_tile_compute_array_mesh
   import bsg_manycore_pkg::*;

--- a/v/bsg_manycore_tile_compute_array_ruche.v
+++ b/v/bsg_manycore_tile_compute_array_ruche.v
@@ -10,14 +10,14 @@
 module bsg_manycore_tile_compute_array_ruche
   import bsg_manycore_pkg::*;
   import bsg_noc_pkg::*; // {P=0, W,E,N,S }
-  #(parameter dmem_size_p = "inv" // number of words in DMEM
-    , parameter icache_entries_p = "inv" // in words
-    , parameter icache_tag_width_p = "inv"
+  #(`BSG_INV_PARAM(dmem_size_p ) // number of words in DMEM
+    , `BSG_INV_PARAM(icache_entries_p ) // in words
+    , `BSG_INV_PARAM(icache_tag_width_p )
 
-    , parameter num_vcache_rows_p = "inv"
-    , parameter vcache_size_p = "inv" // capacity per vcache in words
-    , parameter vcache_block_size_in_words_p ="inv"
-    , parameter vcache_sets_p = "inv"
+    , `BSG_INV_PARAM(num_vcache_rows_p )
+    , `BSG_INV_PARAM(vcache_size_p ) // capacity per vcache in words
+    , `BSG_INV_PARAM(vcache_block_size_in_words_p )
+    , `BSG_INV_PARAM(vcache_sets_p )
 
     // change the default values from "inv" back to -1
     // since num_tiles_x_p and num_tiles_y_p will be used to define the size of 2D array
@@ -40,8 +40,8 @@ module bsg_manycore_tile_compute_array_ruche
 
     // this is the addr width on the manycore network packet (word addr).
     // also known as endpoint physical address (EPA).
-    , parameter addr_width_p = "inv"
-    , parameter data_width_p = "inv" // 32
+    , `BSG_INV_PARAM(addr_width_p )
+    , `BSG_INV_PARAM(data_width_p ) // 32
 
     // default ruche factor
     , parameter ruche_factor_X_p=3
@@ -316,3 +316,5 @@ module bsg_manycore_tile_compute_array_ruche
 
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_manycore_tile_compute_array_ruche)

--- a/v/bsg_manycore_tile_compute_array_ruche.v
+++ b/v/bsg_manycore_tile_compute_array_ruche.v
@@ -5,6 +5,7 @@
  *  
  */
 
+`include "bsg_defines.v"
 
 module bsg_manycore_tile_compute_array_ruche
   import bsg_manycore_pkg::*;

--- a/v/bsg_manycore_tile_compute_mesh.v
+++ b/v/bsg_manycore_tile_compute_mesh.v
@@ -4,6 +4,8 @@
  *  A compute tile with 2D mesh router
  */
 
+`include "bsg_defines.v"
+
 module bsg_manycore_tile_compute_mesh
   import bsg_noc_pkg::*; // { P=0, W,E,N,S }
   import bsg_manycore_pkg::*;

--- a/v/bsg_manycore_tile_compute_mesh.v
+++ b/v/bsg_manycore_tile_compute_mesh.v
@@ -9,29 +9,29 @@
 module bsg_manycore_tile_compute_mesh
   import bsg_noc_pkg::*; // { P=0, W,E,N,S }
   import bsg_manycore_pkg::*;
-  #(parameter dmem_size_p = "inv"
-    , parameter vcache_size_p = "inv"
-    , parameter icache_entries_p = "inv"
-    , parameter icache_tag_width_p = "inv"
-    , parameter x_cord_width_p = "inv"
-    , parameter y_cord_width_p = "inv"
-    , parameter pod_x_cord_width_p = "inv"
-    , parameter pod_y_cord_width_p = "inv"
+  #(`BSG_INV_PARAM(dmem_size_p )
+    , `BSG_INV_PARAM(vcache_size_p )
+    , `BSG_INV_PARAM(icache_entries_p )
+    , `BSG_INV_PARAM(icache_tag_width_p )
+    , `BSG_INV_PARAM(x_cord_width_p )
+    , `BSG_INV_PARAM(y_cord_width_p )
+    , `BSG_INV_PARAM(pod_x_cord_width_p )
+    , `BSG_INV_PARAM(pod_y_cord_width_p )
 
     // Number of tiles in a pod
-    , parameter num_tiles_x_p="inv"
-    , parameter num_tiles_y_p="inv"
+    , `BSG_INV_PARAM(num_tiles_x_p)
+    , `BSG_INV_PARAM(num_tiles_y_p)
     , parameter x_subcord_width_lp = `BSG_SAFE_CLOG2(num_tiles_x_p)
     , parameter y_subcord_width_lp = `BSG_SAFE_CLOG2(num_tiles_y_p)
 
 
 
-    , parameter data_width_p = "inv"
-    , parameter addr_width_p = "inv"
+    , `BSG_INV_PARAM(data_width_p )
+    , `BSG_INV_PARAM(addr_width_p )
 
-    , parameter num_vcache_rows_p = "inv"
-    , parameter vcache_block_size_in_words_p="inv"
-    , parameter vcache_sets_p="inv"
+    , `BSG_INV_PARAM(num_vcache_rows_p )
+    , `BSG_INV_PARAM(vcache_block_size_in_words_p)
+    , `BSG_INV_PARAM(vcache_sets_p)
 
     , parameter dims_p = 2
     , parameter dirs_lp = (dims_p*2)
@@ -192,3 +192,5 @@ module bsg_manycore_tile_compute_mesh
 
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_manycore_tile_compute_mesh)

--- a/v/bsg_manycore_tile_compute_ruche.v
+++ b/v/bsg_manycore_tile_compute_ruche.v
@@ -8,29 +8,29 @@
 module bsg_manycore_tile_compute_ruche
   import bsg_noc_pkg::*; // { P=0, W,E,N,S }
   import bsg_manycore_pkg::*;
-  #(parameter dmem_size_p = "inv"
-    , parameter vcache_size_p ="inv"
-    , parameter icache_entries_p = "inv"
-    , parameter icache_tag_width_p = "inv"
-    , parameter x_cord_width_p = "inv"
-    , parameter y_cord_width_p = "inv"
-    , parameter pod_x_cord_width_p = "inv"
-    , parameter pod_y_cord_width_p = "inv"
+  #(`BSG_INV_PARAM(dmem_size_p )
+    , `BSG_INV_PARAM(vcache_size_p )
+    , `BSG_INV_PARAM(icache_entries_p )
+    , `BSG_INV_PARAM(icache_tag_width_p )
+    , `BSG_INV_PARAM(x_cord_width_p )
+    , `BSG_INV_PARAM(y_cord_width_p )
+    , `BSG_INV_PARAM(pod_x_cord_width_p )
+    , `BSG_INV_PARAM(pod_y_cord_width_p )
 
     // Number of tiles in a pod
-    , parameter num_tiles_x_p="inv"
-    , parameter num_tiles_y_p="inv"
+    , `BSG_INV_PARAM(num_tiles_x_p)
+    , `BSG_INV_PARAM(num_tiles_y_p)
     , parameter x_subcord_width_lp = `BSG_SAFE_CLOG2(num_tiles_x_p)
     , parameter y_subcord_width_lp = `BSG_SAFE_CLOG2(num_tiles_y_p)
 
     , parameter ruche_factor_X_p = 3
     
-    , parameter data_width_p = "inv"
-    , parameter addr_width_p = "inv"
+    , `BSG_INV_PARAM(data_width_p )
+    , `BSG_INV_PARAM(addr_width_p )
 
-    , parameter num_vcache_rows_p = "inv"
-    , parameter vcache_block_size_in_words_p="inv"
-    , parameter vcache_sets_p="inv"
+    , `BSG_INV_PARAM(num_vcache_rows_p )
+    , `BSG_INV_PARAM(vcache_block_size_in_words_p)
+    , `BSG_INV_PARAM(vcache_sets_p)
 
     , parameter dims_p = 3
     , parameter dirs_lp = (dims_p*2)
@@ -235,3 +235,5 @@ module bsg_manycore_tile_compute_ruche
 
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_manycore_tile_compute_ruche)

--- a/v/bsg_manycore_tile_compute_ruche.v
+++ b/v/bsg_manycore_tile_compute_ruche.v
@@ -3,6 +3,8 @@
  *
  */
 
+`include "bsg_defines.v"
+
 module bsg_manycore_tile_compute_ruche
   import bsg_noc_pkg::*; // { P=0, W,E,N,S }
   import bsg_manycore_pkg::*;

--- a/v/bsg_manycore_tile_vcache.v
+++ b/v/bsg_manycore_tile_vcache.v
@@ -13,26 +13,26 @@ module bsg_manycore_tile_vcache
   import bsg_noc_pkg::*;
   import bsg_cache_pkg::*;
   import bsg_manycore_pkg::*;
-  #(parameter addr_width_p="inv"
-    , parameter data_width_p="inv"
-    , parameter x_cord_width_p="inv"
-    , parameter y_cord_width_p="inv"
+  #(`BSG_INV_PARAM(addr_width_p)
+    , `BSG_INV_PARAM(data_width_p)
+    , `BSG_INV_PARAM(x_cord_width_p)
+    , `BSG_INV_PARAM(y_cord_width_p)
 
-    , parameter num_tiles_y_p="inv"
+    , `BSG_INV_PARAM(num_tiles_y_p)
 
-    , parameter vcache_addr_width_p="inv"
-    , parameter vcache_data_width_p="inv"
-    , parameter vcache_ways_p="inv"
-    , parameter vcache_sets_p="inv"
-    , parameter vcache_block_size_in_words_p="inv"
-    , parameter vcache_dma_data_width_p="inv"
+    , `BSG_INV_PARAM(vcache_addr_width_p)
+    , `BSG_INV_PARAM(vcache_data_width_p)
+    , `BSG_INV_PARAM(vcache_ways_p)
+    , `BSG_INV_PARAM(vcache_sets_p)
+    , `BSG_INV_PARAM(vcache_block_size_in_words_p)
+    , `BSG_INV_PARAM(vcache_dma_data_width_p)
 
     // wh_ruche_factor_p supported only for 2^n, n>0.
-    , parameter wh_ruche_factor_p="inv"
-    , parameter wh_cid_width_p="inv"
-    , parameter wh_flit_width_p="inv"
-    , parameter wh_len_width_p="inv"
-    , parameter wh_cord_width_p="inv"
+    , `BSG_INV_PARAM(wh_ruche_factor_p)
+    , `BSG_INV_PARAM(wh_cid_width_p)
+    , `BSG_INV_PARAM(wh_flit_width_p)
+    , `BSG_INV_PARAM(wh_len_width_p)
+    , `BSG_INV_PARAM(wh_cord_width_p)
     , parameter int wh_cord_markers_pos_lp[1:0] = '{wh_cord_width_p, 0}
 
     , parameter req_fifo_els_p=4
@@ -326,3 +326,5 @@ module bsg_manycore_tile_vcache
 
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_manycore_tile_vcache)

--- a/v/bsg_manycore_tile_vcache.v
+++ b/v/bsg_manycore_tile_vcache.v
@@ -7,6 +7,8 @@
  *    the vcache DMA interface is connected to the horizontal 1D wormhole ruche network.
  */
 
+`include "bsg_defines.v"
+
 module bsg_manycore_tile_vcache
   import bsg_noc_pkg::*;
   import bsg_cache_pkg::*;

--- a/v/bsg_manycore_tile_vcache_array.v
+++ b/v/bsg_manycore_tile_vcache_array.v
@@ -4,7 +4,7 @@
  *    This module instantiates vcaches and associated ruche buffers.
  */
 
-
+`include "bsg_defines.v"
 
 module bsg_manycore_tile_vcache_array
   import bsg_noc_pkg::*;

--- a/v/bsg_manycore_tile_vcache_array.v
+++ b/v/bsg_manycore_tile_vcache_array.v
@@ -9,36 +9,36 @@
 module bsg_manycore_tile_vcache_array
   import bsg_noc_pkg::*;
   import bsg_manycore_pkg::*;
-  #(parameter addr_width_p="inv"
-    , parameter data_width_p="inv"
-    , parameter x_cord_width_p="inv"
-    , parameter y_cord_width_p="inv"
-    , parameter pod_x_cord_width_p="inv"
-    , parameter pod_y_cord_width_p="inv"
+  #(`BSG_INV_PARAM(addr_width_p)
+    , `BSG_INV_PARAM(data_width_p)
+    , `BSG_INV_PARAM(x_cord_width_p)
+    , `BSG_INV_PARAM(y_cord_width_p)
+    , `BSG_INV_PARAM(pod_x_cord_width_p)
+    , `BSG_INV_PARAM(pod_y_cord_width_p)
 
     // Number of tiles in a pod
-    , parameter num_tiles_x_p="inv"
-    , parameter num_tiles_y_p="inv"
+    , `BSG_INV_PARAM(num_tiles_x_p)
+    , `BSG_INV_PARAM(num_tiles_y_p)
     
     , parameter x_subcord_width_lp=`BSG_SAFE_CLOG2(num_tiles_x_p)
     , parameter y_subcord_width_lp=`BSG_SAFE_CLOG2(num_tiles_y_p)
 
     // Number of tiles in a subarray 
-    , parameter subarray_num_tiles_x_p="inv"
+    , `BSG_INV_PARAM(subarray_num_tiles_x_p)
 
-    , parameter num_vcache_rows_p = "inv"
-    , parameter vcache_addr_width_p ="inv"
-    , parameter vcache_data_width_p ="inv"
-    , parameter vcache_ways_p="inv"
-    , parameter vcache_sets_p="inv"
-    , parameter vcache_block_size_in_words_p="inv"
-    , parameter vcache_dma_data_width_p="inv"
+    , `BSG_INV_PARAM(num_vcache_rows_p )
+    , `BSG_INV_PARAM(vcache_addr_width_p )
+    , `BSG_INV_PARAM(vcache_data_width_p )
+    , `BSG_INV_PARAM(vcache_ways_p)
+    , `BSG_INV_PARAM(vcache_sets_p)
+    , `BSG_INV_PARAM(vcache_block_size_in_words_p)
+    , `BSG_INV_PARAM(vcache_dma_data_width_p)
 
-    , parameter wh_ruche_factor_p="inv"
-    , parameter wh_cid_width_p="inv"
-    , parameter wh_flit_width_p="inv"
-    , parameter wh_len_width_p="inv"
-    , parameter wh_cord_width_p="inv"
+    , `BSG_INV_PARAM(wh_ruche_factor_p)
+    , `BSG_INV_PARAM(wh_cid_width_p)
+    , `BSG_INV_PARAM(wh_flit_width_p)
+    , `BSG_INV_PARAM(wh_len_width_p)
+    , `BSG_INV_PARAM(wh_cord_width_p)
 
     , parameter num_clk_ports_p=1
     //, parameter reset_depth_p = 3
@@ -220,3 +220,5 @@ module bsg_manycore_tile_vcache_array
 
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_manycore_tile_vcache_array)

--- a/v/bsg_manycore_tq_receiver.v
+++ b/v/bsg_manycore_tq_receiver.v
@@ -4,6 +4,8 @@
 //
 //
 
+`include "bsg_defines.v"
+
 module bsg_tq_receiver #(width_p       = 32
                        // the greatest amount that is processed at a time
                          , max_depth_p = 1

--- a/v/bsg_manycore_tq_receiver.v
+++ b/v/bsg_manycore_tq_receiver.v
@@ -76,3 +76,4 @@ module bsg_tq_receiver #(width_p       = 32
        else $error("## release_i without confirm high! (%m)");
 
 endmodule
+

--- a/v/bsg_manycore_tq_sender.v
+++ b/v/bsg_manycore_tq_sender.v
@@ -104,3 +104,4 @@ module bsg_tq_sender #(width_p       = 32
        else $error("## release_i without confirm high! (%m)");
 
 endmodule
+

--- a/v/bsg_manycore_tq_sender.v
+++ b/v/bsg_manycore_tq_sender.v
@@ -4,6 +4,8 @@
 //
 //
 
+`include "bsg_defines.v"
+
 module bsg_tq_sender #(width_p       = 32
                        // the largest buffer ever allowed
                        , max_els_p   = -1

--- a/v/bsg_manycore_vcache_blocking.v
+++ b/v/bsg_manycore_vcache_blocking.v
@@ -3,6 +3,8 @@
  *
  */
 
+`include "bsg_defines.v"
+
 module bsg_manycore_vcache_blocking
   import bsg_manycore_pkg::*;
   import bsg_cache_pkg::*;

--- a/v/bsg_manycore_vcache_blocking.v
+++ b/v/bsg_manycore_vcache_blocking.v
@@ -8,15 +8,15 @@
 module bsg_manycore_vcache_blocking
   import bsg_manycore_pkg::*;
   import bsg_cache_pkg::*;
-  #(parameter data_width_p="inv"
-    , parameter addr_width_p="inv"
-    , parameter block_size_in_words_p="inv"
-    , parameter sets_p = "inv"
-    , parameter ways_p = "inv"
-    , parameter dma_data_width_p = "inv"
+  #(`BSG_INV_PARAM(data_width_p)
+    , `BSG_INV_PARAM(addr_width_p)
+    , `BSG_INV_PARAM(block_size_in_words_p)
+    , `BSG_INV_PARAM(sets_p )
+    , `BSG_INV_PARAM(ways_p )
+    , `BSG_INV_PARAM(dma_data_width_p )
     
-    , parameter x_cord_width_p="inv"
-    , parameter y_cord_width_p="inv"
+    , `BSG_INV_PARAM(x_cord_width_p)
+    , `BSG_INV_PARAM(y_cord_width_p)
 
     , parameter byte_offset_width_lp=`BSG_SAFE_CLOG2(data_width_p>>3)
     , parameter cache_addr_width_lp=(addr_width_p-1+byte_offset_width_lp)
@@ -133,3 +133,5 @@ module bsg_manycore_vcache_blocking
 
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_manycore_vcache_blocking)

--- a/v/bsg_manycore_vcache_non_blocking.v
+++ b/v/bsg_manycore_vcache_non_blocking.v
@@ -3,6 +3,7 @@
  *
  */
 
+`include "bsg_defines.v"
 
 module bsg_manycore_vcache_non_blocking 
   import bsg_manycore_pkg::*;

--- a/v/bsg_manycore_vcache_non_blocking.v
+++ b/v/bsg_manycore_vcache_non_blocking.v
@@ -8,15 +8,15 @@
 module bsg_manycore_vcache_non_blocking 
   import bsg_manycore_pkg::*;
   import bsg_cache_non_blocking_pkg::*;
-  #(parameter addr_width_p="inv"
-    , parameter data_width_p="inv"
-    , parameter x_cord_width_p="inv"
-    , parameter y_cord_width_p="inv"
+  #(`BSG_INV_PARAM(addr_width_p)
+    , `BSG_INV_PARAM(data_width_p)
+    , `BSG_INV_PARAM(x_cord_width_p)
+    , `BSG_INV_PARAM(y_cord_width_p)
 
-    , parameter sets_p="inv"
-    , parameter ways_p="inv"
-    , parameter block_size_in_words_p="inv"
-    , parameter miss_fifo_els_p="inv"
+    , `BSG_INV_PARAM(sets_p)
+    , `BSG_INV_PARAM(ways_p)
+    , `BSG_INV_PARAM(block_size_in_words_p)
+    , `BSG_INV_PARAM(miss_fifo_els_p)
 
     , parameter byte_offset_width_lp=`BSG_SAFE_CLOG2(data_width_p>>3)
     , parameter cache_addr_width_lp=(addr_width_p-1+byte_offset_width_lp)
@@ -157,3 +157,5 @@ module bsg_manycore_vcache_non_blocking
 
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_manycore_vcache_non_blocking)

--- a/v/bsg_ruche_anti_buffer.v
+++ b/v/bsg_ruche_anti_buffer.v
@@ -8,12 +8,12 @@
 `include "bsg_defines.v"
 
 module bsg_ruche_anti_buffer
-  #(parameter width_p="inv"
+  #(`BSG_INV_PARAM(width_p)
 
-    , parameter ruche_factor_p ="inv"
-    , parameter ruche_stage_p ="inv"
-    , parameter bit west_not_east_p="inv"
-    , parameter bit input_not_output_p="inv"
+    , `BSG_INV_PARAM(ruche_factor_p )
+    , `BSG_INV_PARAM(ruche_stage_p )
+    , `BSG_INV_PARAM(bit west_not_east_p)
+    , `BSG_INV_PARAM(bit input_not_output_p)
 
     , parameter bit ruche_factor_even_lp = (ruche_factor_p % 2 == 0)
     , parameter bit ruche_stage_even_lp = (ruche_stage_p % 2 == 0)
@@ -68,3 +68,5 @@ module bsg_ruche_anti_buffer
 
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_ruche_anti_buffer)

--- a/v/bsg_ruche_anti_buffer.v
+++ b/v/bsg_ruche_anti_buffer.v
@@ -5,6 +5,7 @@
  *    such as wormhole concentrators.
  */
 
+`include "bsg_defines.v"
 
 module bsg_ruche_anti_buffer
   #(parameter width_p="inv"

--- a/v/bsg_ruche_buffer.v
+++ b/v/bsg_ruche_buffer.v
@@ -3,6 +3,7 @@
  *
  */
 
+`include "bsg_defines.v"
 
 module bsg_ruche_buffer
   #(parameter width_p="inv"

--- a/v/bsg_ruche_buffer.v
+++ b/v/bsg_ruche_buffer.v
@@ -6,9 +6,9 @@
 `include "bsg_defines.v"
 
 module bsg_ruche_buffer
-  #(parameter width_p="inv"
-    , parameter ruche_factor_p="inv"
-    , parameter ruche_stage_p="inv"
+  #(`BSG_INV_PARAM(width_p)
+    , `BSG_INV_PARAM(ruche_factor_p)
+    , `BSG_INV_PARAM(ruche_stage_p)
 
     , parameter bit invert_lp = (ruche_stage_p == 0)
       ? (ruche_factor_p % 2 == 0)
@@ -48,3 +48,5 @@ module bsg_ruche_buffer
 
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_ruche_buffer)

--- a/v/bsg_ruche_link_sif_tieoff.v
+++ b/v/bsg_ruche_link_sif_tieoff.v
@@ -8,10 +8,10 @@
 `include "bsg_noc_links.vh"
 
 module bsg_ruche_link_sif_tieoff
-  #(parameter link_data_width_p="inv"
-    , parameter ruche_factor_p="inv"
-    , parameter ruche_stage_p="inv"
-    , parameter bit west_not_east_p="inv" // tie-off on west or east side??
+  #(`BSG_INV_PARAM(link_data_width_p)
+    , `BSG_INV_PARAM(ruche_factor_p)
+    , `BSG_INV_PARAM(ruche_stage_p)
+    , `BSG_INV_PARAM(bit west_not_east_p) // tie-off on west or east side??
   
 
     , parameter bit ruche_factor_even_lp = (ruche_factor_p % 2 == 0)
@@ -67,3 +67,5 @@ module bsg_ruche_link_sif_tieoff
 
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_ruche_link_sif_tieoff)

--- a/v/bsg_ruche_link_sif_tieoff.v
+++ b/v/bsg_ruche_link_sif_tieoff.v
@@ -4,7 +4,7 @@
  *    used for tieing off ruche links (wh) on the sides.
  */
 
-
+`include "bsg_defines.v"
 `include "bsg_noc_links.vh"
 
 module bsg_ruche_link_sif_tieoff

--- a/v/vanilla_bean/alu.v
+++ b/v/vanilla_bean/alu.v
@@ -3,7 +3,7 @@
 
 module alu
   import bsg_vanilla_pkg::*;
-  #(pc_width_p = "inv")
+  #(`BSG_INV_PARAM(pc_width_p ))
            ( input [RV32_reg_data_width_gp-1:0] rs1_i
             ,input [RV32_reg_data_width_gp-1:0] rs2_i
             ,input [RV32_reg_data_width_gp-1:0] pc_plus4_i
@@ -140,3 +140,5 @@ begin
 end
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(alu)

--- a/v/vanilla_bean/alu.v
+++ b/v/vanilla_bean/alu.v
@@ -1,4 +1,6 @@
 
+`include "bsg_defines.v"
+
 module alu
   import bsg_vanilla_pkg::*;
   #(pc_width_p = "inv")

--- a/v/vanilla_bean/bsg_cache_to_axi_hashed.v
+++ b/v/vanilla_bean/bsg_cache_to_axi_hashed.v
@@ -3,6 +3,8 @@
  *    
  */
 
+`include "bsg_defines.v"
+
 module bsg_cache_to_axi_hashed
   import bsg_cache_pkg::*;
   #(parameter addr_width_p="inv"

--- a/v/vanilla_bean/bsg_cache_to_axi_hashed.v
+++ b/v/vanilla_bean/bsg_cache_to_axi_hashed.v
@@ -7,15 +7,15 @@
 
 module bsg_cache_to_axi_hashed
   import bsg_cache_pkg::*;
-  #(parameter addr_width_p="inv"
-    ,parameter block_size_in_words_p="inv"
-    ,parameter data_width_p="inv"
-    ,parameter num_cache_p="inv"
+  #(`BSG_INV_PARAM(addr_width_p)
+    ,`BSG_INV_PARAM(block_size_in_words_p)
+    ,`BSG_INV_PARAM(data_width_p)
+    ,`BSG_INV_PARAM(num_cache_p)
 
-    ,parameter axi_id_width_p="inv" // 6
-    ,parameter axi_addr_width_p="inv"
-    ,parameter axi_data_width_p="inv"
-    ,parameter axi_burst_len_p="inv"
+    ,`BSG_INV_PARAM(axi_id_width_p) // 6
+    ,`BSG_INV_PARAM(axi_addr_width_p)
+    ,`BSG_INV_PARAM(axi_data_width_p)
+    ,`BSG_INV_PARAM(axi_burst_len_p)
 
     ,parameter data_mask_width_lp=(data_width_p>>3)
     ,parameter lg_data_mask_width_lp=`BSG_SAFE_CLOG2(data_mask_width_lp)
@@ -321,3 +321,5 @@ module bsg_cache_to_axi_hashed
   // synopsys translate_on
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_cache_to_axi_hashed)

--- a/v/vanilla_bean/bsg_manycore_proc_vanilla.v
+++ b/v/vanilla_bean/bsg_manycore_proc_vanilla.v
@@ -8,30 +8,30 @@
 module bsg_manycore_proc_vanilla
   import bsg_manycore_pkg::*;
   import bsg_vanilla_pkg::*;
-  #(parameter x_cord_width_p = "inv"
-    , parameter y_cord_width_p = "inv"
-    , parameter pod_x_cord_width_p = "inv"
-    , parameter pod_y_cord_width_p = "inv"
-    , parameter data_width_p = "inv"
-    , parameter addr_width_p = "inv"
+  #(`BSG_INV_PARAM(x_cord_width_p )
+    , `BSG_INV_PARAM(y_cord_width_p )
+    , `BSG_INV_PARAM(pod_x_cord_width_p )
+    , `BSG_INV_PARAM(pod_y_cord_width_p )
+    , `BSG_INV_PARAM(data_width_p )
+    , `BSG_INV_PARAM(addr_width_p )
 
-    , parameter icache_tag_width_p = "inv"
-    , parameter icache_entries_p = "inv"
+    , `BSG_INV_PARAM(icache_tag_width_p )
+    , `BSG_INV_PARAM(icache_entries_p )
 
-    , parameter dmem_size_p = "inv"
-    , parameter num_vcache_rows_p = "inv"
-    , parameter vcache_size_p = "inv"
-    , parameter vcache_block_size_in_words_p="inv"
-    , parameter vcache_sets_p = "inv"
+    , `BSG_INV_PARAM(dmem_size_p )
+    , `BSG_INV_PARAM(num_vcache_rows_p )
+    , `BSG_INV_PARAM(vcache_size_p )
+    , `BSG_INV_PARAM(vcache_block_size_in_words_p)
+    , `BSG_INV_PARAM(vcache_sets_p )
 
-    , parameter num_tiles_x_p="inv"
-    , parameter num_tiles_y_p="inv"
+    , `BSG_INV_PARAM(num_tiles_x_p)
+    , `BSG_INV_PARAM(num_tiles_y_p)
 
     , parameter x_subcord_width_lp = `BSG_SAFE_CLOG2(num_tiles_x_p)
     , parameter y_subcord_width_lp = `BSG_SAFE_CLOG2(num_tiles_y_p)
 
-    , parameter rev_fifo_els_p="inv" // for FIFO credit counting.
-    , parameter fwd_fifo_els_p="inv" // for FIFO credit counting.
+    , `BSG_INV_PARAM(rev_fifo_els_p) // for FIFO credit counting.
+    , `BSG_INV_PARAM(fwd_fifo_els_p) // for FIFO credit counting.
   
     , parameter credit_counter_width_p = `BSG_WIDTH(32)
     , parameter proc_fifo_els_p = 4
@@ -385,3 +385,5 @@ module bsg_manycore_proc_vanilla
   );
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(bsg_manycore_proc_vanilla)

--- a/v/vanilla_bean/bsg_manycore_proc_vanilla.v
+++ b/v/vanilla_bean/bsg_manycore_proc_vanilla.v
@@ -3,6 +3,7 @@
  *
  */
 
+`include "bsg_defines.v"
 
 module bsg_manycore_proc_vanilla
   import bsg_manycore_pkg::*;

--- a/v/vanilla_bean/cl_decode.v
+++ b/v/vanilla_bean/cl_decode.v
@@ -471,3 +471,4 @@ always_comb begin
 end
 
 endmodule
+

--- a/v/vanilla_bean/cl_decode.v
+++ b/v/vanilla_bean/cl_decode.v
@@ -11,6 +11,7 @@
  *
  */
 
+`include "bsg_defines.v"
 
 module cl_decode
 import bsg_vanilla_pkg::*;

--- a/v/vanilla_bean/fcsr.v
+++ b/v/vanilla_bean/fcsr.v
@@ -191,3 +191,4 @@ module fcsr
   // synopsys translate_on
 
 endmodule
+

--- a/v/vanilla_bean/fcsr.v
+++ b/v/vanilla_bean/fcsr.v
@@ -3,6 +3,7 @@
  *
  */
 
+`include "bsg_defines.v"
 
 module fcsr
   import bsg_vanilla_pkg::*;

--- a/v/vanilla_bean/fpu_fdiv_fsqrt.v
+++ b/v/vanilla_bean/fpu_fdiv_fsqrt.v
@@ -130,3 +130,4 @@ module fpu_fdiv_fsqrt
 
 
 endmodule
+

--- a/v/vanilla_bean/fpu_fdiv_fsqrt.v
+++ b/v/vanilla_bean/fpu_fdiv_fsqrt.v
@@ -5,6 +5,7 @@
  *
  */
 
+`include "bsg_defines.v"
 `include "HardFloat_consts.vi"
 
 module fpu_fdiv_fsqrt 

--- a/v/vanilla_bean/fpu_float.v
+++ b/v/vanilla_bean/fpu_float.v
@@ -234,3 +234,4 @@ module fpu_float
 
   
 endmodule
+

--- a/v/vanilla_bean/fpu_float.v
+++ b/v/vanilla_bean/fpu_float.v
@@ -9,6 +9,7 @@
  *    Other float operations becomes available in the second stage.
  */
 
+`include "bsg_defines.v"
 
 module fpu_float
   import bsg_vanilla_pkg::*;

--- a/v/vanilla_bean/fpu_float_aux.v
+++ b/v/vanilla_bean/fpu_float_aux.v
@@ -3,6 +3,7 @@
  *
  */
 
+`include "bsg_defines.v"
 `include "HardFloat_consts.vi"
 
 module fpu_float_aux 

--- a/v/vanilla_bean/fpu_float_aux.v
+++ b/v/vanilla_bean/fpu_float_aux.v
@@ -144,3 +144,4 @@ module fpu_float_aux
 
 
 endmodule
+

--- a/v/vanilla_bean/fpu_float_fma.v
+++ b/v/vanilla_bean/fpu_float_fma.v
@@ -4,6 +4,7 @@
  */
 
 
+`include "bsg_defines.v"
 `include "HardFloat_consts.vi"
 
 module fpu_float_fma

--- a/v/vanilla_bean/fpu_float_fma.v
+++ b/v/vanilla_bean/fpu_float_fma.v
@@ -237,3 +237,4 @@ module fpu_float_fma
 
 
 endmodule
+

--- a/v/vanilla_bean/fpu_float_fma_round.v
+++ b/v/vanilla_bean/fpu_float_fma_round.v
@@ -89,3 +89,4 @@ module fpu_float_fma_round
   
 
 endmodule
+

--- a/v/vanilla_bean/fpu_float_fma_round.v
+++ b/v/vanilla_bean/fpu_float_fma_round.v
@@ -3,6 +3,7 @@
  *
  */
 
+`include "bsg_defines.v"
 `include "HardFloat_consts.vi"
 
 module fpu_float_fma_round

--- a/v/vanilla_bean/fpu_fmin_fmax.v
+++ b/v/vanilla_bean/fpu_fmin_fmax.v
@@ -10,6 +10,7 @@
 //   If only one operand is a NaN, the result is non-NaN operand.
 //  Signaling NaN inputs set the invalid exception flag, even when the result is not NaN.
 
+`include "bsg_defines.v"
 
 module fpu_fmin_fmax 
   #(parameter exp_width_p="inv"

--- a/v/vanilla_bean/fpu_fmin_fmax.v
+++ b/v/vanilla_bean/fpu_fmin_fmax.v
@@ -13,8 +13,8 @@
 `include "bsg_defines.v"
 
 module fpu_fmin_fmax 
-  #(parameter exp_width_p="inv"
-    , parameter sig_width_p="inv"
+  #(`BSG_INV_PARAM(exp_width_p)
+    , `BSG_INV_PARAM(sig_width_p)
 
     , parameter recoded_data_width_lp=(exp_width_p+sig_width_p+1)
   )
@@ -96,3 +96,5 @@ module fpu_fmin_fmax
 
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(fpu_fmin_fmax)

--- a/v/vanilla_bean/fpu_int.v
+++ b/v/vanilla_bean/fpu_int.v
@@ -159,3 +159,4 @@ module fpu_int
 
 
 endmodule
+

--- a/v/vanilla_bean/fpu_int.v
+++ b/v/vanilla_bean/fpu_int.v
@@ -8,7 +8,7 @@
  *  - F2I, FMV
  */
 
-
+`include "bsg_defines.v"
 `include "HardFloat_consts.vi"
 
 module fpu_int

--- a/v/vanilla_bean/fpu_int_fclass.v
+++ b/v/vanilla_bean/fpu_int_fclass.v
@@ -51,3 +51,4 @@ module fpu_int_fclass
 
 
 endmodule
+

--- a/v/vanilla_bean/fpu_int_fclass.v
+++ b/v/vanilla_bean/fpu_int_fclass.v
@@ -3,6 +3,8 @@
  *
  */
 
+`include "bsg_defines.v"
+
 module fpu_int_fclass
   import bsg_vanilla_pkg::*;
   #(parameter exp_width_p=fpu_recoded_exp_width_gp

--- a/v/vanilla_bean/hash_function_reverse.v
+++ b/v/vanilla_bean/hash_function_reverse.v
@@ -2,8 +2,8 @@
 `include "bsg_defines.v"
 
 module hash_function_reverse
-  #(parameter width_p="inv"
-    ,parameter banks_p="inv"
+  #(`BSG_INV_PARAM(width_p)
+    ,`BSG_INV_PARAM(banks_p)
 
     , parameter lg_banks_lp=`BSG_SAFE_CLOG2(banks_p)
     , parameter index_width_lp=$clog2((2**width_p+banks_p-1)/banks_p)
@@ -45,3 +45,5 @@ module hash_function_reverse
 
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(hash_function_reverse)

--- a/v/vanilla_bean/hash_function_reverse.v
+++ b/v/vanilla_bean/hash_function_reverse.v
@@ -1,3 +1,6 @@
+
+`include "bsg_defines.v"
+
 module hash_function_reverse
   #(parameter width_p="inv"
     ,parameter banks_p="inv"

--- a/v/vanilla_bean/icache.v
+++ b/v/vanilla_bean/icache.v
@@ -11,8 +11,8 @@
 
 module icache
   import bsg_vanilla_pkg::*;
-  #(parameter icache_tag_width_p="inv"
-    , parameter icache_entries_p="inv"
+  #(`BSG_INV_PARAM(icache_tag_width_p)
+    , `BSG_INV_PARAM(icache_entries_p)
 
     , parameter icache_addr_width_lp=`BSG_SAFE_CLOG2(icache_entries_p)
     , parameter pc_width_lp=(icache_tag_width_p+icache_addr_width_lp)
@@ -243,3 +243,5 @@ module icache
   assign icache_miss_o = icache_data_lo.tag != pc_r[icache_addr_width_lp+:icache_tag_width_p];
   
 endmodule
+
+`BSG_ABSTRACT_MODULE(icache)

--- a/v/vanilla_bean/icache.v
+++ b/v/vanilla_bean/icache.v
@@ -7,6 +7,7 @@
  *
  */
 
+`include "bsg_defines.v"
 
 module icache
   import bsg_vanilla_pkg::*;

--- a/v/vanilla_bean/idiv.v
+++ b/v/vanilla_bean/idiv.v
@@ -77,3 +77,4 @@ module idiv
 
 
 endmodule
+

--- a/v/vanilla_bean/idiv.v
+++ b/v/vanilla_bean/idiv.v
@@ -5,6 +5,7 @@
  *
  */
 
+`include "bsg_defines.v"
 
 module idiv 
   import bsg_vanilla_pkg::*;

--- a/v/vanilla_bean/load_packer.v
+++ b/v/vanilla_bean/load_packer.v
@@ -3,6 +3,7 @@
  *
  */
 
+`include "bsg_defines.v"
 
 module load_packer
   import bsg_vanilla_pkg::*;

--- a/v/vanilla_bean/load_packer.v
+++ b/v/vanilla_bean/load_packer.v
@@ -60,3 +60,4 @@ module load_packer
   end
 
 endmodule
+

--- a/v/vanilla_bean/lsu.v
+++ b/v/vanilla_bean/lsu.v
@@ -8,6 +8,7 @@
  *
  */
 
+`include "bsg_defines.v"
 
 module lsu
 

--- a/v/vanilla_bean/lsu.v
+++ b/v/vanilla_bean/lsu.v
@@ -17,9 +17,9 @@ module lsu
   import bsg_manycore_addr_pkg::*;
   import bsg_vanilla_pkg::*;
 
-  #(parameter data_width_p="inv"
-    , parameter pc_width_p="inv"
-    , parameter dmem_size_p="inv"
+  #(`BSG_INV_PARAM(data_width_p)
+    , `BSG_INV_PARAM(pc_width_p)
+    , `BSG_INV_PARAM(dmem_size_p)
 
     , localparam dmem_addr_width_lp=`BSG_SAFE_CLOG2(dmem_size_p)
     , localparam data_mask_width_lp=(data_width_p>>3)
@@ -181,3 +181,5 @@ module lsu
 
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(lsu)

--- a/v/vanilla_bean/mcsr.v
+++ b/v/vanilla_bean/mcsr.v
@@ -9,6 +9,7 @@
 //  - mie and mip (read-write)
 //  - mepc (read-write)
 
+`include "bsg_defines.v"
 
 module mcsr
   import bsg_vanilla_pkg::*;

--- a/v/vanilla_bean/mcsr.v
+++ b/v/vanilla_bean/mcsr.v
@@ -15,7 +15,7 @@ module mcsr
   import bsg_vanilla_pkg::*;
   #(parameter reg_addr_width_lp = RV32_reg_addr_width_gp
     , parameter reg_data_width_lp = RV32_reg_data_width_gp
-    , parameter pc_width_p="inv"
+    , `BSG_INV_PARAM(pc_width_p)
     , parameter credit_limit_default_val_p = 32
     , parameter credit_counter_width_p=`BSG_WIDTH(32)
     , parameter cfg_pod_width_p=32
@@ -327,3 +327,5 @@ module mcsr
 
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(mcsr)

--- a/v/vanilla_bean/network_rx.v
+++ b/v/vanilla_bean/network_rx.v
@@ -4,6 +4,7 @@
  *    This handles receiving remote packets, and sending out responses.
  */
 
+`include "bsg_defines.v"
 
 module network_rx 
   import bsg_manycore_pkg::*;

--- a/v/vanilla_bean/network_rx.v
+++ b/v/vanilla_bean/network_rx.v
@@ -9,16 +9,16 @@
 module network_rx 
   import bsg_manycore_pkg::*;
   import bsg_vanilla_pkg::*;
-  #(parameter data_width_p="inv"
-    , parameter addr_width_p="inv"
-    , parameter dmem_size_p="inv"
-    , parameter icache_tag_width_p="inv"
-    , parameter icache_entries_p="inv"
-    , parameter x_cord_width_p="inv"
-    , parameter y_cord_width_p="inv"
+  #(`BSG_INV_PARAM(data_width_p)
+    , `BSG_INV_PARAM(addr_width_p)
+    , `BSG_INV_PARAM(dmem_size_p)
+    , `BSG_INV_PARAM(icache_tag_width_p)
+    , `BSG_INV_PARAM(icache_entries_p)
+    , `BSG_INV_PARAM(x_cord_width_p)
+    , `BSG_INV_PARAM(y_cord_width_p)
 
-    , parameter x_subcord_width_p="inv"
-    , parameter y_subcord_width_p="inv"
+    , `BSG_INV_PARAM(x_subcord_width_p)
+    , `BSG_INV_PARAM(y_subcord_width_p)
 
     , parameter tgo_x_init_val_p = 0
     , parameter tgo_y_init_val_p = 0
@@ -381,3 +381,5 @@ module network_rx
   // synopsys translate_on
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(network_rx)

--- a/v/vanilla_bean/network_tx.v
+++ b/v/vanilla_bean/network_tx.v
@@ -4,6 +4,7 @@
  *    This handles sending out remote packets and receiving responses.
  */
 
+`include "bsg_defines.v"
 
 module network_tx
   import bsg_manycore_pkg::*;

--- a/v/vanilla_bean/network_tx.v
+++ b/v/vanilla_bean/network_tx.v
@@ -9,33 +9,28 @@
 module network_tx
   import bsg_manycore_pkg::*;
   import bsg_vanilla_pkg::*;
-  #(parameter data_width_p="inv"
-    , parameter addr_width_p="inv"
-    , parameter x_cord_width_p="inv"
-    , parameter y_cord_width_p="inv"
-    , parameter pod_x_cord_width_p="inv"
-    , parameter pod_y_cord_width_p="inv"
-    , parameter epa_byte_addr_width_p="inv"
-    , parameter num_vcache_rows_p="inv"
-    , parameter vcache_size_p="inv" // vcache capacity in words
-    , parameter vcache_block_size_in_words_p="inv"
-    , parameter vcache_sets_p="inv"
+  #(`BSG_INV_PARAM(data_width_p)
+    , `BSG_INV_PARAM(addr_width_p)
+    , `BSG_INV_PARAM(x_cord_width_p)
+    , `BSG_INV_PARAM(y_cord_width_p)
+    , `BSG_INV_PARAM(pod_x_cord_width_p)
+    , `BSG_INV_PARAM(pod_y_cord_width_p)
+    , `BSG_INV_PARAM(num_vcache_rows_p)
+    , `BSG_INV_PARAM(vcache_size_p) // vcache capacity in words
+    , `BSG_INV_PARAM(vcache_block_size_in_words_p)
+    , `BSG_INV_PARAM(vcache_sets_p)
  
-    , parameter num_tiles_x_p="inv"
-    , parameter num_tiles_y_p="inv"
+    , `BSG_INV_PARAM(num_tiles_x_p)
+    , `BSG_INV_PARAM(num_tiles_y_p)
     , parameter x_subcord_width_lp=`BSG_SAFE_CLOG2(num_tiles_x_p)
     , parameter y_subcord_width_lp=`BSG_SAFE_CLOG2(num_tiles_y_p)
   
-    , parameter icache_entries_p="inv"
-    , parameter icache_tag_width_p="inv"
-
-    , parameter max_out_credits_p="inv"
+    , `BSG_INV_PARAM(icache_entries_p)
+    , `BSG_INV_PARAM(icache_tag_width_p)
 
     , parameter vcache_addr_width_lp=`BSG_SAFE_CLOG2(vcache_size_p)
 
     , parameter vcache_word_offset_width_lp = `BSG_SAFE_CLOG2(vcache_block_size_in_words_p)
-
-    , parameter credit_counter_width_lp=$clog2(max_out_credits_p+1)
 
     , parameter icache_addr_width_lp=`BSG_SAFE_CLOG2(icache_entries_p)
     , parameter pc_width_lp=(icache_tag_width_p+icache_addr_width_lp)
@@ -249,3 +244,5 @@ module network_tx
   // synopsys translate_on
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(network_tx)

--- a/v/vanilla_bean/regfile.v
+++ b/v/vanilla_bean/regfile.v
@@ -8,6 +8,7 @@
  *    @author tommy
  */
 
+`include "bsg_defines.v"
 
 module regfile
   #(parameter width_p="inv"

--- a/v/vanilla_bean/regfile.v
+++ b/v/vanilla_bean/regfile.v
@@ -11,10 +11,10 @@
 `include "bsg_defines.v"
 
 module regfile
-  #(parameter width_p="inv"
-    , parameter els_p="inv"
-    , parameter num_rs_p="inv"
-    , parameter x0_tied_to_zero_p="inv"
+  #(`BSG_INV_PARAM(width_p)
+    , `BSG_INV_PARAM(els_p)
+    , `BSG_INV_PARAM(num_rs_p)
+    , `BSG_INV_PARAM(x0_tied_to_zero_p)
     , parameter harden_p=0
 
     , parameter addr_width_lp=`BSG_SAFE_CLOG2(els_p)
@@ -53,3 +53,5 @@ module regfile
 
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(regfile)

--- a/v/vanilla_bean/regfile_hard.v
+++ b/v/vanilla_bean/regfile_hard.v
@@ -11,9 +11,9 @@
 `include "bsg_defines.v"
 
 module regfile_hard
-  #(parameter width_p = "inv"
-    , parameter els_p = "inv"
-    , parameter num_rs_p ="inv" // number of read ports. only supports 2 and 3.
+  #(`BSG_INV_PARAM(width_p )
+    , `BSG_INV_PARAM(els_p )
+    , `BSG_INV_PARAM(num_rs_p ) // number of read ports. only supports 2 and 3.
     , parameter x0_tied_to_zero_p=0
     , localparam addr_width_lp = `BSG_SAFE_CLOG2(els_p)
   )
@@ -162,4 +162,6 @@ module regfile_hard
   end
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(regfile_hard)
 

--- a/v/vanilla_bean/regfile_hard.v
+++ b/v/vanilla_bean/regfile_hard.v
@@ -8,6 +8,8 @@
 // register. When there is a write and read and the same time, it output
 // the newly written value, which is "write through"
 
+`include "bsg_defines.v"
+
 module regfile_hard
   #(parameter width_p = "inv"
     , parameter els_p = "inv"

--- a/v/vanilla_bean/regfile_synth.v
+++ b/v/vanilla_bean/regfile_synth.v
@@ -9,10 +9,10 @@
 `include "bsg_defines.v"
 
 module regfile_synth
-  #(parameter width_p="inv"
-    , parameter els_p="inv"
-    , parameter num_rs_p="inv"
-    , parameter x0_tied_to_zero_p="inv"
+  #(`BSG_INV_PARAM(width_p)
+    , `BSG_INV_PARAM(els_p)
+    , `BSG_INV_PARAM(num_rs_p)
+    , `BSG_INV_PARAM(x0_tied_to_zero_p)
 
     , parameter addr_width_lp=`BSG_SAFE_CLOG2(els_p)
   )
@@ -70,3 +70,5 @@ module regfile_synth
 
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(regfile_synth)

--- a/v/vanilla_bean/regfile_synth.v
+++ b/v/vanilla_bean/regfile_synth.v
@@ -6,6 +6,7 @@
  *    @author tommy
  */
 
+`include "bsg_defines.v"
 
 module regfile_synth
   #(parameter width_p="inv"

--- a/v/vanilla_bean/scoreboard.v
+++ b/v/vanilla_bean/scoreboard.v
@@ -5,6 +5,7 @@
  *
  */
 
+`include "bsg_defines.v"
 
 module scoreboard
   import bsg_vanilla_pkg::*;

--- a/v/vanilla_bean/scoreboard.v
+++ b/v/vanilla_bean/scoreboard.v
@@ -10,7 +10,7 @@
 module scoreboard
   import bsg_vanilla_pkg::*;
   #(parameter els_p = RV32_reg_els_gp
-    , parameter num_src_port_p="inv"
+    , `BSG_INV_PARAM(num_src_port_p)
     , parameter num_clear_port_p=1
     , parameter x0_tied_to_zero_p = 0
     , parameter id_width_lp = `BSG_SAFE_CLOG2(els_p)
@@ -186,3 +186,5 @@ module scoreboard
 
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(scoreboard)

--- a/v/vanilla_bean/vanilla_core.v
+++ b/v/vanilla_bean/vanilla_core.v
@@ -6,6 +6,7 @@
  *
  */
 
+`include "bsg_defines.v"
 
 module vanilla_core
   import bsg_vanilla_pkg::*;

--- a/v/vanilla_bean/vanilla_core.v
+++ b/v/vanilla_bean/vanilla_core.v
@@ -11,24 +11,24 @@
 module vanilla_core
   import bsg_vanilla_pkg::*;
   import bsg_manycore_addr_pkg::*;
-  #(parameter data_width_p="inv"
-    , parameter dmem_size_p="inv"
+  #(`BSG_INV_PARAM(data_width_p)
+    , `BSG_INV_PARAM(dmem_size_p)
     
-    , parameter icache_entries_p="inv"
-    , parameter icache_tag_width_p="inv"
+    , `BSG_INV_PARAM(icache_entries_p)
+    , `BSG_INV_PARAM(icache_tag_width_p)
 
-    , parameter x_cord_width_p="inv"
-    , parameter y_cord_width_p="inv"
+    , `BSG_INV_PARAM(x_cord_width_p)
+    , `BSG_INV_PARAM(y_cord_width_p)
 
-    , parameter pod_x_cord_width_p="inv"
-    , parameter pod_y_cord_width_p="inv"
+    , `BSG_INV_PARAM(pod_x_cord_width_p)
+    , `BSG_INV_PARAM(pod_y_cord_width_p)
     
     , parameter credit_counter_width_p=`BSG_WIDTH(32)
 
     // For network input FIFO credit counting
       // By default, 3 credits are needed, because the round trip to get the credit back takes three cycles.
       // ID->EXE->FIFO->CREDIT.
-    , parameter fwd_fifo_els_p="inv"
+    , `BSG_INV_PARAM(fwd_fifo_els_p)
     , parameter lg_fwd_fifo_els_lp=`BSG_WIDTH(fwd_fifo_els_p)
 
     , parameter dmem_addr_width_lp=`BSG_SAFE_CLOG2(dmem_size_p)
@@ -1921,3 +1921,5 @@ module vanilla_core
 
 
 endmodule
+
+`BSG_ABSTRACT_MODULE(vanilla_core)


### PR DESCRIPTION
and also adds `include bsg_defines.v to each module in order to be more friendly to parsers which use single-file compilation units.

Removes a few parameters which were unused (exposed by unset default parameters)