### PR TITLE
Add new cache statistics 

### DIFF
--- a/software/py/vanilla_parser/common.py
+++ b/software/py/vanilla_parser/common.py
@@ -4,13 +4,13 @@ def add_args(parser):
     parser.add_argument("--trace", default="vanilla_operation_trace.csv", type=str,
                         help="Vanilla operation log file")
     parser.add_argument("--stats", default="vanilla_stats.csv", type=str,
-                        help="Vanilla stats log file")
+                        help="Vanilla stats profiler file")
     parser.add_argument("--log", default="vanilla.log", type=str,
                         help="Vanilla log file")
     parser.add_argument("--vcache-trace", default="vcache_operation_trace.csv", type=str,
                         help="Vanilla operation log file")
     parser.add_argument("--vcache-stats", default=None, type=str,
-                        help="Vanilla stats log file")
+                        help="Vanilla cache stats profiler file")
     parser.add_argument("--tile", default=False, action='store_true',
                         help="Also generate per tile stats")
     parser.add_argument("--tile-group", default=False, action='store_true',

--- a/software/py/vanilla_parser/stats_parser.py
+++ b/software/py/vanilla_parser/stats_parser.py
@@ -882,7 +882,7 @@ class CacheBankStats(CacheStats):
         doc += "\t- Bytes Stored Ratio: Bytes Stored to Cache / Bytes Loded to Cache via Store Miss\n"
         pretty["Bytes Stored Ratio"] = (self.df["bytes_st"] / (self.df["miss_st"] * self.__cache_line_words * 4))
 
-        doc += "\t- Bytes Stored Ratio: Bytes Stored to Cache / Bytes Loded to Cache via Store Miss\n"
+        doc += "\t- Bytes Atomic'd Ratio: Bytes Atomic'd in Cache / Bytes Loded to Cache via Atomic Miss\n"
         pretty["Bytes Atomic'd Ratio"] = (self.df["bytes_amo"] / (self.df["miss_amo"] * self.__cache_line_words * 4))
 
         doc += "\t- Bytes Used Ratio: (Bytes Stored to Cache + Bytes Loaded from Cache) / Bytes Loaded to Cache via Miss)\n"

--- a/software/py/vanilla_parser/stats_parser.py
+++ b/software/py/vanilla_parser/stats_parser.py
@@ -749,8 +749,7 @@ class CacheTagStats(CacheStats):
         return s
 
     # Format the events table (misses)
-    @classmethod
-    def __event_tostr(cls, ds, ld, bld, st, bst, atom, batom):
+    def __event_tostr(self, ds, ld, bld, st, bst, atom, batom):
         # Construct a pretty dataframe to print
         df = pd.DataFrame()
 
@@ -777,22 +776,23 @@ class CacheTagStats(CacheStats):
         df["Miss Rate (%)"] = 100 * (df["Misses"] / (df["Operations"])).fillna(0)
         df["Operations / Miss"] = (df["Operations"] / (df["Misses"])).fillna(0)
         df["Bytes / Miss"] = (df["Bytes"] / (df["Misses"])).fillna(0)
+        df["% Used / Miss"] = (100 * df["Bytes"] / (self.__cache_line_words * 4)) / (df["Misses"]).fillna(0)
 
         # Set index to the type
         df = df.set_index(["Type"])
 
         # Set the format for floats
-        fmt = [".0f"] * 4 + [".2f"] * 5
+        fmt = [".0f"] * 4 + [".2f"] * 6
         tab = df.to_markdown(tablefmt="simple", floatfmt=fmt, numalign="right", stralign="right")
 
         l = len(tab.splitlines()[0])   
         s = ""
-        s += cls._make_sub_sep("", l) + "\n"
+        s += self._make_sub_sep("", l) + "\n"
         s += ("Miss Statistics" + " " * l)[:l] + "\n"
-        s += cls._make_sub_sep("", l) + "\n"
+        s += self._make_sub_sep("", l) + "\n"
         s += tab
         s += "\n"
-        s += cls._make_sub_sep("", l) + "\n"
+        s += self._make_sub_sep("", l) + "\n"
 
         return s
 

--- a/software/py/vanilla_parser/stats_parser.py
+++ b/software/py/vanilla_parser/stats_parser.py
@@ -882,7 +882,7 @@ class CacheBankStats(CacheStats):
         doc += "\t- Bytes Stored Ratio: Bytes Stored to Cache / Bytes Loded to Cache via Store Miss\n"
         pretty["Bytes Stored Ratio"] = (self.df["bytes_st"] / (self.df["miss_st"] * self.__cache_line_words * 4))
 
-        doc += "\t- Bytes Atomic'd Ratio: Bytes Atomic'd in Cache / Bytes Loded to Cache via Atomic Miss\n"
+        doc += "\t- Bytes Atomic'd Ratio: Bytes Atomic'd in Cache / Bytes Loaded to Cache via Atomic Miss\n"
         pretty["Bytes Atomic'd Ratio"] = (self.df["bytes_amo"] / (self.df["miss_amo"] * self.__cache_line_words * 4))
 
         doc += "\t- Bytes Used Ratio: (Bytes Stored to Cache + Bytes Loaded from Cache) / Bytes Loaded to Cache via Miss)\n"


### PR DESCRIPTION
While thinking through performance optimization on the manycore we realized it is critical to have a few more metrics on the memory system.

This PR will probably include a few other updates, too (DRAM BW metrics, etc)

First: A metric for how much of a cache line is being used before it is evicted. At the moment I am computing a bytes loaded At the moment these are called Bytes Used Ratios, but I'm open to naming suggestions. 

Before: 

```
-----------------------------------------------------------------------------
Miss Statistics                                                              
-----------------------------------------------------------------------------
Type       Misses    Accesses    Miss Rate (%)
-------  --------  ----------  ---------------
Stores          0      148968             0.00
Loads        9732      161421             6.03
Atomics         0           0             0.00
Total        9732      310389             3.14
-----------------------------------------------------------------------------


############################################################################### Per-Bank Victim Cache Stats ###############################################################################
Table Fields: 
        - Cache Coordinate (Y,X): Cache Coordinate within HammerBlade Pod
        - Total Cycles: Total Cache Execution Cycles
        - # Misses: Total Number of Cache Misses
        - Operations: Total Number of Cache Operations (Loads + Stores + Atomics + Management)
        - Miss Rate: 100 * (Number of Misses / Number of Ops)
        - Memory Access Latency: Average Memory Access Latency for Misses (Total Miss Cycles / Number of Misses)
        - Percent Miss Cycles: 100 * (Total Miss Cycles / Total Cycles)
        - Percent Idle Cycles: 100 * (Total Idle Cycles / Total Cycles)
        - Percent Response Stall Cycles: 100 * (Total Response Stall Cycles / Total Cycles)
        - Percent Operations Cycles: 100 * (Total Operation Cycles / Total Cycles)

Note: inf (Infinite) occurs when a tag window captures miss stall cycles that bleed into its window, but has no misses
======================================================================================= Tag: Kernel =======================================================================================
Cache Coordinate (Y,X)      Total Cycles    # Misses    # Operations    Miss Rate (%)    Mem. Latency    Percent Miss Cycles    Percent Idle Cycles    Percent Stall Cycles    Percent Ops.
------------------------  --------------  ----------  --------------  ---------------  --------------  ---------------------  ---------------------  ----------------------  --------------
('Bottom', 0)                    1305971         304            9728             3.12          102.96                   2.40                  96.88                    0.00            0.74
('Bottom', 1)                    1305971         304            9728             3.12          101.99                   2.37                  96.90                    0.00            0.74
('Bottom', 2)                    1305971         304            9728             3.12          113.89                   2.65                  96.63                    0.00            0.74
('Bottom', 3)                    1305971         304            9728             3.12          108.68                   2.53                  96.75                    0.00            0.74
('Bottom', 4)                    1305971         304            9728             3.12          112.10                   2.61                  96.67                    0.00            0.74
('Bottom', 5)                    1305971         304            9728             3.12          110.41                   2.57                  96.71                    0.00            0.74
('Bottom', 6)                    1305971         304            9728             3.12          110.02                   2.56                  96.72                    0.00            0.74
('Bottom', 7)                    1305971         304            9728             3.12          110.64                   2.58                  96.70                    0.00            0.74
('Bottom', 8)                    1305971         304            9728             3.12          110.48                   2.57                  96.71                    0.00            0.74
('Bottom', 9)                    1305971         304            9728             3.12          110.49                   2.57                  96.71                    0.00            0.74
('Bottom', 10)                   1305971         304            9728             3.12          110.94                   2.58                  96.70                    0.00            0.74
('Bottom', 11)                   1305971         304            9728             3.12          105.22                   2.45                  96.83                    0.00            0.74
('Bottom', 12)                   1305971         304            9728             3.12          104.73                   2.44                  96.84                    0.00            0.74
('Bottom', 13)                   1305971         304            9728             3.12          103.44                   2.41                  96.87                    0.00            0.74
('Bottom', 14)                   1305971         304            9728             3.12          100.95                   2.35                  96.93                    0.00            0.74
('Bottom', 15)                   1305971         304            9728             3.12          107.42                   2.50                  96.78                    0.00            0.74
('Top', 0)                       1305971         305           11776             2.59           99.36                   2.32                  96.79                    0.01            0.90
('Top', 1)                       1305971         305           10880             2.80          103.77                   2.42                  96.77                    0.00            0.83
('Top', 2)                       1305971         305            9984             3.05          110.91                   2.59                  96.67                    0.00            0.76
('Top', 3)                       1305971         305           11776             2.59          107.27                   2.51                  96.62                    0.00            0.90
('Top', 4)                       1305971         304           10240             2.97          107.78                   2.51                  96.73                    0.00            0.78
('Top', 5)                       1305971         304            9728             3.12          110.46                   2.57                  96.71                    0.00            0.74
('Top', 6)                       1305971         304            9728             3.12          110.15                   2.56                  96.71                    0.00            0.74
('Top', 7)                       1305971         304            9946             3.06          109.29                   2.54                  96.72                    0.00            0.76
('Top', 8)                       1305971         304            9837             3.09          110.59                   2.57                  96.70                    0.00            0.75
('Top', 9)                       1305971         304            9728             3.12          112.24                   2.61                  96.67                    0.00            0.74
('Top', 10)                      1305971         304            9728             3.12          107.91                   2.51                  96.77                    0.00            0.74
('Top', 11)                      1305971         304            9728             3.12          105.16                   2.45                  96.83                    0.00            0.74
('Top', 12)                      1305971         304            9728             3.12          107.60                   2.50                  96.77                    0.00            0.74
('Top', 13)                      1305971         304            9728             3.12          103.04                   2.40                  96.88                    0.00            0.74
('Top', 14)                      1305971         304            9728             3.12          102.55                   2.39                  96.89                    0.00            0.74
('Top', 15)                      1305971         304            9728             3.12          102.20                   2.38                  96.90                    0.00            0.74

############################################################################# End Per-Bank Victim Cache Stats #############################################################################
```

After
```
------------------------------------------------------------------------------------------
Miss Statistics                                                                           
------------------------------------------------------------------------------------------
Type       Misses    Accesses    Bytes    Miss Rate (%)    Accesses / Miss    Bytes / Miss
-------  --------  ----------  -------  ---------------  -----------------  --------------
Stores          0      148968   595872             0.00                inf             inf
Loads        9732      161421   645684             5.69              16.59           66.35
Atomics         0           0        0             0.00               0.00            0.00
Total        9732      310389  1241556             3.04              31.89          127.57
------------------------------------------------------------------------------------------


########################################################################################################################### Per-Bank Victim Cache Stats ###########################################################################################################################
Table Fields: 
        - Cache Coordinate (Y,X): Cache Coordinate within HammerBlade Pod
        - Total Cycles: Total Cache Execution Cycles
        - # Misses: Total Number of Cache Misses
        - Operations: Total Number of Cache Operations (Loads + Stores + Atomics + Management)
        - Miss Rate: 100 * (Number of Misses / Number of Ops)
        - Bytes Loaded Ratio: Bytes Loaded from Cache / Bytes Loaded to Cache via Load Miss
        - Bytes Stored Ratio: Bytes Stored to Cache / Bytes Loded to Cache via Store Miss
        - Bytes Atomic'd Ratio: Bytes Atomic'd in Cache / Bytes Loaded to Cache via Atomic Miss
        - Bytes Used Ratio: (Bytes Stored to Cache + Bytes Loaded from Cache) / Bytes Loaded to Cache via Miss)
        - Memory Access Latency: Average Memory Access Latency for Misses (Total Miss Cycles / Number of Misses)
        - Percent Miss Cycles: 100 * (Total Miss Cycles / Total Cycles)
        - Percent Idle Cycles: 100 * (Total Idle Cycles / Total Cycles)
        - Percent Response Stall Cycles: 100 * (Total Response Stall Cycles / Total Cycles)
        - Percent Operations Cycles: 100 * (Total Operation Cycles / Total Cycles)

Note: inf (Infinite) occurs when a tag window captures miss stall cycles that bleed into its window, but has no misses
Note: nan occurs when there are no misses recorded for a type
=================================================================================================================================== Tag: Kernel ===================================================================================================================================
Cache Coordinate (Y,X)      Total Cycles    # Misses    # Operations    Miss Rate (%)    Bytes Loaded Ratio    Bytes Stored Ratio    Bytes Atomic'd Ratio    Bytes Used Ratio    Mem. Latency    Percent Miss Cycles    Percent Idle Cycles    Percent Stall Cycles    Percent Ops.
------------------------  --------------  ----------  --------------  ---------------  --------------------  --------------------  ----------------------  ------------------  --------------  ---------------------  ---------------------  ----------------------  --------------
('Bottom', 0)                    1305971         304            9728             3.12                  1.00                   inf                     nan                2.00          102.96                   2.40                  96.88                    0.00            0.74
('Bottom', 1)                    1305971         304            9728             3.12                  1.00                   inf                     nan                2.00          101.99                   2.37                  96.90                    0.00            0.74
('Bottom', 2)                    1305971         304            9728             3.12                  1.00                   inf                     nan                2.00          113.89                   2.65                  96.63                    0.00            0.74
('Bottom', 3)                    1305971         304            9728             3.12                  1.00                   inf                     nan                2.00          108.68                   2.53                  96.75                    0.00            0.74
('Bottom', 4)                    1305971         304            9728             3.12                  1.00                   inf                     nan                2.00          112.10                   2.61                  96.67                    0.00            0.74
('Bottom', 5)                    1305971         304            9728             3.12                  1.00                   inf                     nan                2.00          110.41                   2.57                  96.71                    0.00            0.74
('Bottom', 6)                    1305971         304            9728             3.12                  1.00                   inf                     nan                2.00          110.02                   2.56                  96.72                    0.00            0.74
('Bottom', 7)                    1305971         304            9728             3.12                  1.00                   inf                     nan                2.00          110.64                   2.58                  96.70                    0.00            0.74
('Bottom', 8)                    1305971         304            9728             3.12                  1.00                   inf                     nan                2.00          110.48                   2.57                  96.71                    0.00            0.74
('Bottom', 9)                    1305971         304            9728             3.12                  1.00                   inf                     nan                2.00          110.49                   2.57                  96.71                    0.00            0.74
('Bottom', 10)                   1305971         304            9728             3.12                  1.00                   inf                     nan                2.00          110.94                   2.58                  96.70                    0.00            0.74
('Bottom', 11)                   1305971         304            9728             3.12                  1.00                   inf                     nan                2.00          105.22                   2.45                  96.83                    0.00            0.74
('Bottom', 12)                   1305971         304            9728             3.12                  1.00                   inf                     nan                2.00          104.73                   2.44                  96.84                    0.00            0.74
('Bottom', 13)                   1305971         304            9728             3.12                  1.00                   inf                     nan                2.00          103.44                   2.41                  96.87                    0.00            0.74
('Bottom', 14)                   1305971         304            9728             3.12                  1.00                   inf                     nan                2.00          100.95                   2.35                  96.93                    0.00            0.74
('Bottom', 15)                   1305971         304            9728             3.12                  1.00                   inf                     nan                2.00          107.42                   2.50                  96.78                    0.00            0.74
('Top', 0)                       1305971         305           11776             2.59                  1.42                   inf                     nan                2.41           99.36                   2.32                  96.79                    0.01            0.90
('Top', 1)                       1305971         305           10880             2.80                  1.23                   inf                     nan                2.23          103.77                   2.42                  96.77                    0.00            0.83
('Top', 2)                       1305971         305            9984             3.05                  1.05                   inf                     nan                2.05          110.91                   2.59                  96.67                    0.00            0.76
('Top', 3)                       1305971         305           11776             2.59                  1.42                   inf                     nan                2.41          107.27                   2.51                  96.62                    0.00            0.90
('Top', 4)                       1305971         304           10240             2.97                  1.11                   inf                     nan                2.11          107.78                   2.51                  96.73                    0.00            0.78
('Top', 5)                       1305971         304            9728             3.12                  1.00                   inf                     nan                2.00          110.46                   2.57                  96.71                    0.00            0.74
('Top', 6)                       1305971         304            9728             3.12                  1.00                   inf                     nan                2.00          110.15                   2.56                  96.71                    0.00            0.74
('Top', 7)                       1305971         304            9946             3.06                  1.04                   inf                     nan                2.04          109.29                   2.54                  96.72                    0.00            0.76
('Top', 8)                       1305971         304            9837             3.09                  1.02                   inf                     nan                2.02          110.59                   2.57                  96.70                    0.00            0.75
('Top', 9)                       1305971         304            9728             3.12                  1.00                   inf                     nan                2.00          112.24                   2.61                  96.67                    0.00            0.74
('Top', 10)                      1305971         304            9728             3.12                  1.00                   inf                     nan                2.00          107.91                   2.51                  96.77                    0.00            0.74
('Top', 11)                      1305971         304            9728             3.12                  1.00                   inf                     nan                2.00          105.16                   2.45                  96.83                    0.00            0.74
('Top', 12)                      1305971         304            9728             3.12                  1.00                   inf                     nan                2.00          107.60                   2.50                  96.77                    0.00            0.74
('Top', 13)                      1305971         304            9728             3.12                  1.00                   inf                     nan                2.00          103.04                   2.40                  96.88                    0.00            0.74
('Top', 14)                      1305971         304            9728             3.12                  1.00                   inf                     nan                2.00          102.55                   2.39                  96.89                    0.00            0.74
('Top', 15)                      1305971         304            9728             3.12                  1.00                   inf                     nan                2.00          102.20                   2.38                  96.90                    0.00            0.74

######################################################################################################################### End Per-Bank Victim Cache Stats #########################################################################################################################

```
