### PR TITLE
turning off icache during reset

### DIFF
--- a/v/vanilla_bean/vanilla_core.v
+++ b/v/vanilla_bean/vanilla_core.v
@@ -1227,7 +1227,7 @@ module vanilla_core
     : 1'b1;
 
   assign icache_v_li = icache_v_i | ifetch_v_i
-    | (read_icache & ~stall_all & ~(stall_id & ~flush));
+    | (~reset_i & read_icache & ~stall_all & ~(stall_id & ~flush));
 
   assign icache_w_li = icache_v_i | ifetch_v_i;
 


### PR DESCRIPTION
When vanilla core is in reset (by the freeze register), it should still allow remote packets to be written into the icache, but turn off the enable pin while not being written.