### PR TITLE
Added a workaround for parameter-controlled elaboration in Verilator

### DIFF
--- a/testbenches/common/v/bsg_nonsynth_manycore_testbench.v
+++ b/testbenches/common/v/bsg_nonsynth_manycore_testbench.v
@@ -805,7 +805,7 @@ if (enable_vcore_profiling_p) begin
     ,.origin_y_cord_p(`BSG_MACHINE_ORIGIN_Y_CORD)
   ) vcore_prof (
     .*
-    ,.clk_i(clk_i && $root.`HOST_MODULE_PATH.testbench.enable_vcore_profiling_p)
+    ,.clk_i(clk_i)
     ,.global_ctr_i($root.`HOST_MODULE_PATH.global_ctr)
     ,.print_stat_v_i($root.`HOST_MODULE_PATH.print_stat_v)
     ,.print_stat_tag_i($root.`HOST_MODULE_PATH.print_stat_tag)

--- a/testbenches/common/v/bsg_nonsynth_manycore_testbench.v
+++ b/testbenches/common/v/bsg_nonsynth_manycore_testbench.v
@@ -774,6 +774,16 @@ module bsg_nonsynth_manycore_testbench
 //    PROFILERS     //
 //                  //
 
+// NOTE: Verilator does not allow parameter-controlled module
+// instantiation (There's an issue filed, but not fixed as of
+// 4.222). For this reason, we clock gate the profilers based on the
+// profiler parameter. E.g.: ,.clk_i(clk_i && $root.`HOST_MODULE_PATH.testbench.enable_vcore_profiling_p)
+//
+// I agree that this is super annoying but until it gets fixed, this
+// is the only way to prevent Verilator from running the profilers and
+// slowing down simulation.
+   
+
 // Exponential parsing from surelog: https://github.com/chipsalliance/Surelog/issues/2035
 `ifndef SURELOG
 if (enable_vcore_profiling_p) begin
@@ -788,6 +798,7 @@ if (enable_vcore_profiling_p) begin
     ,.origin_y_cord_p(`BSG_MACHINE_ORIGIN_Y_CORD)
   ) vcore_prof (
     .*
+    ,.clk_i(clk_i && $root.`HOST_MODULE_PATH.testbench.enable_vcore_profiling_p)
     ,.global_ctr_i($root.`HOST_MODULE_PATH.global_ctr)
     ,.print_stat_v_i($root.`HOST_MODULE_PATH.print_stat_v)
     ,.print_stat_tag_i($root.`HOST_MODULE_PATH.print_stat_tag)
@@ -807,6 +818,7 @@ if (enable_vcore_profiling_p) begin
     ,.origin_y_cord_p(`BSG_MACHINE_ORIGIN_Y_CORD)
   ) rlt (
     .*
+    ,.clk_i(clk_i && $root.`HOST_MODULE_PATH.testbench.enable_vcore_profiling_p)
     ,.global_ctr_i($root.`HOST_MODULE_PATH.global_ctr)
     ,.trace_en_i($root.`HOST_MODULE_PATH.trace_en)
   );
@@ -822,6 +834,7 @@ if (enable_cache_profiling_p) begin
   ) vcache_prof (
     // everything else
     .*
+    ,.clk_i(clk_i && $root.`HOST_MODULE_PATH.testbench.enable_cache_profiling_p)
     // bsg_cache_miss
     ,.chosen_way_n(miss.chosen_way_n)
     // from testbench
@@ -845,6 +858,7 @@ if (enable_router_profiling_p) begin
     ,.origin_y_cord_p(`BSG_MACHINE_ORIGIN_Y_CORD)
   ) rp0 (
     .*
+    ,.clk_i(clk_i && $root.`HOST_MODULE_PATH.testbench.enable_router_profiling_p)
     ,.global_ctr_i($root.`HOST_MODULE_PATH.global_ctr)
     ,.trace_en_i($root.`HOST_MODULE_PATH.trace_en)
     ,.print_stat_v_i($root.`HOST_MODULE_PATH.print_stat_v)
@@ -859,6 +873,7 @@ if (enable_vcore_pc_coverage_p) begin
   )
   pc_cov (
     .*
+    ,.clk_i(clk_i && $root.`HOST_MODULE_PATH.testbench.enable_vcore_pc_coverage_p)
     ,.coverage_en_i($root.`HOST_MODULE_PATH.coverage_en)
   );
 end
