### PR TITLE
Moves File Open/Close Operations in Trace Profiler

### DIFF
--- a/machines/sim_filelist.mk
+++ b/machines/sim_filelist.mk
@@ -55,6 +55,7 @@ VSOURCES += $(BASEJUMP_STL_DIR)/bsg_cache/bsg_wormhole_to_cache_dma_fanout.v
 VSOURCES += $(BSG_MANYCORE_DIR)/testbenches/common/v/router_profiler.v
 VSOURCES += $(BSG_MANYCORE_DIR)/testbenches/common/v/vanilla_core_trace.v
 VSOURCES += $(BSG_MANYCORE_DIR)/testbenches/common/v/remote_load_trace.v
+CSOURCES += $(BSG_MANYCORE_DIR)/testbenches/common/v/remote_load_profiler.cpp
 VSOURCES += $(BSG_MANYCORE_DIR)/testbenches/common/v/instr_trace.v
 VSOURCES += $(BSG_MANYCORE_DIR)/testbenches/common/v/vanilla_core_profiler.v
 CSOURCES += $(BSG_MANYCORE_DIR)/testbenches/common/v/vanilla_core_profiler.cpp

--- a/machines/sim_filelist.mk
+++ b/machines/sim_filelist.mk
@@ -57,6 +57,7 @@ VSOURCES += $(BSG_MANYCORE_DIR)/testbenches/common/v/vanilla_core_trace.v
 VSOURCES += $(BSG_MANYCORE_DIR)/testbenches/common/v/remote_load_trace.v
 VSOURCES += $(BSG_MANYCORE_DIR)/testbenches/common/v/instr_trace.v
 VSOURCES += $(BSG_MANYCORE_DIR)/testbenches/common/v/vanilla_core_profiler.v
+CSOURCES += $(BSG_MANYCORE_DIR)/testbenches/common/v/vanilla_core_profiler.cpp
 VSOURCES += $(BSG_MANYCORE_DIR)/testbenches/common/v/vcache_profiler.v
 VSOURCES += $(BSG_MANYCORE_DIR)/testbenches/common/v/vcache_non_blocking_profiler.v
 VSOURCES += $(BSG_MANYCORE_DIR)/testbenches/common/v/infinite_mem_profiler.v

--- a/machines/sim_filelist.mk
+++ b/machines/sim_filelist.mk
@@ -59,6 +59,7 @@ VSOURCES += $(BSG_MANYCORE_DIR)/testbenches/common/v/instr_trace.v
 VSOURCES += $(BSG_MANYCORE_DIR)/testbenches/common/v/vanilla_core_profiler.v
 CSOURCES += $(BSG_MANYCORE_DIR)/testbenches/common/v/vanilla_core_profiler.cpp
 VSOURCES += $(BSG_MANYCORE_DIR)/testbenches/common/v/vcache_profiler.v
+CSOURCES += $(BSG_MANYCORE_DIR)/testbenches/common/v/vcache_profiler.cpp
 VSOURCES += $(BSG_MANYCORE_DIR)/testbenches/common/v/vcache_non_blocking_profiler.v
 VSOURCES += $(BSG_MANYCORE_DIR)/testbenches/common/v/infinite_mem_profiler.v
 VSOURCES += $(BSG_MANYCORE_DIR)/testbenches/common/v/bsg_nonsynth_manycore_tag_master.v

--- a/machines/sim_filelist.mk
+++ b/machines/sim_filelist.mk
@@ -1,5 +1,6 @@
 # This file contains a list of non-synthesizable files used in manycore
 # simulation. These augment the sythesizable files in core.include.
+VINCLUDES += $(BSG_MANYCORE_DIR)/testbenches/common/v
 
 VHEADERS += $(BSG_MANYCORE_DIR)/testbenches/common/v/bsg_manycore_mem_cfg_pkg.v
 VHEADERS += $(BSG_MANYCORE_DIR)/testbenches/common/v/bsg_manycore_network_cfg_pkg.v

--- a/testbenches/common/v/profiler.hpp
+++ b/testbenches/common/v/profiler.hpp
@@ -9,6 +9,7 @@ public:
     }
 
     // members
+    int is_init;
     int is_exit;
     int trace_file;
 };
@@ -18,30 +19,30 @@ public:
     extern "C" void profiler_name ## _init(             \
         int _trace_file                                 \
         ) {                                             \
-        if (profiler_name == nullptr) {                 \
-            profiler_name = new bsg_profiler::profiler; \
-            profiler_name->trace_file = _trace_file;    \
+        if (profiler_name.is_init == 0) {               \
+            profiler_name.trace_file = _trace_file;     \
         }                                               \
     }
 
 #define PROFILER_EXIT_FUNC(profiler_name)            \
     extern "C" void profiler_name ##_exit() {        \
+        profiler_name.is_exit = 1;                   \
         return;                                      \
     }
 
 #define PROFILER_IS_INIT_FUNC(profiler_name)        \
     extern "C" int profiler_name ## _is_init() {    \
-        return (profiler_name != nullptr);          \
+        return profiler_name.is_init;               \
     }
 
 #define PROFILER_IS_EXIT_FUNC(profiler_name)        \
     extern "C" int profiler_name ##_is_exit() {     \
-        return profiler_name->is_exit;              \
+        return profiler_name.is_exit;               \
     }
 
 #define PROFILER_TRACE_FD_FUNC(profiler_name)           \
     extern "C" int profiler_name ##_trace_fd() {        \
-        return profiler_name->trace_file;               \
+        return profiler_name.trace_file;                \
     }
 
 #define DEFINE_PROFILER(profiler_name)          \

--- a/testbenches/common/v/profiler.hpp
+++ b/testbenches/common/v/profiler.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <mutex>
 namespace bsg_profiler {
 class profiler {
 public:
@@ -12,8 +13,20 @@ public:
     int is_init;
     int is_exit;
     int trace_file;
+
+    std::mutex mtx;
 };
 }
+
+#define PROFILER_LOCK_FUNC(profiler_name)               \
+    extern "C" void profiler_name ##_lock() {           \
+        profiler_name.mtx.lock();                       \
+    }
+
+#define PROFILER_UNLOCK_FUNC(profiler_name)             \
+    extern "C" void profiler_name ##_unlock() {         \
+        profiler_name.mtx.unlock();                     \
+    }
 
 #define PROFILER_INIT_FUNC(profiler_name)               \
     extern "C" void profiler_name ## _init(             \

--- a/testbenches/common/v/profiler.hpp
+++ b/testbenches/common/v/profiler.hpp
@@ -50,4 +50,6 @@ public:
     PROFILER_EXIT_FUNC(profiler_name)           \
     PROFILER_IS_INIT_FUNC(profiler_name)        \
     PROFILER_IS_EXIT_FUNC(profiler_name)        \
-    PROFILER_TRACE_FD_FUNC(profiler_name)
+    PROFILER_TRACE_FD_FUNC(profiler_name)       \
+    PROFILER_LOCK_FUNC(profiler_name)           \
+    PROFILER_UNLOCK_FUNC(profiler_name)

--- a/testbenches/common/v/profiler.hpp
+++ b/testbenches/common/v/profiler.hpp
@@ -1,0 +1,52 @@
+#pragma once
+namespace bsg_profiler {
+class profiler {
+public:
+    // constructors
+    profiler()
+        : is_exit(0)
+        , trace_file(-1) {
+    }
+
+    // members
+    int is_exit;
+    int trace_file;
+};
+}
+
+#define PROFILER_INIT_FUNC(profiler_name)               \
+    extern "C" void profiler_name ## _init(             \
+        int _trace_file                                 \
+        ) {                                             \
+        if (profiler_name == nullptr) {                 \
+            profiler_name = new bsg_profiler::profiler; \
+            profiler_name->trace_file = _trace_file;    \
+        }                                               \
+    }
+
+#define PROFILER_EXIT_FUNC(profiler_name)            \
+    extern "C" void profiler_name ##_exit() {        \
+        return;                                      \
+    }
+
+#define PROFILER_IS_INIT_FUNC(profiler_name)        \
+    extern "C" int profiler_name ## _is_init() {    \
+        return (profiler_name != nullptr);          \
+    }
+
+#define PROFILER_IS_EXIT_FUNC(profiler_name)        \
+    extern "C" int profiler_name ##_is_exit() {     \
+        return profiler_name->is_exit;              \
+    }
+
+#define PROFILER_TRACE_FD_FUNC(profiler_name)           \
+    extern "C" int profiler_name ##_trace_fd() {        \
+        return profiler_name->trace_file;               \
+    }
+
+#define DEFINE_PROFILER(profiler_name)          \
+    PROFILER_INIT_FUNC(profiler_name)           \
+    PROFILER_EXIT_FUNC(profiler_name)           \
+    PROFILER_IS_INIT_FUNC(profiler_name)        \
+    PROFILER_IS_EXIT_FUNC(profiler_name)        \
+    PROFILER_TRACE_FD_FUNC(profiler_name)

--- a/testbenches/common/v/profiler.vh
+++ b/testbenches/common/v/profiler.vh
@@ -1,0 +1,50 @@
+`ifndef PROFILER_VH
+`define PROFILER_VH
+
+`define DECLARE_PROFILER_INIT_FUNC(profiler_name) \
+import "DPI-C" context function \
+  void profiler_name``_init(int tracer_fd);
+
+`define DECLARE_PROFILER_EXIT_FUNC(profiler_name) \
+import "DPI-C" context function \
+  void profiler_name``_exit();
+
+`define DECLARE_PROFILER_IS_INIT_FUNC(profiler_name) \
+import "DPI-C" context function \
+  int profiler_name``_is_init();
+
+`define DECLARE_PROFILER_IS_EXIT_FUNC(profiler_name) \
+import "DPI-C" context function \
+  int profiler_name``_is_exit();
+
+`define DECLARE_PROFILER_TRACE_FD_FUNC(profiler_name) \
+import  "DPI-C" context function \
+  int profiler_name``_trace_fd();
+
+`define DEFINE_PROFILER_INITIAL_BLOCK(profiler_name, trace_file_name, trace_file_header) \
+initial begin \
+  if (profiler_name``_is_init() == 0) begin \
+    int trace_fd = $fopen(trace_file_name, "w"); \
+    profiler_name``_init(trace_fd); \
+    $fwrite(trace_fd, trace_file_header); \
+  end \
+end
+
+`define DEFINE_PROFILER_FINAL_BLOCK(profiler_name, trace_file_name, trace_file_header) \
+  final begin \
+    if (profiler_name``_is_exit()) begin \
+      $fclose(profiler_name``_trace_fd()); \
+      profiler_name``_exit(); \
+    end \
+  end
+
+`define DEFINE_PROFILER(profiler_name, trace_file_name, trace_file_header) \
+  `DECLARE_PROFILER_INIT_FUNC(profiler_name) \
+  `DECLARE_PROFILER_EXIT_FUNC(profiler_name) \
+  `DECLARE_PROFILER_IS_INIT_FUNC(profiler_name) \
+  `DECLARE_PROFILER_IS_EXIT_FUNC(profiler_name) \
+  `DECLARE_PROFILER_TRACE_FD_FUNC(profiler_name) \
+  `DEFINE_PROFILER_INITIAL_BLOCK(profiler_name, trace_file_name, trace_file_header) \
+  `DEFINE_PROFILER_FINAL_BLOCK(profiler_name)
+
+`endif

--- a/testbenches/common/v/profiler.vh
+++ b/testbenches/common/v/profiler.vh
@@ -21,21 +21,34 @@ import "DPI-C" context function \
 import  "DPI-C" context function \
   int profiler_name``_trace_fd();
 
