### PR TITLE
Add nonsynth saifgen macros

### DIFF
--- a/software/bsg_manycore_lib/bsg_manycore.h
+++ b/software/bsg_manycore_lib/bsg_manycore.h
@@ -249,6 +249,9 @@ inline void bsg_fence()      { __asm__ __volatile__("fence" :::); }
 #define bsg_saif_start() bsg_global_store(IO_X_INDEX, IO_Y_INDEX,0xFFF0,0)
 #define bsg_saif_end()   bsg_global_store(IO_X_INDEX, IO_Y_INDEX,0xFFF4,0)
 
+#define bsg_nonsynth_saif_start() asm volatile ("addi zero,zero,1")
+#define bsg_nonsynth_saif_end() asm volatile ("addi zero,zero,2")
+
 #define bsg_print_stat(tag) do { bsg_remote_int_ptr ptr = bsg_remote_ptr_io(IO_X_INDEX,0xd0c); *ptr = tag; } while (0)
 
 


### PR DESCRIPTION
I understand why the existing macros are used, and why Tommy is using packets, not architecturally-idempotent operations (like these)

Brining these back temporarily to evaluate both approaches.