@@ -879,6 +894,7 @@ if (enable_vanilla_core_trace_p) begin
     ,.dmem_size_p(dmem_size_p)
   ) trace0 (
     .*
+    ,.clk_i(clk_i && $root.`HOST_MODULE_PATH.testbench.enable_vanilla_core_trace_p)
   );
 end
 

--- a/testbenches/common/v/bsg_nonsynth_manycore_testbench.v
+++ b/testbenches/common/v/bsg_nonsynth_manycore_testbench.v
@@ -774,18 +774,25 @@ module bsg_nonsynth_manycore_testbench
 //    PROFILERS     //
 //                  //
 
-// NOTE: Verilator does not allow parameter-controlled module
-// instantiation (There's an issue filed, but not fixed as of
-// 4.222). For this reason, we clock gate the profilers based on the
-// profiler parameter. E.g.: ,.clk_i(clk_i && $root.`HOST_MODULE_PATH.testbench.enable_vcore_profiling_p)
+// NOTE: Verilator does not allow parameter-controlled module binds
+// (There's an issue filed, but not fixed as of 4.222). There are two ways we can fix this:
+//
+// 1. Clock gate the profilers based on the profiler parameter. E.g.:
+//   ,.clk_i(clk_i && $root.`HOST_MODULE_PATH.testbench.enable_vcore_profiling_p)
+//
+// 2. Disable the profilers using Macros.
+//
+// Using clock gating was somewhat controversial, so for the moment we
+// are controling the instantiation using macros *** FOR VERILATOR
+// ONLY ***
 //
 // I agree that this is super annoying but until it gets fixed, this
 // is the only way to prevent Verilator from running the profilers and
 // slowing down simulation.
-   
 
 // Exponential parsing from surelog: https://github.com/chipsalliance/Surelog/issues/2035
 `ifndef SURELOG
+`ifndef VERILATOR_WORKAROUND_DISABLE_VCORE_PROFILING
 if (enable_vcore_profiling_p) begin
   // vanilla core profiler
    bind vanilla_core vanilla_core_profiler #(
@@ -818,13 +825,15 @@ if (enable_vcore_profiling_p) begin
     ,.origin_y_cord_p(`BSG_MACHINE_ORIGIN_Y_CORD)
   ) rlt (
     .*
-    ,.clk_i(clk_i && $root.`HOST_MODULE_PATH.testbench.enable_vcore_profiling_p)
+    ,.clk_i(clk_i)
     ,.global_ctr_i($root.`HOST_MODULE_PATH.global_ctr)
     ,.trace_en_i($root.`HOST_MODULE_PATH.trace_en)
   );
 
 end
+`endif
 
+`ifndef VERILATOR_WORKAROUND_DISABLE_VCACHE_PROFILING
 if (enable_cache_profiling_p) begin
   bind bsg_cache vcache_profiler #(
     .data_width_p(data_width_p)