+`define DECLARE_PROFILER_LOCK_FUNC(profiler_name) \
+import "DPI-C" context function \
+  void profiler_name``_lock();
+
+`define DECLARE_PROFILER_UNLOCK_FUNC(profiler_name) \
+import "DPI-C" context function \
+  void profiler_name``_unlock();
+
+
 `define DEFINE_PROFILER_INITIAL_BLOCK(profiler_name, trace_file_name, trace_file_header) \
 initial begin \
+  profiler_name``_lock();  \
   if (profiler_name``_is_init() == 0) begin \
     int trace_fd = $fopen(trace_file_name, "w"); \
     profiler_name``_init(trace_fd); \
     $fwrite(trace_fd, trace_file_header); \
   end \
+  profiler_name``_unlock(); \
 end
 
 `define DEFINE_PROFILER_FINAL_BLOCK(profiler_name, trace_file_name, trace_file_header) \
   final begin \
+    profiler_name``_lock(); \
     if (profiler_name``_is_exit()) begin \
       $fclose(profiler_name``_trace_fd()); \
       profiler_name``_exit(); \
     end \
+    profiler_name``_unlock(); \
   end
 
 `define DEFINE_PROFILER(profiler_name, trace_file_name, trace_file_header) \
@@ -44,6 +57,8 @@ end
   `DECLARE_PROFILER_IS_INIT_FUNC(profiler_name) \
   `DECLARE_PROFILER_IS_EXIT_FUNC(profiler_name) \
   `DECLARE_PROFILER_TRACE_FD_FUNC(profiler_name) \
+  `DECLARE_PROFILER_LOCK_FUNC(profiler_name) \
+  `DECLARE_PROFILER_UNLOCK_FUNC(profiler_name) \
   `DEFINE_PROFILER_INITIAL_BLOCK(profiler_name, trace_file_name, trace_file_header) \
   `DEFINE_PROFILER_FINAL_BLOCK(profiler_name)
 

--- a/testbenches/common/v/remote_load_profiler.cpp
+++ b/testbenches/common/v/remote_load_profiler.cpp
@@ -1,0 +1,3 @@
+#include "profiler.hpp"
+bsg_profiler::profiler *remote_load_profiler = nullptr;
+DEFINE_PROFILER(remote_load_profiler);

--- a/testbenches/common/v/remote_load_profiler.cpp
+++ b/testbenches/common/v/remote_load_profiler.cpp
@@ -1,3 +1,3 @@
 #include "profiler.hpp"
-bsg_profiler::profiler *remote_load_profiler = nullptr;
+bsg_profiler::profiler remote_load_profiler;
 DEFINE_PROFILER(remote_load_profiler);

--- a/testbenches/common/v/remote_load_trace.v
+++ b/testbenches/common/v/remote_load_trace.v
@@ -21,6 +21,7 @@
 // {latency}      # of cycles to complete remote load. (end_cycle - start_cycle)
 
 `include "bsg_manycore_defines.vh"
+`include "profiler.vh"
 
 module remote_load_trace
   import bsg_manycore_pkg::*;
@@ -70,32 +71,10 @@ module remote_load_trace
     , input [31:0] global_ctr_i
   );
 
-  import "DPI-C" context function
-    void remote_load_profiler_init(int trace_fd);
-  import "DPI-C" context function
-    void remote_load_profiler_exit();
-  import "DPI-C" context function
-    int remote_load_profiler_is_init();
-  import "DPI-C" context function
-    int remote_load_profiler_is_exit();
-  import "DPI-C" context function
-    int remote_load_profiler_trace_fd();
-
-  initial begin
-    if (remote_load_profiler_is_init() == 0) begin
-      int trace_fd = $fopen("remote_load_trace.csv", "w");
-      $fwrite(trace_fd, "start_cycle,end_cycle,src_x,src_y,dest_x,dest_y,type,latency\n");
-      remote_load_profiler_init(trace_fd);
-    end
-  end
-
-  final begin
-    if (remote_load_profiler_is_exit() == 0) begin
-      $fclose(remote_load_profiler_trace_fd());
-      remote_load_profiler_exit();
-    end
-  end
-
+  `DEFINE_PROFILER(remote_load_profiler
+                   ,"remote_load_trace.csv"
+                   ,"start_cycle,end_cycle,src_x,src_y,dest_x,dest_y,type,latency\n"
+                   )
 
   wire [x_cord_width_p-1:0] global_x = {pod_x_i, my_x_i};
   wire [y_cord_width_p-1:0] global_y = {pod_y_i, my_y_i};

--- a/testbenches/common/v/remote_load_trace.v
+++ b/testbenches/common/v/remote_load_trace.v
@@ -39,8 +39,6 @@ module remote_load_trace
     , parameter `BSG_INV_PARAM(origin_x_cord_p)
     , parameter `BSG_INV_PARAM(origin_y_cord_p)
 
-    , parameter tracefile_p = "remote_load_trace.csv"
-
     , parameter packet_width_lp=
     `bsg_manycore_packet_width(addr_width_p,data_width_p,x_cord_width_p,y_cord_width_p)
   )
@@ -157,29 +155,6 @@ module remote_load_trace
   
 
 
