### PR TITLE
Add bsg_group_strider, and SPMD test

### DIFF
--- a/software/bsg_manycore_lib/bsg_group_strider.hpp
+++ b/software/bsg_manycore_lib/bsg_group_strider.hpp
@@ -18,6 +18,12 @@
 //    bsg_tile_group_strider<bsg_tiles_X, 1, bsg_tiles_Y, 1, int> stride_y(foo, 0, 0);
 //
 // Use the stride() method to get an updated pointer after construction.
+//
+// When the strider reaches the end of a tile group it wraps back
+// around to 0 -- i.e. mod.
+
+// NOTE: THIS STRIDER ONLY WORKS WITH TILE GROUPS THAT ARE A POWER OF
+// TWO IN THE DIMENSION(S) OF STRIDING.
 
 #ifndef __BSG_GROUP_STRIDER
 #define __BSG_GROUP_STRIDER
@@ -33,6 +39,9 @@
 #define BSG_TILE_GROUP_LOG_X_DIM ((int)(log2(BSG_TILE_GROUP_X_DIM)))
 
 #define MAKE_MASK(WIDTH) ((1UL << (WIDTH)) - 1UL)
+// TG_X/Y -- Tile Group X/Y Dimension
+// S_X/Y -- Number of tiles to stride X/Y dimension
+// T -- Type of underlying pointer.
 template<unsigned int TG_X, unsigned int S_X, unsigned int TG_Y, unsigned int S_Y, typename T>
 class bsg_tile_group_strider{
         static const unsigned int GROUP_EPA_WIDTH = REMOTE_EPA_WIDTH;
@@ -50,8 +59,8 @@ class bsg_tile_group_strider{
 protected:
 public:
         T *ptr;
-        // x_off and y_off are starting tile offsets in the horizontal
-        // and vertical directions.
+        // x/y_off starting stride offsets in the horizontal and
+        // vertical directions.
         bsg_tile_group_strider(T *p, int x_off, int y_off){
                 ptr =(T*)( ((1 << GROUP_PREFIX_SHIFT)
                             | (y_off << GROUP_Y_COORD_SHIFT)
@@ -59,6 +68,8 @@ public:
                             | ((unsigned int) p)));
         }
 
+        // Execute a stride operation and return a pointer to the new
+        // location.
         T* stride(){
                 if(S_X == 0){
                         return ptr = (T*)(((unsigned int) ptr + Y_STRIDE) & Y_MASK);

--- a/software/bsg_manycore_lib/bsg_group_strider.hpp
+++ b/software/bsg_manycore_lib/bsg_group_strider.hpp
@@ -1,0 +1,74 @@
+// The intent of this file is to provide a simple, templated method
+// for striding between the scratchpads of tiles in a tile group
+//
+// The following example strides horizontally between the foo variable
+// in a tile group:
+//    int foo;
+//    bsg_tile_group_strider<bsg_tiles_X, 1, bsg_tiles_Y, 0, int> stride_x(foo, 0, 0);
+//
+// The following example strides vertically with a tile stride of 1 in
+// a tile group:
+//    int foo;
+//    bsg_tile_group_strider<bsg_tiles_X, 0, bsg_tiles_Y, 1, int> stride_y(foo, 0, 0);
+//
+// The following example moves diagonally with a horizontal tile
+// stride of 1, and a vertical tile stride of 1 between tiles in a
+// tile group:
+//    int foo;
+//    bsg_tile_group_strider<bsg_tiles_X, 1, bsg_tiles_Y, 1, int> stride_y(foo, 0, 0);
+//
+// Use the stride() method to get an updated pointer after construction.
+
+#ifndef __BSG_GROUP_STRIDER
+#define __BSG_GROUP_STRIDER
+
+#include <bsg_manycore.h>
+#include <bsg_set_tile_x_y.h>
+
+#include <math.h>
+
+#define BSG_TILE_GROUP_X_DIM bsg_tiles_X
+#define BSG_TILE_GROUP_Y_DIM bsg_tiles_Y
+#define BSG_TILE_GROUP_LOG_Y_DIM ((int)(log2(BSG_TILE_GROUP_Y_DIM)))
+#define BSG_TILE_GROUP_LOG_X_DIM ((int)(log2(BSG_TILE_GROUP_X_DIM)))
+
+#define MAKE_MASK(WIDTH) ((1UL << (WIDTH)) - 1UL)
+template<unsigned int TG_X, unsigned int S_X, unsigned int TG_Y, unsigned int S_Y, typename T>
+class bsg_tile_group_strider{
+        static const unsigned int GROUP_EPA_WIDTH = REMOTE_EPA_WIDTH;
+        static const unsigned int GROUP_X_COORD_WIDTH = REMOTE_X_CORD_WIDTH;
+        static const unsigned int GROUP_Y_COORD_WIDTH = REMOTE_Y_CORD_WIDTH;
+        static const unsigned int GROUP_X_COORD_SHIFT = (GROUP_EPA_WIDTH);
+        static const unsigned int GROUP_Y_COORD_SHIFT = (GROUP_X_COORD_SHIFT+GROUP_X_COORD_WIDTH);
+        static const unsigned int GROUP_PREFIX_SHIFT = (GROUP_Y_COORD_SHIFT+GROUP_Y_COORD_WIDTH);
+
+        static const unsigned int Y_STRIDE = (1 << GROUP_Y_COORD_SHIFT);
+        static const unsigned int X_STRIDE = (1 << GROUP_X_COORD_SHIFT);
+        static const unsigned int Y_MASK = ~(MAKE_MASK(GROUP_Y_COORD_WIDTH - (unsigned int)(log2(TG_Y))) << ((unsigned int)(log2(TG_Y)) + GROUP_Y_COORD_SHIFT));
+        static const unsigned int X_MASK = ~(MAKE_MASK(GROUP_X_COORD_WIDTH - (unsigned int)(log2(TG_X))) << ((unsigned int)(log2(TG_X)) + GROUP_X_COORD_SHIFT));
+
+protected:
+public:
+        T *ptr;
+        // x_off and y_off are starting tile offsets in the horizontal
+        // and vertical directions.
+        bsg_tile_group_strider(T *p, int x_off, int y_off){
+                ptr =(T*)( ((1 << GROUP_PREFIX_SHIFT)
+                            | (y_off << GROUP_Y_COORD_SHIFT)
+                            | (x_off << GROUP_X_COORD_SHIFT)
+                            | ((unsigned int) p)));
+        }
+
+        T* stride(){
+                if(S_X == 0){
+                        return ptr = (T*)(((unsigned int) ptr + Y_STRIDE) & Y_MASK);
+                } else if(S_Y == 0){
+                        return ptr = (T*)(((unsigned int) ptr + X_STRIDE) & X_MASK);
+                } else {
+                        return ptr = (T*)(((((unsigned int) ptr + X_STRIDE) & X_MASK) + Y_STRIDE) & Y_MASK);
+                }
+        }
+
+};
+
+#endif

--- a/software/spmd/strider/Makefile
+++ b/software/spmd/strider/Makefile
@@ -1,0 +1,17 @@
+bsg_tiles_X = 4
+bsg_tiles_Y = 4
+
+
+all: main.run
+
+OBJECT_FILES=main.o bsg_barrier_amoadd.o
+
+include ../Makefile.include
+
+main.riscv: $(LINK_SCRIPT) $(OBJECT_FILES) $(SPMD_COMMON_OBJECTS) $(BSG_MANYCORE_LIB) crt.o
+	$(RISCV_LINK) $(OBJECT_FILES) $(SPMD_COMMON_OBJECTS) -L. "-l:$(BSG_MANYCORE_LIB)" -o $@ $(RISCV_LINK_OPTS)
+
+
+main.o: Makefile
+
+include ../../mk/Makefile.tail_rules

--- a/software/spmd/strider/main.cpp
+++ b/software/spmd/strider/main.cpp
@@ -1,0 +1,58 @@
+
+#include "bsg_manycore.h"
+#include "bsg_set_tile_x_y.h"
+#include "bsg_group_strider.hpp"
+#include <algorithm>
+#include "bsg_barrier_amoadd.h"
+
+// AMOADD barrier
+extern void bsg_barrier_amoadd(int*, int*);
+int amoadd_lock __attribute__ ((section (".dram"))) = 0;
+int amoadd_alarm = 1;
+
+int main()
+{
+
+        bsg_set_tile_x_y();
+        bsg_fence();
+        bsg_barrier_amoadd(&amoadd_lock, &amoadd_alarm);  
+        
+        bsg_tile_group_strider<BSG_TILE_GROUP_X_DIM, 1, BSG_TILE_GROUP_Y_DIM, 0, int> stride_x(&__bsg_x, 0, 0);
+        bsg_tile_group_strider<BSG_TILE_GROUP_X_DIM, 0, BSG_TILE_GROUP_Y_DIM, 1, int> stride_y(&__bsg_y, 0, 0);
+        bsg_tile_group_strider<BSG_TILE_GROUP_X_DIM, 1, BSG_TILE_GROUP_Y_DIM, 1, int> stride_xy(&__bsg_y, 0, 0);
+        bsg_printf("%d, %d\n", __bsg_y, __bsg_x);
+
+        if ((__bsg_x == 0) && (__bsg_y == 0)) {
+
+                // Stride vertically between tiles
+                for (int i = 1; i < bsg_tiles_Y; i++){
+                        int cur = *stride_y.stride();
+                        bsg_printf("Tile (%d, %d) @ Tile (%d, %d), __bsg_y = %d\n", __bsg_y, __bsg_x, i, 0, cur);
+                        if(i != cur)
+                                bsg_fail();
+                }
+
+                // Stride horizontally
+                for (int i = 1; i < bsg_tiles_X; i++){
+                        int cur = *stride_x.stride();
+                        bsg_printf("Tile (%d, %d) @ Tile (%d, %d), __bsg_y = %d\n", __bsg_y, __bsg_x, 0, i, cur);
+                        if(i != cur)
+                                bsg_fail();
+                }
+
+                // Stride diagonally
+                int lim = std::min(bsg_tiles_X, bsg_tiles_Y);
+                for (int i = 1; i < lim; i++){
+                        int cur = *stride_xy.stride();
+                        bsg_printf("Tile (%d, %d) @ Tile (%d, %d), __bsg_y = %d\n", __bsg_y, __bsg_x, i, i, cur);
+                        if(i != cur)
+                                bsg_fail();
+                }
+  
+                bsg_finish();
+        }
+
+        bsg_wait_while(1);
+
+}
+

--- a/software/spmd/strider/main.cpp
+++ b/software/spmd/strider/main.cpp
@@ -25,22 +25,24 @@ int main()
         if ((__bsg_x == 0) && (__bsg_y == 0)) {
 
                 // Stride vertically between tiles
-                for (int i = 1; i < bsg_tiles_Y; i++){
+                for (int i = 1; i <= bsg_tiles_Y; i++){
                         int cur = *stride_y.stride();
                         bsg_printf("Tile (%d, %d) @ Tile (%d, %d), __bsg_y = %d\n", __bsg_y, __bsg_x, i, 0, cur);
-                        if(i != cur)
+                        // The strider will wrap around to 0 at the edge of the tile group
+                        if((i % bsg_tiles_Y) != cur)
                                 bsg_fail();
                 }
 
                 // Stride horizontally
-                for (int i = 1; i < bsg_tiles_X; i++){
+                for (int i = 1; i <= bsg_tiles_X; i++){
                         int cur = *stride_x.stride();
                         bsg_printf("Tile (%d, %d) @ Tile (%d, %d), __bsg_y = %d\n", __bsg_y, __bsg_x, 0, i, cur);
-                        if(i != cur)
+                        // The strider will wrap around to 0 at the edge of the tile group
+                        if((i % bsg_tiles_X) != cur)
                                 bsg_fail();
                 }
 
-                // Stride diagonally
+                // Stride diagonally, no wrap 
                 int lim = std::min(bsg_tiles_X, bsg_tiles_Y);
                 for (int i = 1; i < lim; i++){
                         int cur = *stride_xy.stride();


### PR DESCRIPTION
This is a C++ class for striding between tiles in a tile group.

It can be used to stride between tiles in the horizontal, vertical, or diagonal direction. This can be more than the size of the tile group, but must be static.

This is used in the optimized SGEMM implementation, but is more general than that. Hence, why it is being merged here.



