### PR TITLE
Adding east_not_west to cid

### DIFF
--- a/testbenches/common/v/spmd_testbench.v
+++ b/testbenches/common/v/spmd_testbench.v
@@ -42,7 +42,7 @@ module spmd_testbench
 
   parameter wh_flit_width_p = vcache_dma_data_width_p;
   parameter wh_ruche_factor_p = 2;
-  parameter wh_cid_width_p = `BSG_SAFE_CLOG2(2*wh_ruche_factor_p); // no concentration in this testbench; cid is ignored.
+  parameter wh_cid_width_p = `BSG_SAFE_CLOG2(2*wh_ruche_factor_p+1); // no concentration in this testbench; cid is ignored.
   parameter wh_len_width_p = `BSG_SAFE_CLOG2(1+(vcache_block_size_in_words_p*vcache_data_width_p/vcache_dma_data_width_p)); // header + addr + data
   parameter wh_cord_width_p = x_cord_width_p;
 

--- a/testbenches/common/v/spmd_testbench.v
+++ b/testbenches/common/v/spmd_testbench.v
@@ -42,7 +42,7 @@ module spmd_testbench
 
   parameter wh_flit_width_p = vcache_dma_data_width_p;
   parameter wh_ruche_factor_p = 2;
-  parameter wh_cid_width_p = `BSG_SAFE_CLOG2(2*wh_ruche_factor_p+1); // no concentration in this testbench; cid is ignored.
+  parameter wh_cid_width_p = `BSG_SAFE_CLOG2(2*2*wh_ruche_factor_p); // no concentration in this testbench; cid is ignored.
   parameter wh_len_width_p = `BSG_SAFE_CLOG2(1+(vcache_block_size_in_words_p*vcache_data_width_p/vcache_dma_data_width_p)); // header + addr + data
   parameter wh_cord_width_p = x_cord_width_p;
 

--- a/v/bsg_manycore_tile_vcache.v
+++ b/v/bsg_manycore_tile_vcache.v
@@ -286,7 +286,8 @@ module bsg_manycore_tile_vcache
     // concentrator id
     // lower bits come from lower bits of global_x
     // upper bits come from whether its north or south vc.
-    ,.my_wh_cid_i({~global_y_r[y_subcord_width_lp-1], global_x_r[0+:lg_wh_ruche_factor_lp]})
+    // top bit is whether its eastbound or westbound
+    ,.my_wh_cid_i({wh_dest_east_not_west_lo, ~global_y_r[y_subcord_width_lp-1], global_x_r[0+:lg_wh_ruche_factor_lp]})
   );
  
 


### PR DESCRIPTION
This PR adds east_not_west to the wormhole CID. This is very useful for systems which combine the east and west memory streams and would like to differentiate between them. Because we have spare bits in the header, this change should have no PPA impact on the manycore hardware itself