-  // responses logging
-  integer fd;
-
-  initial begin
-    fd = $fopen(tracefile_p, "w");
-    $fwrite(fd,"");   
-    $fclose(fd);
-  end
-
-
-  // origin tile writes the csv header.
-  always @ (negedge reset_i) begin
-    if ((global_x == x_cord_width_p'(origin_x_cord_p))
-      & (global_y == y_cord_width_p'(origin_y_cord_p))) begin
-
-      fd = $fopen(tracefile_p, "a");
-      $fwrite(fd,"start_cycle,end_cycle,src_x,src_y,dest_x,dest_y,type,latency\n");
-      $fclose(fd);
-      
-    end
-  end
-
-
   always @ (negedge clk_i) begin
     if (~reset_i & trace_en_i) begin
 
@@ -188,8 +163,7 @@ module remote_load_trace
         case (returned_pkt_type_i)
 
           e_return_int_wb: begin
-            fd = $fopen(tracefile_p, "a");
-            $fwrite(fd,"%0d,%0d,%0d,%0d,%0d,%0d,%s,%0d\n", 
+            $fwrite($root.`HOST_MODULE_PATH.remote_trace_fd,"%0d,%0d,%0d,%0d,%0d,%0d,%s,%0d\n",
               int_rl_status_r[returned_reg_id_i].start_cycle,
               global_ctr_i,
               global_x,
@@ -199,12 +173,10 @@ module remote_load_trace
               "int",
               global_ctr_i-int_rl_status_r[returned_reg_id_i].start_cycle
             );   
-            $fclose(fd);
           end
 
           e_return_float_wb: begin
-            fd = $fopen(tracefile_p, "a");
-            $fwrite(fd,"%0d,%0d,%0d,%0d,%0d,%0d,%s,%0d\n", 
+            $fwrite($root.`HOST_MODULE_PATH.remote_trace_fd,"%0d,%0d,%0d,%0d,%0d,%0d,%s,%0d\n",
               float_rl_status_r[returned_reg_id_i].start_cycle,
               global_ctr_i,
               global_x,
@@ -214,12 +186,10 @@ module remote_load_trace
               "float",
               global_ctr_i-float_rl_status_r[returned_reg_id_i].start_cycle
             );   
-            $fclose(fd);
 
           end
           e_return_ifetch: begin
-            fd = $fopen(tracefile_p, "a");
-            $fwrite(fd,"%0d,%0d,%0d,%0d,%0d,%0d,%s,%0d\n", 
+            $fwrite($root.`HOST_MODULE_PATH.remote_trace_fd,"%0d,%0d,%0d,%0d,%0d,%0d,%s,%0d\n",
               icache_status_r.start_cycle,
               global_ctr_i,
               global_x,
@@ -229,7 +199,6 @@ module remote_load_trace
               "icache",
               global_ctr_i-icache_status_r.start_cycle
             );   
-            $fclose(fd);
 
           end
 

--- a/testbenches/common/v/spmd_testbench.v
+++ b/testbenches/common/v/spmd_testbench.v
@@ -218,7 +218,16 @@ module spmd_testbench
     $fclose(vcache_trace_fd);
   end
   
-  // router trace
+  // remote load trace
+  int remote_trace_fd;
+  localparam remote_load_trace_file_lp = "remote_load_trace.csv";
+  initial begin
+    remote_trace_fd = $fopen(remote_load_trace_file_lp, "w");
+    $fwrite(remote_trace_fd, "start_cycle,end_cycle,src_x,src_y,dest_x,dest_y,type,latency\n");
+  end
+  final begin
+    $fclose(remote_trace_fd);
+  end
 
   // coverage enable
   int coverage_arg;

--- a/testbenches/common/v/spmd_testbench.v
+++ b/testbenches/common/v/spmd_testbench.v
@@ -196,17 +196,6 @@ module spmd_testbench
     assign trace_en = (trace_arg == 1);
   end
   
-  // remote load trace
-  int remote_trace_fd;
-  localparam remote_load_trace_file_lp = "remote_load_trace.csv";
-  initial begin
-    remote_trace_fd = $fopen(remote_load_trace_file_lp, "w");
-    $fwrite(remote_trace_fd, "start_cycle,end_cycle,src_x,src_y,dest_x,dest_y,type,latency\n");
-  end
-  final begin
-    $fclose(remote_trace_fd);
-  end
-
   // coverage enable
   int coverage_arg;
   logic coverage_en;

--- a/testbenches/common/v/spmd_testbench.v
+++ b/testbenches/common/v/spmd_testbench.v
@@ -195,17 +195,6 @@ module spmd_testbench
     status = $value$plusargs("vanilla_trace_en=%d", trace_arg);
     assign trace_en = (trace_arg == 1);
   end
-
-  // vcache trace
-  int vcache_trace_fd;
-  localparam vcache_trace_file_lp = "vcache_operation_trace.csv";
-  initial begin
-    vcache_trace_fd = $fopen(vcache_trace_file_lp, "w");
-    $fwrite(vcache_trace_fd, "cycle,vcache,operation\n");
-  end
-  final begin
-    $fclose(vcache_trace_fd);
-  end
   
   // remote load trace
   int remote_trace_fd;

--- a/testbenches/common/v/spmd_testbench.v
+++ b/testbenches/common/v/spmd_testbench.v
@@ -208,6 +208,16 @@ module spmd_testbench
   end
 
   // vcache trace
+  int vcache_trace_fd;
+  localparam vcache_trace_file_lp = "vcache_operation_trace.csv";
+  initial begin
+    vcache_trace_fd = $fopen(vcache_trace_file_lp, "w");
+    $fwrite(vcache_trace_fd, "cycle,vcache,operation\n");
+  end
+  final begin
+    $fclose(vcache_trace_fd);
+  end
+  
   // router trace
 
   // coverage enable

--- a/testbenches/common/v/spmd_testbench.v
+++ b/testbenches/common/v/spmd_testbench.v
@@ -196,17 +196,6 @@ module spmd_testbench
     assign trace_en = (trace_arg == 1);
   end
 
-  // vanilla operations trace
-  int vanilla_trace_fd;
-  localparam vanilla_trace_file = "vanilla_operation_trace.csv";
-  initial begin
-    vanilla_trace_fd = $fopen(vanilla_trace_file, "w");
-    $fwrite(vanilla_trace_fd, "cycle,x,y,pc,operation\n");
-  end
-  final begin
-    $fclose(vanilla_trace_fd);
-  end
-
   // vcache trace
   int vcache_trace_fd;
   localparam vcache_trace_file_lp = "vcache_operation_trace.csv";

--- a/testbenches/common/v/spmd_testbench.v
+++ b/testbenches/common/v/spmd_testbench.v
@@ -196,6 +196,20 @@ module spmd_testbench
     assign trace_en = (trace_arg == 1);
   end
 
+  // vanilla operations trace
+  int vanilla_trace_fd;
+  localparam vanilla_trace_file = "vanilla_operation_trace.csv";
+  initial begin
+    vanilla_trace_fd = $fopen(vanilla_trace_file, "w");
+    $fwrite(vanilla_trace_fd, "cycle,x,y,pc,operation\n");
+  end
+  final begin
+    $fclose(vanilla_trace_fd);
+  end
+
+  // vcache trace
+  // router trace
+
   // coverage enable
   int coverage_arg;
   logic coverage_en;

--- a/testbenches/common/v/vanilla_core_profiler.cpp
+++ b/testbenches/common/v/vanilla_core_profiler.cpp
@@ -1,0 +1,38 @@
+#include <cstdio>
+#include <cstdlib>
+#include <memory>
+
+namespace bsg_vanilla_core_profiler
+{
+    int is_init = 0;
+    int is_exit = 0;
+    int trace_file = -1;
+}
+extern "C"
+{
+    using namespace bsg_vanilla_core_profiler;
+    void bsg_vanilla_core_profiler_init(
+        int _trace_file
+        ) {
+        if (!is_init) {
+            trace_file = _trace_file;
+            is_init = 1;
+        }
+    }
+
+    void bsg_vanilla_core_profiler_exit() {
+        return;
+    }
+
+    int bsg_vanilla_core_profiler_is_init() {
+        return is_init;
+    }
+
+    int bsg_vanilla_core_profiler_is_exit() {
+        return is_exit;
+    }
+
+    int  bsg_vanilla_core_profiler_trace_fd() {
+        return trace_file;
+    }
+}

--- a/testbenches/common/v/vanilla_core_profiler.cpp
+++ b/testbenches/common/v/vanilla_core_profiler.cpp
@@ -1,41 +1,5 @@
 #include "profiler.hpp"
 
-// namespace bsg_vanilla_core_profiler
-// {
-//     int is_init = 0;
-//     int is_exit = 0;
-//     int trace_file = -1;
-//}
-
 bsg_profiler::profiler *bsg_vanilla_core_profiler = nullptr;
 
 DEFINE_PROFILER(bsg_vanilla_core_profiler);
-
-// extern "C"
-// {
-//     using namespace bsg_vanilla_core_profiler;
-//     void bsg_vanilla_core_profiler_init(
-//         int _trace_file
-//         ) {
-//         if (!is_init) {
-//             trace_file = _trace_file;
-//             is_init = 1;
-//         }
-//     }
-
-//     void bsg_vanilla_core_profiler_exit() {
-//         return;
-//     }
-
-//     int bsg_vanilla_core_profiler_is_init() {
-//         return is_init;
-//     }
-
-//     int bsg_vanilla_core_profiler_is_exit() {
-//         return is_exit;
-//     }
-
-//     int  bsg_vanilla_core_profiler_trace_fd() {
-//         return trace_file;
-//     }
-// }

--- a/testbenches/common/v/vanilla_core_profiler.cpp
+++ b/testbenches/common/v/vanilla_core_profiler.cpp
@@ -1,5 +1,5 @@
 #include "profiler.hpp"
 
-bsg_profiler::profiler *bsg_vanilla_core_profiler = nullptr;
+bsg_profiler::profiler bsg_vanilla_core_profiler;
 
 DEFINE_PROFILER(bsg_vanilla_core_profiler);

--- a/testbenches/common/v/vanilla_core_profiler.cpp
+++ b/testbenches/common/v/vanilla_core_profiler.cpp
@@ -1,38 +1,41 @@
-#include <cstdio>
-#include <cstdlib>
-#include <memory>
+#include "profiler.hpp"
 
-namespace bsg_vanilla_core_profiler
-{
-    int is_init = 0;
-    int is_exit = 0;
-    int trace_file = -1;
-}
-extern "C"
-{
-    using namespace bsg_vanilla_core_profiler;
-    void bsg_vanilla_core_profiler_init(
-        int _trace_file
-        ) {
-        if (!is_init) {
-            trace_file = _trace_file;
-            is_init = 1;
-        }
-    }
+// namespace bsg_vanilla_core_profiler
+// {
+//     int is_init = 0;
+//     int is_exit = 0;
+//     int trace_file = -1;
+//}
 
-    void bsg_vanilla_core_profiler_exit() {
-        return;
-    }
+bsg_profiler::profiler *bsg_vanilla_core_profiler = nullptr;
 
-    int bsg_vanilla_core_profiler_is_init() {
-        return is_init;
-    }
+DEFINE_PROFILER(bsg_vanilla_core_profiler);
 
-    int bsg_vanilla_core_profiler_is_exit() {
-        return is_exit;
-    }
+// extern "C"
+// {
+//     using namespace bsg_vanilla_core_profiler;
+//     void bsg_vanilla_core_profiler_init(
+//         int _trace_file
+//         ) {
+//         if (!is_init) {
+//             trace_file = _trace_file;
+//             is_init = 1;
+//         }
+//     }
 
-    int  bsg_vanilla_core_profiler_trace_fd() {
-        return trace_file;
-    }
-}
+//     void bsg_vanilla_core_profiler_exit() {
+//         return;
+//     }
+
+//     int bsg_vanilla_core_profiler_is_init() {
+//         return is_init;
+//     }
+
+//     int bsg_vanilla_core_profiler_is_exit() {
+//         return is_exit;
+//     }
+
+//     int  bsg_vanilla_core_profiler_trace_fd() {
+//         return trace_file;
+//     }
+// }

--- a/testbenches/common/v/vanilla_core_profiler.v
+++ b/testbenches/common/v/vanilla_core_profiler.v
@@ -104,8 +104,15 @@ module vanilla_core_profiler
 
   // task to print a line of operation trace
   task print_operation_trace(string op, logic [data_width_p-1:0] pc);
-    integer fd = $root.`HOST_MODULE_PATH.vanilla_trace_fd;    
-    $fwrite(fd, "%0d,%0d,%0d,%0h,%s\n", global_ctr_i, global_x_i - origin_x_cord_p, global_y_i - origin_y_cord_p, pc, op);
+    $fwrite
+      ($root.`HOST_MODULE_PATH.vanilla_trace_fd
+       , "%0d,%0d,%0d,%0h,%s\n"
+       , global_ctr_i
+       , global_x_i - origin_x_cord_p
+       , global_y_i - origin_y_cord_p
+       , pc
+       , op
+       );
   endtask
 
 

--- a/testbenches/common/v/vanilla_core_profiler.v
+++ b/testbenches/common/v/vanilla_core_profiler.v
@@ -914,7 +914,7 @@ module vanilla_core_profiler
   localparam logfile_lp = "vanilla_stats.csv";
   localparam tracefile_lp = "vanilla_operation_trace.csv";
 
-  integer fd, fd2;
+  integer fd;
   string header;
    initial begin
       fd = $fopen(logfile_lp, "w");
@@ -1073,10 +1073,6 @@ module vanilla_core_profiler
       $fwrite(fd, "stall_remote_flw_wb");
       $fwrite(fd, "\n");
       $fclose(fd);
-
-      fd2 = $fopen(tracefile_lp, "w");
-      $fwrite(fd2, "cycle,x,y,pc,operation\n");
-      $fclose(fd2);
 
     end // if ((my_x_i == x_cord_width_p'(origin_x_cord_p)) & (my_y_i == y_cord_width_p'(origin_y_cord_p)))
    end // always @ (my_x_i)
@@ -1242,149 +1238,147 @@ module vanilla_core_profiler
       
         // trace logging
         if (~reset_i & trace_en_i) begin
-          fd2 = $fopen(tracefile_lp, "a");
              
-          if (fadd_inc) print_operation_trace(fd2, "fadd", fp_exe_pc_r);
-          else if (fsub_inc) print_operation_trace(fd2, "fsub", fp_exe_pc_r);
-          else if (fmul_inc) print_operation_trace(fd2, "fmul", fp_exe_pc_r);
-          else if (fsgnj_inc) print_operation_trace(fd2, "fsgnj", fp_exe_pc_r);
-          else if (fsgnjn_inc) print_operation_trace(fd2, "fsgnjn", fp_exe_pc_r);
-          else if (fsgnjx_inc) print_operation_trace(fd2, "fsgnjx", fp_exe_pc_r);
-          else if (fmin_inc) print_operation_trace(fd2, "fmin", fp_exe_pc_r);
-          else if (fmax_inc) print_operation_trace(fd2, "fmax", fp_exe_pc_r);
-          else if (fcvt_s_w_inc) print_operation_trace(fd2, "fcvt_s_w", fp_exe_pc_r);
-          else if (fcvt_s_wu_inc) print_operation_trace(fd2, "fcvt_s_wu", fp_exe_pc_r);
-          else if (fmv_w_x_inc) print_operation_trace(fd2, "fmv_w_x", fp_exe_pc_r);
-          else if (fmadd_inc) print_operation_trace(fd2, "fmadd", fp_exe_pc_r);
-          else if (fmsub_inc) print_operation_trace(fd2, "fmsub", fp_exe_pc_r);
-          else if (fnmsub_inc) print_operation_trace(fd2, "fnmsub", fp_exe_pc_r);
-          else if (fnmadd_inc) print_operation_trace(fd2, "fnmadd", fp_exe_pc_r);
+          if (fadd_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "fadd", fp_exe_pc_r);
+          else if (fsub_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "fsub", fp_exe_pc_r);
+          else if (fmul_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "fmul", fp_exe_pc_r);
+          else if (fsgnj_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "fsgnj", fp_exe_pc_r);
+          else if (fsgnjn_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "fsgnjn", fp_exe_pc_r);
+          else if (fsgnjx_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "fsgnjx", fp_exe_pc_r);
+          else if (fmin_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "fmin", fp_exe_pc_r);
+          else if (fmax_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "fmax", fp_exe_pc_r);
+          else if (fcvt_s_w_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "fcvt_s_w", fp_exe_pc_r);
+          else if (fcvt_s_wu_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "fcvt_s_wu", fp_exe_pc_r);
+          else if (fmv_w_x_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "fmv_w_x", fp_exe_pc_r);
+          else if (fmadd_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "fmadd", fp_exe_pc_r);
+          else if (fmsub_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "fmsub", fp_exe_pc_r);
+          else if (fnmsub_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "fnmsub", fp_exe_pc_r);
+          else if (fnmadd_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "fnmadd", fp_exe_pc_r);
 
-          else if (feq_inc) print_operation_trace(fd2, "feq", exe_pc);
-          else if (flt_inc) print_operation_trace(fd2, "flt", exe_pc);
-          else if (fle_inc) print_operation_trace(fd2, "fle", exe_pc);
-          else if (fcvt_w_s_inc) print_operation_trace(fd2, "fcvt_w_s", exe_pc);
-          else if (fcvt_wu_s_inc) print_operation_trace(fd2, "fcvt_wu_s", exe_pc);
-          else if (fclass_inc) print_operation_trace(fd2, "fclass", exe_pc);
-          else if (fmv_x_w_inc) print_operation_trace(fd2, "fmv_x_w", exe_pc);
+          else if (feq_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "feq", exe_pc);
+          else if (flt_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "flt", exe_pc);
+          else if (fle_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "fle", exe_pc);
+          else if (fcvt_w_s_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "fcvt_w_s", exe_pc);
+          else if (fcvt_wu_s_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "fcvt_wu_s", exe_pc);
+          else if (fclass_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "fclass", exe_pc);
+          else if (fmv_x_w_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "fmv_x_w", exe_pc);
 
-          else if (fdiv_inc) print_operation_trace(fd2, "fdiv", exe_pc);
-          else if (fsqrt_inc) print_operation_trace(fd2, "fsqrt", exe_pc);
+          else if (fdiv_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "fdiv", exe_pc);
+          else if (fsqrt_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "fsqrt", exe_pc);
 
-          else if (local_ld_inc) print_operation_trace(fd2, "local_ld", exe_pc);
-          else if (local_st_inc) print_operation_trace(fd2, "local_st", exe_pc);
-          else if (remote_ld_dram_inc) print_operation_trace(fd2, "remote_ld_dram", exe_pc);
-          else if (remote_ld_global_inc) print_operation_trace(fd2, "remote_ld_global", exe_pc);
-          else if (remote_ld_group_inc) print_operation_trace(fd2, "remote_ld_group", exe_pc);
-          else if (remote_st_dram_inc) print_operation_trace(fd2, "remote_st_dram", exe_pc);
-          else if (remote_st_global_inc) print_operation_trace(fd2, "remote_st_global", exe_pc);
-          else if (remote_st_group_inc) print_operation_trace(fd2, "remote_st_group", exe_pc);
+          else if (local_ld_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "local_ld", exe_pc);
+          else if (local_st_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "local_st", exe_pc);
+          else if (remote_ld_dram_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "remote_ld_dram", exe_pc);
+          else if (remote_ld_global_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "remote_ld_global", exe_pc);
+          else if (remote_ld_group_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "remote_ld_group", exe_pc);
+          else if (remote_st_dram_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "remote_st_dram", exe_pc);
+          else if (remote_st_global_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "remote_st_global", exe_pc);
+          else if (remote_st_group_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "remote_st_group", exe_pc);
 
-          else if (local_flw_inc) print_operation_trace(fd2, "local_flw", exe_pc);
-          else if (local_fsw_inc) print_operation_trace(fd2, "local_fsw", exe_pc);
-          else if (remote_flw_dram_inc) print_operation_trace(fd2, "remote_flw_dram", exe_pc);
-          else if (remote_flw_global_inc) print_operation_trace(fd2, "remote_flw_global", exe_pc);
-          else if (remote_flw_group_inc) print_operation_trace(fd2, "remote_flw_group", exe_pc);
-          else if (remote_fsw_dram_inc) print_operation_trace(fd2, "remote_fsw_dram", exe_pc);
-          else if (remote_fsw_global_inc) print_operation_trace(fd2, "remote_fsw_global", exe_pc);
-          else if (remote_fsw_group_inc) print_operation_trace(fd2, "remote_fsw_group", exe_pc);
+          else if (local_flw_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "local_flw", exe_pc);
+          else if (local_fsw_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "local_fsw", exe_pc);
+          else if (remote_flw_dram_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "remote_flw_dram", exe_pc);
+          else if (remote_flw_global_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "remote_flw_global", exe_pc);
+          else if (remote_flw_group_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "remote_flw_group", exe_pc);
+          else if (remote_fsw_dram_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "remote_fsw_dram", exe_pc);
+          else if (remote_fsw_global_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "remote_fsw_global", exe_pc);
+          else if (remote_fsw_group_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "remote_fsw_group", exe_pc);
 
-          else if (icache_miss_inc) print_operation_trace(fd2, "icache_miss", exe_pc);
-          else if (lr_inc) print_operation_trace(fd2, "lr", exe_pc);
-          else if (lr_aq_inc) print_operation_trace(fd2, "lr_aq", exe_pc);
-          else if (amoswap_inc) print_operation_trace(fd2, "amoswap", exe_pc);
-          else if (amoor_inc) print_operation_trace(fd2, "amoor", exe_pc); 
-          else if (amoadd_inc) print_operation_trace(fd2, "amoadd", exe_pc); 
+          else if (icache_miss_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "icache_miss", exe_pc);
+          else if (lr_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "lr", exe_pc);
+          else if (lr_aq_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "lr_aq", exe_pc);
+          else if (amoswap_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "amoswap", exe_pc);
+          else if (amoor_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "amoor", exe_pc); 
+          else if (amoadd_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "amoadd", exe_pc); 
 
-          else if (beq_inc) print_operation_trace(fd2, "beq", exe_pc);
-          else if (bne_inc) print_operation_trace(fd2, "bne", exe_pc);
-          else if (blt_inc) print_operation_trace(fd2, "blt", exe_pc);
-          else if (bge_inc) print_operation_trace(fd2, "bge", exe_pc);
-          else if (bltu_inc) print_operation_trace(fd2, "bltu", exe_pc);
-          else if (bgeu_inc) print_operation_trace(fd2, "bgeu", exe_pc);
-          else if (jal_inc) print_operation_trace(fd2, "jal", exe_pc);
-          else if (jalr_inc) print_operation_trace(fd2, "jalr", exe_pc);
+          else if (beq_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "beq", exe_pc);
+          else if (bne_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "bne", exe_pc);
+          else if (blt_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "blt", exe_pc);
+          else if (bge_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "bge", exe_pc);
+          else if (bltu_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "bltu", exe_pc);
+          else if (bgeu_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "bgeu", exe_pc);
+          else if (jal_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "jal", exe_pc);
+          else if (jalr_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "jalr", exe_pc);
 
-          else if (beq_miss_inc) print_operation_trace(fd2, "beq_miss", exe_pc);
-          else if (bne_miss_inc) print_operation_trace(fd2, "bne_miss", exe_pc);
-          else if (blt_miss_inc) print_operation_trace(fd2, "blt_miss", exe_pc);
-          else if (bge_miss_inc) print_operation_trace(fd2, "bge_miss", exe_pc);
-          else if (bltu_miss_inc) print_operation_trace(fd2, "bltu_miss", exe_pc);
-          else if (bgeu_miss_inc) print_operation_trace(fd2, "bgeu_miss", exe_pc);
-          else if (jalr_miss_inc) print_operation_trace(fd2, "jalr_miss", exe_pc);
+          else if (beq_miss_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "beq_miss", exe_pc);
+          else if (bne_miss_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "bne_miss", exe_pc);
+          else if (blt_miss_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "blt_miss", exe_pc);
+          else if (bge_miss_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "bge_miss", exe_pc);
+          else if (bltu_miss_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "bltu_miss", exe_pc);
+          else if (bgeu_miss_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "bgeu_miss", exe_pc);
+          else if (jalr_miss_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "jalr_miss", exe_pc);
      
-          else if (sll_inc) print_operation_trace(fd2, "sll", exe_pc); 
-          else if (slli_inc) print_operation_trace(fd2, "slli", exe_pc); 
-          else if (srl_inc) print_operation_trace(fd2, "srl", exe_pc); 
-          else if (srli_inc) print_operation_trace(fd2, "srli", exe_pc); 
-          else if (sra_inc) print_operation_trace(fd2, "sra", exe_pc); 
-          else if (srai_inc) print_operation_trace(fd2, "srai", exe_pc); 
+          else if (sll_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "sll", exe_pc); 
+          else if (slli_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "slli", exe_pc); 
+          else if (srl_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "srl", exe_pc); 
+          else if (srli_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "srli", exe_pc); 
+          else if (sra_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "sra", exe_pc); 
+          else if (srai_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "srai", exe_pc); 
 
-          else if (add_inc) print_operation_trace(fd2, "add", exe_pc);
-          else if (addi_inc) print_operation_trace(fd2, "addi", exe_pc);
-          else if (sub_inc) print_operation_trace(fd2, "sub", exe_pc);
-          else if (lui_inc) print_operation_trace(fd2, "lui", exe_pc);
-          else if (auipc_inc) print_operation_trace(fd2, "auipc", exe_pc);
-          else if (xor_inc) print_operation_trace(fd2, "xor", exe_pc);
-          else if (xori_inc) print_operation_trace(fd2, "xori", exe_pc);
-          else if (or_inc) print_operation_trace(fd2, "or", exe_pc);
-          else if (ori_inc) print_operation_trace(fd2, "ori", exe_pc);
-          else if (and_inc) print_operation_trace(fd2, "and", exe_pc);
-          else if (andi_inc) print_operation_trace(fd2, "andi", exe_pc);
-          else if (slt_inc) print_operation_trace(fd2, "slt", exe_pc);
-          else if (slti_inc) print_operation_trace(fd2, "slti", exe_pc);
-          else if (sltu_inc) print_operation_trace(fd2, "sltu", exe_pc);
-          else if (sltiu_inc) print_operation_trace(fd2, "sltiu", exe_pc);
+          else if (add_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "add", exe_pc);
+          else if (addi_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "addi", exe_pc);
+          else if (sub_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "sub", exe_pc);
+          else if (lui_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "lui", exe_pc);
+          else if (auipc_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "auipc", exe_pc);
+          else if (xor_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "xor", exe_pc);
+          else if (xori_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "xori", exe_pc);
+          else if (or_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "or", exe_pc);
+          else if (ori_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "ori", exe_pc);
+          else if (and_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "and", exe_pc);
+          else if (andi_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "andi", exe_pc);
+          else if (slt_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "slt", exe_pc);
+          else if (slti_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "slti", exe_pc);
+          else if (sltu_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "sltu", exe_pc);
+          else if (sltiu_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "sltiu", exe_pc);
 
-          else if (div_inc) print_operation_trace(fd2, "div", exe_pc);
-          else if (divu_inc) print_operation_trace(fd2, "divu", exe_pc);
-          else if (rem_inc) print_operation_trace(fd2, "rem", exe_pc);
-          else if (remu_inc) print_operation_trace(fd2, "remu", exe_pc);
-          else if (mul_inc) print_operation_trace(fd2, "mul", exe_pc);
+          else if (div_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "div", exe_pc);
+          else if (divu_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "divu", exe_pc);
+          else if (rem_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "rem", exe_pc);
+          else if (remu_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "remu", exe_pc);
+          else if (mul_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "mul", exe_pc);
 
-          else if (fence_inc) print_operation_trace(fd2, "fence", exe_pc);
+          else if (fence_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "fence", exe_pc);
 
-          else if (csrrw_inc) print_operation_trace(fd2, "csrrw", exe_pc);
-          else if (csrrs_inc) print_operation_trace(fd2, "csrrs", exe_pc);
-          else if (csrrc_inc) print_operation_trace(fd2, "csrrc", exe_pc);
-          else if (csrrwi_inc) print_operation_trace(fd2, "csrrwi", exe_pc);
-          else if (csrrsi_inc) print_operation_trace(fd2, "csrrsi", exe_pc);
-          else if (csrrci_inc) print_operation_trace(fd2, "csrrci", exe_pc);
+          else if (csrrw_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "csrrw", exe_pc);
+          else if (csrrs_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "csrrs", exe_pc);
+          else if (csrrc_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "csrrc", exe_pc);
+          else if (csrrwi_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "csrrwi", exe_pc);
+          else if (csrrsi_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "csrrsi", exe_pc);
+          else if (csrrci_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "csrrci", exe_pc);
 
-          else if (barsend_inc) print_operation_trace(fd2, "barsend", exe_pc);
-          else if (barrecv_inc) print_operation_trace(fd2, "barrecv", exe_pc);
+          else if (barsend_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "barsend", exe_pc);
+          else if (barrecv_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "barrecv", exe_pc);
 
           // Traces that can be attributed to stall_all should have higher priority of being printed
           // than stall_id, flush traces.
-          else if (stall_remote_ld_wb) print_operation_trace(fd2, "stall_remote_ld_wb", exe_pc);
-          else if (stall_ifetch_wait) print_operation_trace(fd2, "stall_ifetch_wait", exe_pc);
-          else if (stall_remote_flw_wb) print_operation_trace(fd2, "stall_remote_flw_wb", exe_pc);
+          else if (stall_remote_ld_wb) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "stall_remote_ld_wb", exe_pc);
+          else if (stall_ifetch_wait) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "stall_ifetch_wait", exe_pc);
+          else if (stall_remote_flw_wb) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "stall_remote_flw_wb", exe_pc);
 
           // flush/bubble, stall_id traces
-          else if (branch_miss_bubble_inc) print_operation_trace(fd2, "bubble_branch_miss", exe_bubble_pc_r);
-          else if (jalr_miss_bubble_inc) print_operation_trace(fd2, "bubble_jalr_miss", exe_bubble_pc_r);
-          else if (icache_miss_bubble_inc) print_operation_trace(fd2, "bubble_icache_miss", exe_bubble_pc_r);
-          else if (stall_depend_dram_load_inc) print_operation_trace(fd2, "stall_depend_dram_load", exe_bubble_pc_r);
-          else if (stall_depend_group_load_inc) print_operation_trace(fd2, "stall_depend_group_load", exe_bubble_pc_r);
-          else if (stall_depend_global_load_inc) print_operation_trace(fd2, "stall_depend_global_load", exe_bubble_pc_r);
-          else if (stall_depend_idiv_inc) print_operation_trace(fd2, "stall_depend_idiv", exe_bubble_pc_r);
-          else if (stall_depend_fdiv_inc) print_operation_trace(fd2, "stall_depend_fdiv", exe_bubble_pc_r);
-          else if (stall_depend_local_load_inc) print_operation_trace(fd2, "stall_depend_local_load", exe_bubble_pc_r);
-          else if (stall_depend_imul_inc) print_operation_trace(fd2, "stall_depend_imul", exe_bubble_pc_r);
-          else if (stall_amo_aq_inc) print_operation_trace(fd2, "stall_amo_aq", exe_bubble_pc_r);
-          else if (stall_amo_rl_inc) print_operation_trace(fd2, "stall_amo_rl", exe_bubble_pc_r);
-          else if (stall_bypass_inc) print_operation_trace(fd2, "stall_bypass", exe_bubble_pc_r);
-          else if (stall_lr_aq_inc) print_operation_trace(fd2, "stall_lr_aq", exe_bubble_pc_r);
-          else if (stall_fence_inc) print_operation_trace(fd2, "stall_fence", exe_bubble_pc_r);
-          else if (stall_remote_req_inc) print_operation_trace(fd2, "stall_remote_req", exe_bubble_pc_r);
-          else if (stall_remote_credit_inc) print_operation_trace(fd2, "stall_remote_credit", exe_bubble_pc_r);
-          else if (stall_fdiv_busy_inc) print_operation_trace(fd2, "stall_fdiv_busy", exe_bubble_pc_r);
-          else if (stall_idiv_busy_inc) print_operation_trace(fd2, "stall_idiv_busy", exe_bubble_pc_r);
-          else if (stall_fcsr_inc) print_operation_trace(fd2, "stall_fcsr", exe_bubble_pc_r);
-          else if (stall_barrier_inc) print_operation_trace(fd2, "stall_barrier", exe_bubble_pc_r);
-          else print_operation_trace(fd2, "unknown", 0);
+          else if (branch_miss_bubble_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "bubble_branch_miss", exe_bubble_pc_r);
+          else if (jalr_miss_bubble_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "bubble_jalr_miss", exe_bubble_pc_r);
+          else if (icache_miss_bubble_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "bubble_icache_miss", exe_bubble_pc_r);
+          else if (stall_depend_dram_load_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "stall_depend_dram_load", exe_bubble_pc_r);
+          else if (stall_depend_group_load_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "stall_depend_group_load", exe_bubble_pc_r);
+          else if (stall_depend_global_load_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "stall_depend_global_load", exe_bubble_pc_r);
+          else if (stall_depend_idiv_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "stall_depend_idiv", exe_bubble_pc_r);
+          else if (stall_depend_fdiv_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "stall_depend_fdiv", exe_bubble_pc_r);
+          else if (stall_depend_local_load_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "stall_depend_local_load", exe_bubble_pc_r);
+          else if (stall_depend_imul_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "stall_depend_imul", exe_bubble_pc_r);
+          else if (stall_amo_aq_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "stall_amo_aq", exe_bubble_pc_r);
+          else if (stall_amo_rl_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "stall_amo_rl", exe_bubble_pc_r);
+          else if (stall_bypass_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "stall_bypass", exe_bubble_pc_r);
+          else if (stall_lr_aq_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "stall_lr_aq", exe_bubble_pc_r);
+          else if (stall_fence_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "stall_fence", exe_bubble_pc_r);
+          else if (stall_remote_req_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "stall_remote_req", exe_bubble_pc_r);
+          else if (stall_remote_credit_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "stall_remote_credit", exe_bubble_pc_r);
+          else if (stall_fdiv_busy_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "stall_fdiv_busy", exe_bubble_pc_r);
+          else if (stall_idiv_busy_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "stall_idiv_busy", exe_bubble_pc_r);
+          else if (stall_fcsr_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "stall_fcsr", exe_bubble_pc_r);
+          else if (stall_barrier_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "stall_barrier", exe_bubble_pc_r);
+          else print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "unknown", 0);
 
-          $fclose(fd2);
         end
    end // always @ (negedge clk_i)
 

--- a/testbenches/common/v/vanilla_core_profiler.v
+++ b/testbenches/common/v/vanilla_core_profiler.v
@@ -103,7 +103,8 @@ module vanilla_core_profiler
   assign print_stat_tag = print_stat_tag_i;
 
   // task to print a line of operation trace
-  task print_operation_trace(integer fd, string op, logic [data_width_p-1:0] pc);
+  task print_operation_trace(string op, logic [data_width_p-1:0] pc);
+    integer fd = $root.`HOST_MODULE_PATH.vanilla_trace_fd;    
     $fwrite(fd, "%0d,%0d,%0d,%0h,%s\n", global_ctr_i, global_x_i - origin_x_cord_p, global_y_i - origin_y_cord_p, pc, op);
   endtask
 
@@ -1239,145 +1240,145 @@ module vanilla_core_profiler
         // trace logging
         if (~reset_i & trace_en_i) begin
              
-          if (fadd_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "fadd", fp_exe_pc_r);
-          else if (fsub_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "fsub", fp_exe_pc_r);
-          else if (fmul_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "fmul", fp_exe_pc_r);
-          else if (fsgnj_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "fsgnj", fp_exe_pc_r);
-          else if (fsgnjn_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "fsgnjn", fp_exe_pc_r);
-          else if (fsgnjx_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "fsgnjx", fp_exe_pc_r);
-          else if (fmin_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "fmin", fp_exe_pc_r);
-          else if (fmax_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "fmax", fp_exe_pc_r);
-          else if (fcvt_s_w_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "fcvt_s_w", fp_exe_pc_r);
-          else if (fcvt_s_wu_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "fcvt_s_wu", fp_exe_pc_r);
-          else if (fmv_w_x_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "fmv_w_x", fp_exe_pc_r);
-          else if (fmadd_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "fmadd", fp_exe_pc_r);
-          else if (fmsub_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "fmsub", fp_exe_pc_r);
-          else if (fnmsub_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "fnmsub", fp_exe_pc_r);
-          else if (fnmadd_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "fnmadd", fp_exe_pc_r);
+          if (fadd_inc) print_operation_trace("fadd", fp_exe_pc_r);
+          else if (fsub_inc) print_operation_trace("fsub", fp_exe_pc_r);
+          else if (fmul_inc) print_operation_trace("fmul", fp_exe_pc_r);
+          else if (fsgnj_inc) print_operation_trace("fsgnj", fp_exe_pc_r);
+          else if (fsgnjn_inc) print_operation_trace("fsgnjn", fp_exe_pc_r);
+          else if (fsgnjx_inc) print_operation_trace("fsgnjx", fp_exe_pc_r);
+          else if (fmin_inc) print_operation_trace("fmin", fp_exe_pc_r);
+          else if (fmax_inc) print_operation_trace("fmax", fp_exe_pc_r);
+          else if (fcvt_s_w_inc) print_operation_trace("fcvt_s_w", fp_exe_pc_r);
+          else if (fcvt_s_wu_inc) print_operation_trace("fcvt_s_wu", fp_exe_pc_r);
+          else if (fmv_w_x_inc) print_operation_trace("fmv_w_x", fp_exe_pc_r);
+          else if (fmadd_inc) print_operation_trace("fmadd", fp_exe_pc_r);
+          else if (fmsub_inc) print_operation_trace("fmsub", fp_exe_pc_r);
+          else if (fnmsub_inc) print_operation_trace("fnmsub", fp_exe_pc_r);
+          else if (fnmadd_inc) print_operation_trace("fnmadd", fp_exe_pc_r);
 
-          else if (feq_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "feq", exe_pc);
-          else if (flt_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "flt", exe_pc);
-          else if (fle_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "fle", exe_pc);
-          else if (fcvt_w_s_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "fcvt_w_s", exe_pc);
-          else if (fcvt_wu_s_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "fcvt_wu_s", exe_pc);
-          else if (fclass_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "fclass", exe_pc);
-          else if (fmv_x_w_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "fmv_x_w", exe_pc);
+          else if (feq_inc) print_operation_trace("feq", exe_pc);
+          else if (flt_inc) print_operation_trace("flt", exe_pc);
+          else if (fle_inc) print_operation_trace("fle", exe_pc);
+          else if (fcvt_w_s_inc) print_operation_trace("fcvt_w_s", exe_pc);
+          else if (fcvt_wu_s_inc) print_operation_trace("fcvt_wu_s", exe_pc);
+          else if (fclass_inc) print_operation_trace("fclass", exe_pc);
+          else if (fmv_x_w_inc) print_operation_trace("fmv_x_w", exe_pc);
 
-          else if (fdiv_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "fdiv", exe_pc);
-          else if (fsqrt_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "fsqrt", exe_pc);
+          else if (fdiv_inc) print_operation_trace("fdiv", exe_pc);
+          else if (fsqrt_inc) print_operation_trace("fsqrt", exe_pc);
 
-          else if (local_ld_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "local_ld", exe_pc);
-          else if (local_st_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "local_st", exe_pc);
-          else if (remote_ld_dram_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "remote_ld_dram", exe_pc);
-          else if (remote_ld_global_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "remote_ld_global", exe_pc);
-          else if (remote_ld_group_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "remote_ld_group", exe_pc);
-          else if (remote_st_dram_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "remote_st_dram", exe_pc);
-          else if (remote_st_global_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "remote_st_global", exe_pc);
-          else if (remote_st_group_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "remote_st_group", exe_pc);
+          else if (local_ld_inc) print_operation_trace("local_ld", exe_pc);
+          else if (local_st_inc) print_operation_trace("local_st", exe_pc);
+          else if (remote_ld_dram_inc) print_operation_trace("remote_ld_dram", exe_pc);
+          else if (remote_ld_global_inc) print_operation_trace("remote_ld_global", exe_pc);
+          else if (remote_ld_group_inc) print_operation_trace("remote_ld_group", exe_pc);
+          else if (remote_st_dram_inc) print_operation_trace("remote_st_dram", exe_pc);
+          else if (remote_st_global_inc) print_operation_trace("remote_st_global", exe_pc);
+          else if (remote_st_group_inc) print_operation_trace("remote_st_group", exe_pc);
 
-          else if (local_flw_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "local_flw", exe_pc);
-          else if (local_fsw_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "local_fsw", exe_pc);
-          else if (remote_flw_dram_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "remote_flw_dram", exe_pc);
-          else if (remote_flw_global_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "remote_flw_global", exe_pc);
-          else if (remote_flw_group_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "remote_flw_group", exe_pc);
-          else if (remote_fsw_dram_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "remote_fsw_dram", exe_pc);
-          else if (remote_fsw_global_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "remote_fsw_global", exe_pc);
-          else if (remote_fsw_group_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "remote_fsw_group", exe_pc);
+          else if (local_flw_inc) print_operation_trace("local_flw", exe_pc);
+          else if (local_fsw_inc) print_operation_trace("local_fsw", exe_pc);
+          else if (remote_flw_dram_inc) print_operation_trace("remote_flw_dram", exe_pc);
+          else if (remote_flw_global_inc) print_operation_trace("remote_flw_global", exe_pc);
+          else if (remote_flw_group_inc) print_operation_trace("remote_flw_group", exe_pc);
+          else if (remote_fsw_dram_inc) print_operation_trace("remote_fsw_dram", exe_pc);
+          else if (remote_fsw_global_inc) print_operation_trace("remote_fsw_global", exe_pc);
+          else if (remote_fsw_group_inc) print_operation_trace("remote_fsw_group", exe_pc);
 
-          else if (icache_miss_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "icache_miss", exe_pc);
-          else if (lr_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "lr", exe_pc);
-          else if (lr_aq_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "lr_aq", exe_pc);
-          else if (amoswap_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "amoswap", exe_pc);
-          else if (amoor_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "amoor", exe_pc); 
-          else if (amoadd_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "amoadd", exe_pc); 
+          else if (icache_miss_inc) print_operation_trace("icache_miss", exe_pc);
+          else if (lr_inc) print_operation_trace("lr", exe_pc);
+          else if (lr_aq_inc) print_operation_trace("lr_aq", exe_pc);
+          else if (amoswap_inc) print_operation_trace("amoswap", exe_pc);
+          else if (amoor_inc) print_operation_trace("amoor", exe_pc); 
+          else if (amoadd_inc) print_operation_trace("amoadd", exe_pc); 
 
-          else if (beq_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "beq", exe_pc);
-          else if (bne_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "bne", exe_pc);
-          else if (blt_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "blt", exe_pc);
-          else if (bge_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "bge", exe_pc);
-          else if (bltu_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "bltu", exe_pc);
-          else if (bgeu_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "bgeu", exe_pc);
-          else if (jal_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "jal", exe_pc);
-          else if (jalr_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "jalr", exe_pc);
+          else if (beq_inc) print_operation_trace("beq", exe_pc);
+          else if (bne_inc) print_operation_trace("bne", exe_pc);
+          else if (blt_inc) print_operation_trace("blt", exe_pc);
+          else if (bge_inc) print_operation_trace("bge", exe_pc);
+          else if (bltu_inc) print_operation_trace("bltu", exe_pc);
+          else if (bgeu_inc) print_operation_trace("bgeu", exe_pc);
+          else if (jal_inc) print_operation_trace("jal", exe_pc);
+          else if (jalr_inc) print_operation_trace("jalr", exe_pc);
 
-          else if (beq_miss_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "beq_miss", exe_pc);
-          else if (bne_miss_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "bne_miss", exe_pc);
-          else if (blt_miss_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "blt_miss", exe_pc);
-          else if (bge_miss_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "bge_miss", exe_pc);
-          else if (bltu_miss_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "bltu_miss", exe_pc);
-          else if (bgeu_miss_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "bgeu_miss", exe_pc);
-          else if (jalr_miss_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "jalr_miss", exe_pc);
+          else if (beq_miss_inc) print_operation_trace("beq_miss", exe_pc);
+          else if (bne_miss_inc) print_operation_trace("bne_miss", exe_pc);
+          else if (blt_miss_inc) print_operation_trace("blt_miss", exe_pc);
+          else if (bge_miss_inc) print_operation_trace("bge_miss", exe_pc);
+          else if (bltu_miss_inc) print_operation_trace("bltu_miss", exe_pc);
+          else if (bgeu_miss_inc) print_operation_trace("bgeu_miss", exe_pc);
+          else if (jalr_miss_inc) print_operation_trace("jalr_miss", exe_pc);
      
-          else if (sll_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "sll", exe_pc); 
-          else if (slli_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "slli", exe_pc); 
-          else if (srl_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "srl", exe_pc); 
-          else if (srli_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "srli", exe_pc); 
-          else if (sra_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "sra", exe_pc); 
-          else if (srai_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "srai", exe_pc); 
+          else if (sll_inc) print_operation_trace("sll", exe_pc); 
+          else if (slli_inc) print_operation_trace("slli", exe_pc); 
+          else if (srl_inc) print_operation_trace("srl", exe_pc); 
+          else if (srli_inc) print_operation_trace("srli", exe_pc); 
+          else if (sra_inc) print_operation_trace("sra", exe_pc); 
+          else if (srai_inc) print_operation_trace("srai", exe_pc); 
 
-          else if (add_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "add", exe_pc);
-          else if (addi_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "addi", exe_pc);
-          else if (sub_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "sub", exe_pc);
-          else if (lui_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "lui", exe_pc);
-          else if (auipc_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "auipc", exe_pc);
-          else if (xor_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "xor", exe_pc);
-          else if (xori_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "xori", exe_pc);
-          else if (or_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "or", exe_pc);
-          else if (ori_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "ori", exe_pc);
-          else if (and_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "and", exe_pc);
-          else if (andi_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "andi", exe_pc);
-          else if (slt_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "slt", exe_pc);
-          else if (slti_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "slti", exe_pc);
-          else if (sltu_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "sltu", exe_pc);
-          else if (sltiu_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "sltiu", exe_pc);
+          else if (add_inc) print_operation_trace("add", exe_pc);
+          else if (addi_inc) print_operation_trace("addi", exe_pc);
+          else if (sub_inc) print_operation_trace("sub", exe_pc);
+          else if (lui_inc) print_operation_trace("lui", exe_pc);
+          else if (auipc_inc) print_operation_trace("auipc", exe_pc);
+          else if (xor_inc) print_operation_trace("xor", exe_pc);
+          else if (xori_inc) print_operation_trace("xori", exe_pc);
+          else if (or_inc) print_operation_trace("or", exe_pc);
+          else if (ori_inc) print_operation_trace("ori", exe_pc);
+          else if (and_inc) print_operation_trace("and", exe_pc);
+          else if (andi_inc) print_operation_trace("andi", exe_pc);
+          else if (slt_inc) print_operation_trace("slt", exe_pc);
+          else if (slti_inc) print_operation_trace("slti", exe_pc);
+          else if (sltu_inc) print_operation_trace("sltu", exe_pc);
+          else if (sltiu_inc) print_operation_trace("sltiu", exe_pc);
 
-          else if (div_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "div", exe_pc);
-          else if (divu_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "divu", exe_pc);
-          else if (rem_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "rem", exe_pc);
-          else if (remu_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "remu", exe_pc);
-          else if (mul_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "mul", exe_pc);
+          else if (div_inc) print_operation_trace("div", exe_pc);
+          else if (divu_inc) print_operation_trace("divu", exe_pc);
+          else if (rem_inc) print_operation_trace("rem", exe_pc);
+          else if (remu_inc) print_operation_trace("remu", exe_pc);
+          else if (mul_inc) print_operation_trace("mul", exe_pc);
 
-          else if (fence_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "fence", exe_pc);
+          else if (fence_inc) print_operation_trace("fence", exe_pc);
 
-          else if (csrrw_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "csrrw", exe_pc);
-          else if (csrrs_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "csrrs", exe_pc);
-          else if (csrrc_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "csrrc", exe_pc);
-          else if (csrrwi_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "csrrwi", exe_pc);
-          else if (csrrsi_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "csrrsi", exe_pc);
-          else if (csrrci_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "csrrci", exe_pc);
+          else if (csrrw_inc) print_operation_trace("csrrw", exe_pc);
+          else if (csrrs_inc) print_operation_trace("csrrs", exe_pc);
+          else if (csrrc_inc) print_operation_trace("csrrc", exe_pc);
+          else if (csrrwi_inc) print_operation_trace("csrrwi", exe_pc);
+          else if (csrrsi_inc) print_operation_trace("csrrsi", exe_pc);
+          else if (csrrci_inc) print_operation_trace("csrrci", exe_pc);
 
-          else if (barsend_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "barsend", exe_pc);
-          else if (barrecv_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "barrecv", exe_pc);
+          else if (barsend_inc) print_operation_trace("barsend", exe_pc);
+          else if (barrecv_inc) print_operation_trace("barrecv", exe_pc);
 
           // Traces that can be attributed to stall_all should have higher priority of being printed
           // than stall_id, flush traces.
-          else if (stall_remote_ld_wb) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "stall_remote_ld_wb", exe_pc);
-          else if (stall_ifetch_wait) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "stall_ifetch_wait", exe_pc);
-          else if (stall_remote_flw_wb) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "stall_remote_flw_wb", exe_pc);
+          else if (stall_remote_ld_wb) print_operation_trace("stall_remote_ld_wb", exe_pc);
+          else if (stall_ifetch_wait) print_operation_trace("stall_ifetch_wait", exe_pc);
+          else if (stall_remote_flw_wb) print_operation_trace("stall_remote_flw_wb", exe_pc);
 
           // flush/bubble, stall_id traces
-          else if (branch_miss_bubble_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "bubble_branch_miss", exe_bubble_pc_r);
-          else if (jalr_miss_bubble_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "bubble_jalr_miss", exe_bubble_pc_r);
-          else if (icache_miss_bubble_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "bubble_icache_miss", exe_bubble_pc_r);
-          else if (stall_depend_dram_load_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "stall_depend_dram_load", exe_bubble_pc_r);
-          else if (stall_depend_group_load_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "stall_depend_group_load", exe_bubble_pc_r);
-          else if (stall_depend_global_load_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "stall_depend_global_load", exe_bubble_pc_r);
-          else if (stall_depend_idiv_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "stall_depend_idiv", exe_bubble_pc_r);
-          else if (stall_depend_fdiv_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "stall_depend_fdiv", exe_bubble_pc_r);
-          else if (stall_depend_local_load_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "stall_depend_local_load", exe_bubble_pc_r);
-          else if (stall_depend_imul_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "stall_depend_imul", exe_bubble_pc_r);
-          else if (stall_amo_aq_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "stall_amo_aq", exe_bubble_pc_r);
-          else if (stall_amo_rl_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "stall_amo_rl", exe_bubble_pc_r);
-          else if (stall_bypass_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "stall_bypass", exe_bubble_pc_r);
-          else if (stall_lr_aq_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "stall_lr_aq", exe_bubble_pc_r);
-          else if (stall_fence_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "stall_fence", exe_bubble_pc_r);
-          else if (stall_remote_req_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "stall_remote_req", exe_bubble_pc_r);
-          else if (stall_remote_credit_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "stall_remote_credit", exe_bubble_pc_r);
-          else if (stall_fdiv_busy_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "stall_fdiv_busy", exe_bubble_pc_r);
-          else if (stall_idiv_busy_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "stall_idiv_busy", exe_bubble_pc_r);
-          else if (stall_fcsr_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "stall_fcsr", exe_bubble_pc_r);
-          else if (stall_barrier_inc) print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "stall_barrier", exe_bubble_pc_r);
-          else print_operation_trace($root.`HOST_MODULE_PATH.vanilla_trace_fd, "unknown", 0);
+          else if (branch_miss_bubble_inc) print_operation_trace("bubble_branch_miss", exe_bubble_pc_r);
+          else if (jalr_miss_bubble_inc) print_operation_trace("bubble_jalr_miss", exe_bubble_pc_r);
+          else if (icache_miss_bubble_inc) print_operation_trace("bubble_icache_miss", exe_bubble_pc_r);
+          else if (stall_depend_dram_load_inc) print_operation_trace("stall_depend_dram_load", exe_bubble_pc_r);
+          else if (stall_depend_group_load_inc) print_operation_trace("stall_depend_group_load", exe_bubble_pc_r);
+          else if (stall_depend_global_load_inc) print_operation_trace("stall_depend_global_load", exe_bubble_pc_r);
+          else if (stall_depend_idiv_inc) print_operation_trace("stall_depend_idiv", exe_bubble_pc_r);
+          else if (stall_depend_fdiv_inc) print_operation_trace("stall_depend_fdiv", exe_bubble_pc_r);
+          else if (stall_depend_local_load_inc) print_operation_trace("stall_depend_local_load", exe_bubble_pc_r);
+          else if (stall_depend_imul_inc) print_operation_trace("stall_depend_imul", exe_bubble_pc_r);
+          else if (stall_amo_aq_inc) print_operation_trace("stall_amo_aq", exe_bubble_pc_r);
+          else if (stall_amo_rl_inc) print_operation_trace("stall_amo_rl", exe_bubble_pc_r);
+          else if (stall_bypass_inc) print_operation_trace("stall_bypass", exe_bubble_pc_r);
+          else if (stall_lr_aq_inc) print_operation_trace("stall_lr_aq", exe_bubble_pc_r);
+          else if (stall_fence_inc) print_operation_trace("stall_fence", exe_bubble_pc_r);
+          else if (stall_remote_req_inc) print_operation_trace("stall_remote_req", exe_bubble_pc_r);
+          else if (stall_remote_credit_inc) print_operation_trace("stall_remote_credit", exe_bubble_pc_r);
+          else if (stall_fdiv_busy_inc) print_operation_trace("stall_fdiv_busy", exe_bubble_pc_r);
+          else if (stall_idiv_busy_inc) print_operation_trace("stall_idiv_busy", exe_bubble_pc_r);
+          else if (stall_fcsr_inc) print_operation_trace("stall_fcsr", exe_bubble_pc_r);
+          else if (stall_barrier_inc) print_operation_trace("stall_barrier", exe_bubble_pc_r);
+          else print_operation_trace("unknown", 0);
 
         end
    end // always @ (negedge clk_i)

--- a/testbenches/common/v/vanilla_core_profiler.v
+++ b/testbenches/common/v/vanilla_core_profiler.v
@@ -13,6 +13,7 @@
 
 `include "bsg_manycore_defines.vh"
 `include "bsg_vanilla_defines.vh"
+`include "profiler.vh"
 
 module vanilla_core_profiler
   import bsg_manycore_pkg::*;
@@ -102,35 +103,10 @@ module vanilla_core_profiler
   bsg_manycore_vanilla_core_stat_tag_s print_stat_tag;
   assign print_stat_tag = print_stat_tag_i;
 
-  import "DPI-C" context function
-    void bsg_vanilla_core_profiler_init(int tracer_fd);
-
-  import "DPI-C" context function
-    void bsg_vanilla_core_profiler_exit();
-
-  import "DPI-C" context function
-    int bsg_vanilla_core_profiler_is_init();
-
-  import "DPI-C" context function
-    int bsg_vanilla_core_profiler_is_exit();
-
-  import "DPI-C" context function
-    int  bsg_vanilla_core_profiler_trace_fd();
-
-  initial begin
-    if (bsg_vanilla_core_profiler_is_init() == 0) begin
-      int trace_fd = $fopen("vanilla_operation_trace.csv", "w");
-      bsg_vanilla_core_profiler_init(trace_fd);
-      $fwrite(trace_fd, "cycle,x,y,pc,operation\n");
-    end
-  end
-
-  final begin
-    if (bsg_vanilla_core_profiler_is_exit()) begin
-      $fclose(bsg_vanilla_core_profiler_trace_fd());
-      bsg_vanilla_core_profiler_exit();
-    end
-  end
+  `DEFINE_PROFILER(bsg_vanilla_core_profiler
+                   , "vanilla_operation_trace.csv"
+                   , "cycle,x,y,pc,operation\n"
+                   )
 
   // task to print a line of operation trace
   task print_operation_trace(string op, logic [data_width_p-1:0] pc);

--- a/testbenches/common/v/vanilla_core_profiler.v
+++ b/testbenches/common/v/vanilla_core_profiler.v
@@ -102,10 +102,40 @@ module vanilla_core_profiler
   bsg_manycore_vanilla_core_stat_tag_s print_stat_tag;
   assign print_stat_tag = print_stat_tag_i;
 
+  import "DPI-C" context function
+    void bsg_vanilla_core_profiler_init(int tracer_fd);
+
+  import "DPI-C" context function
+    void bsg_vanilla_core_profiler_exit();
+
+  import "DPI-C" context function
+    int bsg_vanilla_core_profiler_is_init();
+
+  import "DPI-C" context function
+    int bsg_vanilla_core_profiler_is_exit();
+
+  import "DPI-C" context function
+    int  bsg_vanilla_core_profiler_trace_fd();
+
+  initial begin
+    if (bsg_vanilla_core_profiler_is_init() == 0) begin
+      int trace_fd = $fopen("vanilla_operation_trace.csv", "w");
+      bsg_vanilla_core_profiler_init(trace_fd);
+      $fwrite(trace_fd, "cycle,x,y,pc,operation\n");
+    end
+  end
+
+  final begin
+    if (bsg_vanilla_core_profiler_is_exit()) begin
+      $fclose(bsg_vanilla_core_profiler_trace_fd());
+      bsg_vanilla_core_profiler_exit();
+    end
+  end
+
   // task to print a line of operation trace
   task print_operation_trace(string op, logic [data_width_p-1:0] pc);
     $fwrite
-      ($root.`HOST_MODULE_PATH.vanilla_trace_fd
+      (bsg_vanilla_core_profiler_trace_fd()
        , "%0d,%0d,%0d,%0h,%s\n"
        , global_ctr_i
        , global_x_i - origin_x_cord_p

--- a/testbenches/common/v/vcache_profiler.cpp
+++ b/testbenches/common/v/vcache_profiler.cpp
@@ -1,0 +1,5 @@
+#include "profiler.hpp"
+
+bsg_profiler::profiler *bsg_vcache_profiler = nullptr;
+
+DEFINE_PROFILER(bsg_vcache_profiler);

--- a/testbenches/common/v/vcache_profiler.cpp
+++ b/testbenches/common/v/vcache_profiler.cpp
@@ -1,5 +1,5 @@
 #include "profiler.hpp"
 
-bsg_profiler::profiler *bsg_vcache_profiler = nullptr;
+bsg_profiler::profiler bsg_vcache_profiler;
 
 DEFINE_PROFILER(bsg_vcache_profiler);

--- a/testbenches/common/v/vcache_profiler.v
+++ b/testbenches/common/v/vcache_profiler.v
@@ -5,6 +5,7 @@
 
 `include "bsg_defines.v"
 `include "bsg_cache.vh"
+`include "profiler.vh"
 
 module vcache_profiler
   import bsg_cache_pkg::*;
@@ -47,31 +48,10 @@ module vcache_profiler
     , input trace_en_i // from toplevel testbench
   );
 
-  import "DPI-C" context function
-    void bsg_vcache_profiler_init(int trace_fd);
-  import "DPI-C" context function
-    int bsg_vcache_profiler_is_init();
-  import "DPI-C" context function
-    int bsg_vcache_profiler_is_exit();
-  import "DPI-C" context function
-    void bsg_vcache_profiler_exit();
-  import "DPI-C" context function
-    int bsg_vcache_profiler_trace_fd();
-
-  initial begin
-    if (bsg_vcache_profiler_is_init() == 0) begin
-      int trace_fd = $fopen("vcache_operation_trace.csv", "w");
-      $fwrite(trace_fd, "cycle,vcache,operation\n");
-      bsg_vcache_profiler_init(trace_fd);
-    end
-  end
-
-  final begin
-    if (bsg_vcache_profiler_is_exit() == 0) begin
-      $fclose(bsg_vcache_profiler_trace_fd());
-      bsg_vcache_profiler_exit();
-    end
-  end
+  `DEFINE_PROFILER(bsg_vcache_profiler
+                   ,"vcache_operation_trace.csv"
+                   ,"cycle,vcache,operation\n"
+                   )
 
   // task to print a line of operation trace
   task print_operation_trace(string vcache_name, string op);

--- a/testbenches/common/v/vcache_profiler.v
+++ b/testbenches/common/v/vcache_profiler.v
@@ -336,19 +336,17 @@ module vcache_profiler
 
 
         if (~reset_i & trace_en_i) begin
-          trace_fd = $fopen(tracefile_lp, "a");
-
           // If miss handler has finished the dma request and result is ready
           // for a missed request
           if (inc_miss_ld)
-            print_operation_trace(trace_fd, my_name, "miss_ld");
+            print_operation_trace($root.`HOST_MODULE_PATH.vcache_trace_fd, my_name, "miss_ld");
           else if (inc_miss_st)
-            print_operation_trace(trace_fd, my_name, "miss_st");
+            print_operation_trace($root.`HOST_MODULE_PATH.vcache_trace_fd, my_name, "miss_st");
 
 
           // If miss handler is still busy on a request
           else if (miss_v) begin
-            print_operation_trace(trace_fd, my_name, "miss");
+            print_operation_trace($root.`HOST_MODULE_PATH.vcache_trace_fd, my_name, "miss");
           end 
 
         
@@ -357,74 +355,73 @@ module vcache_profiler
 
             if (inc_ld) begin
               if (inc_ld_ld) 
-                print_operation_trace(trace_fd, my_name, "ld_ld");
+                print_operation_trace($root.`HOST_MODULE_PATH.vcache_trace_fd, my_name, "ld_ld");
               else if (inc_ld_ldu)
-                print_operation_trace(trace_fd, my_name, "ld_ldu");
+                print_operation_trace($root.`HOST_MODULE_PATH.vcache_trace_fd, my_name, "ld_ldu");
               else if (inc_ld_lw)
-                print_operation_trace(trace_fd, my_name, "ld_lw");
+                print_operation_trace($root.`HOST_MODULE_PATH.vcache_trace_fd, my_name, "ld_lw");
               else if (inc_ld_lwu)
-                print_operation_trace(trace_fd, my_name, "ld_lwu");
+                print_operation_trace($root.`HOST_MODULE_PATH.vcache_trace_fd, my_name, "ld_lwu");
               else if (inc_ld_lh)
-                print_operation_trace(trace_fd, my_name, "ld_lh");
+                print_operation_trace($root.`HOST_MODULE_PATH.vcache_trace_fd, my_name, "ld_lh");
               else if (inc_ld_lhu)
-                print_operation_trace(trace_fd, my_name, "ld_lhu");
+                print_operation_trace($root.`HOST_MODULE_PATH.vcache_trace_fd, my_name, "ld_lhu");
               else if (inc_ld_lb) 
-                print_operation_trace(trace_fd, my_name, "ld_lb");
+                print_operation_trace($root.`HOST_MODULE_PATH.vcache_trace_fd, my_name, "ld_lb");
               else if (inc_ld_lbu)
-                print_operation_trace(trace_fd, my_name, "ld_lbu");
+                print_operation_trace($root.`HOST_MODULE_PATH.vcache_trace_fd, my_name, "ld_lbu");
               else
-                print_operation_trace(trace_fd, my_name, "ld");
+                print_operation_trace($root.`HOST_MODULE_PATH.vcache_trace_fd, my_name, "ld");
             end
 
 
             else if (inc_st) begin
               if (inc_sm_sd)
-                print_operation_trace(trace_fd, my_name, "sm_sd");  
+                print_operation_trace($root.`HOST_MODULE_PATH.vcache_trace_fd, my_name, "sm_sd");  
               else if (inc_sm_sw)
-                print_operation_trace(trace_fd, my_name, "sm_sw");  
+                print_operation_trace($root.`HOST_MODULE_PATH.vcache_trace_fd, my_name, "sm_sw");  
               else if (inc_sm_sh)
-                print_operation_trace(trace_fd, my_name, "sm_sh");  
+                print_operation_trace($root.`HOST_MODULE_PATH.vcache_trace_fd, my_name, "sm_sh");  
               else if (inc_sm_sb)
-                print_operation_trace(trace_fd, my_name, "sm_sb");  
+                print_operation_trace($root.`HOST_MODULE_PATH.vcache_trace_fd, my_name, "sm_sb");  
               else
-                print_operation_trace(trace_fd, my_name, "st");
+                print_operation_trace($root.`HOST_MODULE_PATH.vcache_trace_fd, my_name, "st");
             end
 
 
             else if (inc_stall_rsp)
-              print_operation_trace(trace_fd, my_name, "stall_rsp");
+              print_operation_trace($root.`HOST_MODULE_PATH.vcache_trace_fd, my_name, "stall_rsp");
 
             else if (inc_tagst)
-              print_operation_trace(trace_fd, my_name, "tagst");
+              print_operation_trace($root.`HOST_MODULE_PATH.vcache_trace_fd, my_name, "tagst");
             else if (inc_tagfl)
-              print_operation_trace(trace_fd, my_name, "tagfl");
+              print_operation_trace($root.`HOST_MODULE_PATH.vcache_trace_fd, my_name, "tagfl");
             else if (inc_taglv)
-              print_operation_trace(trace_fd, my_name, "taglv");
+              print_operation_trace($root.`HOST_MODULE_PATH.vcache_trace_fd, my_name, "taglv");
             else if (inc_tagla)
-              print_operation_trace(trace_fd, my_name, "tagla");
+              print_operation_trace($root.`HOST_MODULE_PATH.vcache_trace_fd, my_name, "tagla");
             else if (inc_afl)
-              print_operation_trace(trace_fd, my_name, "afl");
+              print_operation_trace($root.`HOST_MODULE_PATH.vcache_trace_fd, my_name, "afl");
             else if (inc_aflinv)
-              print_operation_trace(trace_fd, my_name, "aflinv");
+              print_operation_trace($root.`HOST_MODULE_PATH.vcache_trace_fd, my_name, "aflinv");
             else if (inc_ainv)
-              print_operation_trace(trace_fd, my_name, "ainv");
+              print_operation_trace($root.`HOST_MODULE_PATH.vcache_trace_fd, my_name, "ainv");
             else if (inc_alock)
-              print_operation_trace(trace_fd, my_name, "alock");
+              print_operation_trace($root.`HOST_MODULE_PATH.vcache_trace_fd, my_name, "alock");
             else if (inc_aunlock)
-              print_operation_trace(trace_fd, my_name, "aunlock");
+              print_operation_trace($root.`HOST_MODULE_PATH.vcache_trace_fd, my_name, "aunlock");
             else if (inc_atomic)
-              print_operation_trace(trace_fd, my_name, "atomic");
+              print_operation_trace($root.`HOST_MODULE_PATH.vcache_trace_fd, my_name, "atomic");
             else if (inc_amoswap)
-              print_operation_trace(trace_fd, my_name, "amoswap");
+              print_operation_trace($root.`HOST_MODULE_PATH.vcache_trace_fd, my_name, "amoswap");
             else if (inc_amoor)
-              print_operation_trace(trace_fd, my_name, "amoor");
+              print_operation_trace($root.`HOST_MODULE_PATH.vcache_trace_fd, my_name, "amoor");
             else if (inc_amoadd)
-              print_operation_trace(trace_fd, my_name, "amoadd");
+              print_operation_trace($root.`HOST_MODULE_PATH.vcache_trace_fd, my_name, "amoadd");
             else
-              print_operation_trace(trace_fd, my_name, "idle");
+              print_operation_trace($root.`HOST_MODULE_PATH.vcache_trace_fd, my_name, "idle");
           end
 
-          $fclose(trace_fd);
         end // if (~reset_i & trace_en_i)
     end // always @ (negedge clk_i)
 

--- a/testbenches/common/v/vcache_profiler.v
+++ b/testbenches/common/v/vcache_profiler.v
@@ -47,10 +47,35 @@ module vcache_profiler
     , input trace_en_i // from toplevel testbench
   );
 
+  import "DPI-C" context function
+    void bsg_vcache_profiler_init(int trace_fd);
+  import "DPI-C" context function
+    int bsg_vcache_profiler_is_init();
+  import "DPI-C" context function
+    int bsg_vcache_profiler_is_exit();
+  import "DPI-C" context function
+    void bsg_vcache_profiler_exit();
+  import "DPI-C" context function
+    int bsg_vcache_profiler_trace_fd();
+
+  initial begin
+    if (bsg_vcache_profiler_is_init() == 0) begin
+      int trace_fd = $fopen("vcache_operation_trace.csv", "w");
+      $fwrite(trace_fd, "cycle,vcache,operation\n");
+      bsg_vcache_profiler_init(trace_fd);
+    end
+  end
+
+  final begin
+    if (bsg_vcache_profiler_is_exit() == 0) begin
+      $fclose(bsg_vcache_profiler_trace_fd());
+      bsg_vcache_profiler_exit();
+    end
+  end
 
   // task to print a line of operation trace
-  task print_operation_trace(integer fd, string vcache_name, string op);
-    $fwrite(fd, "%0d,%0s,%0s\n", global_ctr_i, vcache_name, op);
+  task print_operation_trace(string vcache_name, string op);
+    $fwrite(bsg_vcache_profiler_trace_fd(), "%0d,%0s,%0s\n", global_ctr_i, vcache_name, op);
   endtask
 
 
@@ -339,14 +364,14 @@ module vcache_profiler
           // If miss handler has finished the dma request and result is ready
           // for a missed request
           if (inc_miss_ld)
-            print_operation_trace($root.`HOST_MODULE_PATH.vcache_trace_fd, my_name, "miss_ld");
+            print_operation_trace(my_name, "miss_ld");
           else if (inc_miss_st)
-            print_operation_trace($root.`HOST_MODULE_PATH.vcache_trace_fd, my_name, "miss_st");
+            print_operation_trace(my_name, "miss_st");
 
 
           // If miss handler is still busy on a request
           else if (miss_v) begin
-            print_operation_trace($root.`HOST_MODULE_PATH.vcache_trace_fd, my_name, "miss");
+            print_operation_trace(my_name, "miss");
           end 
 
         
@@ -355,71 +380,71 @@ module vcache_profiler
 
             if (inc_ld) begin
               if (inc_ld_ld) 
-                print_operation_trace($root.`HOST_MODULE_PATH.vcache_trace_fd, my_name, "ld_ld");
+                print_operation_trace(my_name, "ld_ld");
               else if (inc_ld_ldu)
-                print_operation_trace($root.`HOST_MODULE_PATH.vcache_trace_fd, my_name, "ld_ldu");
+                print_operation_trace(my_name, "ld_ldu");
               else if (inc_ld_lw)
-                print_operation_trace($root.`HOST_MODULE_PATH.vcache_trace_fd, my_name, "ld_lw");
+                print_operation_trace(my_name, "ld_lw");
               else if (inc_ld_lwu)
-                print_operation_trace($root.`HOST_MODULE_PATH.vcache_trace_fd, my_name, "ld_lwu");
+                print_operation_trace(my_name, "ld_lwu");
               else if (inc_ld_lh)
-                print_operation_trace($root.`HOST_MODULE_PATH.vcache_trace_fd, my_name, "ld_lh");
+                print_operation_trace(my_name, "ld_lh");
               else if (inc_ld_lhu)
-                print_operation_trace($root.`HOST_MODULE_PATH.vcache_trace_fd, my_name, "ld_lhu");
+                print_operation_trace(my_name, "ld_lhu");
               else if (inc_ld_lb) 
-                print_operation_trace($root.`HOST_MODULE_PATH.vcache_trace_fd, my_name, "ld_lb");
+                print_operation_trace(my_name, "ld_lb");
               else if (inc_ld_lbu)
-                print_operation_trace($root.`HOST_MODULE_PATH.vcache_trace_fd, my_name, "ld_lbu");
+                print_operation_trace(my_name, "ld_lbu");
               else
-                print_operation_trace($root.`HOST_MODULE_PATH.vcache_trace_fd, my_name, "ld");
+                print_operation_trace(my_name, "ld");
             end
 
 
             else if (inc_st) begin
               if (inc_sm_sd)
-                print_operation_trace($root.`HOST_MODULE_PATH.vcache_trace_fd, my_name, "sm_sd");  
+                print_operation_trace(my_name, "sm_sd");
               else if (inc_sm_sw)
-                print_operation_trace($root.`HOST_MODULE_PATH.vcache_trace_fd, my_name, "sm_sw");  
+                print_operation_trace(my_name, "sm_sw");
               else if (inc_sm_sh)
-                print_operation_trace($root.`HOST_MODULE_PATH.vcache_trace_fd, my_name, "sm_sh");  
+                print_operation_trace(my_name, "sm_sh");
               else if (inc_sm_sb)
-                print_operation_trace($root.`HOST_MODULE_PATH.vcache_trace_fd, my_name, "sm_sb");  
+                print_operation_trace(my_name, "sm_sb");
               else
-                print_operation_trace($root.`HOST_MODULE_PATH.vcache_trace_fd, my_name, "st");
+                print_operation_trace(my_name, "st");
             end
 
 
             else if (inc_stall_rsp)
-              print_operation_trace($root.`HOST_MODULE_PATH.vcache_trace_fd, my_name, "stall_rsp");
+              print_operation_trace(my_name, "stall_rsp");
 
             else if (inc_tagst)
-              print_operation_trace($root.`HOST_MODULE_PATH.vcache_trace_fd, my_name, "tagst");
+              print_operation_trace(my_name, "tagst");
             else if (inc_tagfl)
-              print_operation_trace($root.`HOST_MODULE_PATH.vcache_trace_fd, my_name, "tagfl");
+              print_operation_trace(my_name, "tagfl");
             else if (inc_taglv)
-              print_operation_trace($root.`HOST_MODULE_PATH.vcache_trace_fd, my_name, "taglv");
+              print_operation_trace(my_name, "taglv");
             else if (inc_tagla)
-              print_operation_trace($root.`HOST_MODULE_PATH.vcache_trace_fd, my_name, "tagla");
+              print_operation_trace(my_name, "tagla");
             else if (inc_afl)
-              print_operation_trace($root.`HOST_MODULE_PATH.vcache_trace_fd, my_name, "afl");
+              print_operation_trace(my_name, "afl");
             else if (inc_aflinv)
-              print_operation_trace($root.`HOST_MODULE_PATH.vcache_trace_fd, my_name, "aflinv");
+              print_operation_trace(my_name, "aflinv");
             else if (inc_ainv)
-              print_operation_trace($root.`HOST_MODULE_PATH.vcache_trace_fd, my_name, "ainv");
+              print_operation_trace(my_name, "ainv");
             else if (inc_alock)
-              print_operation_trace($root.`HOST_MODULE_PATH.vcache_trace_fd, my_name, "alock");
+              print_operation_trace(my_name, "alock");
             else if (inc_aunlock)
-              print_operation_trace($root.`HOST_MODULE_PATH.vcache_trace_fd, my_name, "aunlock");
+              print_operation_trace(my_name, "aunlock");
             else if (inc_atomic)
-              print_operation_trace($root.`HOST_MODULE_PATH.vcache_trace_fd, my_name, "atomic");
+              print_operation_trace(my_name, "atomic");
             else if (inc_amoswap)
-              print_operation_trace($root.`HOST_MODULE_PATH.vcache_trace_fd, my_name, "amoswap");
+              print_operation_trace(my_name, "amoswap");
             else if (inc_amoor)
-              print_operation_trace($root.`HOST_MODULE_PATH.vcache_trace_fd, my_name, "amoor");
+              print_operation_trace(my_name, "amoor");
             else if (inc_amoadd)
-              print_operation_trace($root.`HOST_MODULE_PATH.vcache_trace_fd, my_name, "amoadd");
+              print_operation_trace(my_name, "amoadd");
             else
-              print_operation_trace($root.`HOST_MODULE_PATH.vcache_trace_fd, my_name, "idle");
+              print_operation_trace(my_name, "idle");
           end
 
         end // if (~reset_i & trace_en_i)


### PR DESCRIPTION
Currently the tracers call $fopen and $fclose inside of always blocks in modules that are instantiated many times.
When the trace is enabled this results in $fopen/$fclose being called redundantly many times per cycle.
I found that calling $fopen and $fclose just once at the start of the simulation reduced sim time by 1.6x (average) and as much as 2x. 