### PR TITLE
fcsr assertion fix

### DIFF
--- a/v/vanilla_bean/fcsr.v
+++ b/v/vanilla_bean/fcsr.v
@@ -183,8 +183,8 @@ module fcsr
   // synopsys translate_off
   always_ff @ (negedge clk_i) begin
     if (~reset_i) begin
-      if (v_i & data_v_o) begin
-        assert(~(|fflags_v_i)) else $error("Exception cannot be accrued while being written by fcsr op.");
+      if (v_i & ((addr_i == `RV32_CSR_FFLAGS_ADDR) || (addr_i == `RV32_CSR_FCSR_ADDR))) begin
+        assert(~(|fflags_v_i)) else $error("[BSG_ERROR] Exception cannot be accrued while being written by fcsr op.");
       end
     end
   end


### PR DESCRIPTION
A CSR instruction in ID should stall (stall_fcsr) until all the float instructions that could update fflags (e.g. fpu_float, fpu_int, fdiv ops) and have already been issued, finish and update fflags. Currently, the exception in fcsr module is being triggered even when the CSR instruction modifies only frm (rounding mode). So the assertion is being fixed to prevent this false alarm.