### PR TITLE
Ci pod 4x4 hbm2

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,6 +9,7 @@ stages:
   - test_1x1
   - test_1x1_hbm2
   - test_4x4
+  - test_4x4_hbm2
 
 build-repos:
   stage: checkout
@@ -317,6 +318,58 @@ test-interrupt-4x4:
     - vcs
   script:
     - export BSG_MACHINE_PATH=$CI_PROJECT_DIR/bsg_manycore/machines/pod_4x4
+    - echo "Running interrupt regression..."
+    - cd bsg_manycore
+    - pwd
+    - ./ci/interrupt.sh
+  cache:
+    key: $CI_COMMIT_REF_NAME
+    paths:
+      - $CI_PROJECT_DIR/bsg_cadenv
+      - $CI_PROJECT_DIR/basejump_stl
+      - $CI_PROJECT_DIR/bsg_manycore
+      - $CI_PROJECT_DIR/bsg_bladerunner
+    policy: pull
+  only:
+    refs:
+      - /^ci_.*$/
+      - master
+  retry: 2
+
+
+test-spmd-4x4-hbm2:
+  stage: test_4x4_hbm2
+  tags:
+    - bsg
+    - vcs
+  script:
+    - export BSG_MACHINE_PATH=$CI_PROJECT_DIR/bsg_manycore/machines/pod_4x4_hbm2
+    - echo "Running Manycore regression..."
+    - cd bsg_manycore
+    - pwd
+    - ./ci/spmd.sh
+  cache:
+    key: $CI_COMMIT_REF_NAME
+    paths:
+      - $CI_PROJECT_DIR/bsg_cadenv
+      - $CI_PROJECT_DIR/basejump_stl
+      - $CI_PROJECT_DIR/bsg_manycore
+      - $CI_PROJECT_DIR/bsg_bladerunner
+    policy: pull
+  only:
+    refs:
+      - /^ci_.*$/
+      - master
+  retry: 2
+
+
+test-interrupt-4x4-hbm2:
+  stage: test_4x4_hbm2
+  tags:
+    - bsg
+    - vcs
+  script:
+    - export BSG_MACHINE_PATH=$CI_PROJECT_DIR/bsg_manycore/machines/pod_4x4_hbm2
     - echo "Running interrupt regression..."
     - cd bsg_manycore
     - pwd

--- a/machines/platform.mk
+++ b/machines/platform.mk
@@ -2,7 +2,7 @@
 BSG_PLATFORM ?= vcs
 
 ifeq ($(BSG_PLATFORM),vcs)
-DEFAULT_MACHINES = pod_1x1 pod_1x1_hbm2 pod_4x4
+DEFAULT_MACHINES = pod_1x1 pod_1x1_hbm2 pod_4x4 pod_4x4_hbm2
 BSG_SIM_BASE = simv
 else ifeq ($(BSG_PLATFORM),verilator)
 DEFAULT_MACHINES = pod_1x1_4X2Y

--- a/software/spmd/bsg_simple_mutex_test/Makefile
+++ b/software/spmd/bsg_simple_mutex_test/Makefile
@@ -4,7 +4,7 @@ export BSG_MANYCORE_DIR := $(shell git rev-parse --show-toplevel)
 # bsg_tiles_X = 2
 # bsg_tiles_Y = 2
 
-RISCV_GXX_EXTRA_OPTS = -DITERS=16
+RISCV_GXX_EXTRA_OPTS = -DITERS=8
 
 include $(BSG_MANYCORE_DIR)/software/mk/Makefile.master
 include $(BSG_MANYCORE_DIR)/software/mk/Makefile.tail_rules


### PR DESCRIPTION
Adding pod_4x4_hbm2 CI and reducing bsg_simple_mutex_test iteration times, which takes the longest time to run.