### PR TITLE
Refix verilator

### DIFF
--- a/testbenches/common/v/profiler.vh
+++ b/testbenches/common/v/profiler.vh
@@ -31,21 +31,24 @@ import "DPI-C" context function \
 
 
 `define DEFINE_PROFILER_INITIAL_BLOCK(profiler_name, trace_file_name, trace_file_header) \
+int init_trace_fd; \
 initial begin \
   profiler_name``_lock();  \
   if (profiler_name``_is_init() == 0) begin \
-    int trace_fd = $fopen(trace_file_name, "w"); \
-    profiler_name``_init(trace_fd); \
-    $fwrite(trace_fd, trace_file_header); \
+    init_trace_fd = $fopen(trace_file_name, "w"); \
+    profiler_name``_init(init_trace_fd); \
+    $fwrite(init_trace_fd, trace_file_header); \
   end \
   profiler_name``_unlock(); \
 end
 
-`define DEFINE_PROFILER_FINAL_BLOCK(profiler_name, trace_file_name, trace_file_header) \
+`define DEFINE_PROFILER_FINAL_BLOCK(profiler_name) \
+  int final_trace_fd; \
   final begin \
     profiler_name``_lock(); \
     if (profiler_name``_is_exit()) begin \
-      $fclose(profiler_name``_trace_fd()); \
+      final_trace_fd = profiler_name``_trace_fd(); \
+      $fclose(final_trace_fd); \
       profiler_name``_exit(); \
     end \
     profiler_name``_unlock(); \

--- a/v/bsg_manycore_accel_default.v
+++ b/v/bsg_manycore_accel_default.v
@@ -23,6 +23,8 @@ module bsg_manycore_accel_default
      , `BSG_INV_PARAM(num_tiles_x_p )
      , `BSG_INV_PARAM(num_tiles_y_p )
 
+     , `BSG_INV_PARAM(icache_block_size_in_words_p)
+
      , localparam x_subcord_width_lp = `BSG_SAFE_CLOG2(num_tiles_x_p)
      , y_subcord_width_lp = `BSG_SAFE_CLOG2(num_tiles_y_p)
 
@@ -39,6 +41,9 @@ module bsg_manycore_accel_default
      , data_mask_width_lp=(data_width_p>>3)
      , reg_addr_width_lp=RV32_reg_addr_width_gp
 
+     , parameter `BSG_INV_PARAM(barrier_dirs_p)
+     , localparam barrier_lg_dirs_lp=`BSG_SAFE_CLOG2(barrier_dirs_p+1)
+
      , link_sif_width_lp =
       `bsg_manycore_link_sif_width(addr_width_p,data_width_p,x_cord_width_p,y_cord_width_p)
 
@@ -49,6 +54,11 @@ module bsg_manycore_accel_default
     // input and output links
     , input  [link_sif_width_lp-1:0] link_sif_i
     , output [link_sif_width_lp-1:0] link_sif_o
+
+    , input barrier_data_i
+    , output barrier_data_o
+    , output [barrier_dirs_p-1:0]     barrier_src_r_o
+    , output [barrier_lg_dirs_lp-1:0] barrier_dest_r_o
 
     // subcord within a pod
     , input [x_subcord_width_lp-1:0] my_x_i

--- a/v/bsg_manycore_gather_scatter.v
+++ b/v/bsg_manycore_gather_scatter.v
@@ -52,6 +52,8 @@ module bsg_manycore_gather_scatter
     , `BSG_INV_PARAM(num_tiles_x_p )
     , `BSG_INV_PARAM(num_tiles_y_p )
 
+    , `BSG_INV_PARAM(icache_block_size_in_words_p)
+
     , localparam x_subcord_width_lp = `BSG_SAFE_CLOG2(num_tiles_x_p)
     , y_subcord_width_lp = `BSG_SAFE_CLOG2(num_tiles_y_p)
 
@@ -68,6 +70,9 @@ module bsg_manycore_gather_scatter
     , data_mask_width_lp = (data_width_p>>3)
     , reg_addr_width_lp=RV32_reg_addr_width_gp
 
+    , parameter `BSG_INV_PARAM(barrier_dirs_p)
+    , localparam barrier_lg_dirs_lp=`BSG_SAFE_CLOG2(barrier_dirs_p+1)
+
     , link_sif_width_lp =
       `bsg_manycore_link_sif_width(addr_width_p,data_width_p,x_cord_width_p,y_cord_width_p)
   )
@@ -78,6 +83,11 @@ module bsg_manycore_gather_scatter
     // mesh network
     , input [link_sif_width_lp-1:0] link_sif_i
     , output [link_sif_width_lp-1:0] link_sif_o
+
+    , input barrier_data_i
+    , output barrier_data_o
+    , output [barrier_dirs_p-1:0]     barrier_src_r_o
+    , output [barrier_lg_dirs_lp-1:0] barrier_dest_r_o
 
     // subcord within a pod
     , input [x_cord_width_p-1:0] my_x_i


### PR DESCRIPTION
These are minor fixes to get verilator back and happy. The barrier change is just to stifle errors since those modules are unused and probably broken as is. The profiler change is to get around a feature missing of declaring a local int variable within an initial/final block.

Merge with: https://github.com/bespoke-silicon-group/bsg_replicant/pull/752