@@ -834,7 +843,7 @@ if (enable_cache_profiling_p) begin
   ) vcache_prof (
     // everything else
     .*
-    ,.clk_i(clk_i && $root.`HOST_MODULE_PATH.testbench.enable_cache_profiling_p)
+    ,.clk_i(clk_i)
     // bsg_cache_miss
     ,.chosen_way_n(miss.chosen_way_n)
     // from testbench
@@ -845,9 +854,11 @@ if (enable_cache_profiling_p) begin
   );
 
   end
+`endif
 
 // Covergroups are not fully supported by Verilator 4.213
 `ifndef VERILATOR
+`ifndef VERILATOR_WORKAROUND_DISABLE_ROUTER_PROFILER
 if (enable_router_profiling_p) begin
   bind bsg_mesh_router router_profiler #(
     .x_cord_width_p(x_cord_width_p)
@@ -858,14 +869,15 @@ if (enable_router_profiling_p) begin
     ,.origin_y_cord_p(`BSG_MACHINE_ORIGIN_Y_CORD)
   ) rp0 (
     .*
-    ,.clk_i(clk_i && $root.`HOST_MODULE_PATH.testbench.enable_router_profiling_p)
+    ,.clk_i(clk_i)
     ,.global_ctr_i($root.`HOST_MODULE_PATH.global_ctr)
     ,.trace_en_i($root.`HOST_MODULE_PATH.trace_en)
     ,.print_stat_v_i($root.`HOST_MODULE_PATH.print_stat_v)
   );
 end
+`endif
 
-
+`ifndef VERILATOR_WORKAROUND_DISABLE_VCORE_COVERAGE
 if (enable_vcore_pc_coverage_p) begin
   bind vanilla_core bsg_nonsynth_manycore_vanilla_core_pc_cov #(
     .icache_tag_width_p(icache_tag_width_p)
@@ -873,10 +885,11 @@ if (enable_vcore_pc_coverage_p) begin
   )
   pc_cov (
     .*
-    ,.clk_i(clk_i && $root.`HOST_MODULE_PATH.testbench.enable_vcore_pc_coverage_p)
+    ,.clk_i(clk_i)
     ,.coverage_en_i($root.`HOST_MODULE_PATH.coverage_en)
   );
 end
+`endif
 `endif
 `endif
 
@@ -884,6 +897,7 @@ end
   ///   TRACER    ///
   ///             ///
   
+`ifndef VERILATOR_WORKAROUND_DISABLE_VCORE_TRACE
 if (enable_vanilla_core_trace_p) begin
   bind vanilla_core vanilla_core_trace #(
     .x_cord_width_p(x_cord_width_p)
@@ -894,10 +908,10 @@ if (enable_vanilla_core_trace_p) begin
     ,.dmem_size_p(dmem_size_p)
   ) trace0 (
     .*
-    ,.clk_i(clk_i && $root.`HOST_MODULE_PATH.testbench.enable_vanilla_core_trace_p)
+    ,.clk_i(clk_i)
   );
 end
-
+`endif
 
 
 endmodule

--- a/testbenches/common/v/spmd_testbench.v
+++ b/testbenches/common/v/spmd_testbench.v
@@ -137,7 +137,10 @@ module spmd_testbench
 `ifdef BSG_ENABLE_VANILLA_CORE_TRACE
     ,.enable_vanilla_core_trace_p(1)
 `endif
-  ) tb (
+  // DR: If the instance name is changed, the bind statements in the
+  // file where this module is defined, and header strings in the
+  // profilers need to be changed as well.
+  ) testbench (
     .clk_i(core_clk)
     ,.reset_i(global_reset)
 
@@ -173,7 +176,7 @@ module spmd_testbench
     ,.icache_block_size_in_words_p(icache_block_size_in_words_p)
     ,.io_x_cord_p(`BSG_MACHINE_HOST_X_CORD)
     ,.io_y_cord_p(`BSG_MACHINE_HOST_Y_CORD)
-    ,.saif_toggle_scope_p("spmd_testbench.tb.DUT.podrow.px[0].pod.mc_y[0].mc_x[0].mc.y[0].x[0].tile")
+    ,.saif_toggle_scope_p("spmd_testbench.testbench.DUT.podrow.px[0].pod.mc_y[0].mc_x[0].mc.y[0].x[0].tile")
   ) io (
     .clk_i(core_clk)
     ,.reset_i(reset_r)


### PR DESCRIPTION
This seems like a simple fix, but I want to make sure we're all on board because it has some subtle (and annoying) implications.

There are two changes. First, because Verilator doesn't correctly handle parameter-controlled instantiation of modules, our methodology for disabling/enabling the profilers doesn't work in Verilator. Instead, we need to "clock gate" them like so: 

```   
bind vanilla_core vanilla_core_profiler #(
    .x_cord_width_p(x_cord_width_p)
    ,.y_cord_width_p(y_cord_width_p)
    ,.icache_tag_width_p(icache_tag_width_p)
    ,.icache_entries_p(icache_entries_p)
    ,.data_width_p(data_width_p)
    ,.origin_x_cord_p(`BSG_MACHINE_ORIGIN_X_CORD)
    ,.origin_y_cord_p(`BSG_MACHINE_ORIGIN_Y_CORD)
  ) vcore_prof (
    .*
    ,.clk_i(clk_i && $root.`HOST_MODULE_PATH.testbench.enable_vcore_profiling_p)

```
I added a comment explaining this. Also, I used && because I'm worried that someone (or more likely some tool) will use some value that isn't strictly 1 (e.g. "yes"). Using && gets around this.


The second change is the instance name of `bsg_nonsynth_manycore_testbench` in spmd_testbench.v. I switched it from `tb`, to `testbench` because we want to reference the parameters (above) from bsg_nonsynth_manycore_testbench.v, not the top level.

I realize this might be the most controversial change and I agree it's annoying. We typically use this instantiation path in other tools (e.g. saif analysis). I changed the SAIF header string in the path to reflect this but I realize that there are other scripts that may depend on `tb`, not `testbench`. In replicant, we actually depend on `testbench`, and my impression was that there was more instances to change there than in manycore (hopefully just the one above?)

This seemed like the shortest path, but I'm willing to be convinced that it will break some other part of the flow and find a better way to handle it.