### PR TITLE
Add amoor and lw prefetch commands

### DIFF
--- a/software/bsg_manycore_lib/bsg_manycore.h
+++ b/software/bsg_manycore_lib/bsg_manycore.h
@@ -167,6 +167,18 @@ inline void bsg_fence()      { __asm__ __volatile__("fence" :::); }
 
 #define bsg_compiler_memory_barrier() asm volatile("" ::: "memory")
 
+
+// These functions are a simple way to issue pre-fetch commands to the
+// caches.  amo prefetch should not be used in practice since it marks
+// the cache line as dirty. However, it is a great way to verify that
+// preloads are accomplishing their goal; if all data is prefetched
+// correctly with an amo operation, the load and store miss rate will
+// go to 0.
+inline void bsg_amo_prefetch(int * ptr){ asm volatile ("amoor.w x0, x0, 0(%[p])": : [p] "r" (ptr));}
+// Verify behavioral correctness with amo prefetch, then replace with
+// lw prefetch:
+inline void bsg_lw_prefetch(int * ptr){ asm volatile ("lw x0, 0(%[p])": : [p] "r" (ptr));}
+        
 #define bsg_commit_stores() do { bsg_fence(); /* fixme: add commit stores instr */  } while (0)
 
 // This micros are used to print the definiations in manycore program at compile time.


### PR DESCRIPTION
Admittedly one of the more odd PRs that I've submitted.

This PR adds two inline functions: `bsg_amo_prefetch` and `bsg_lw_prefetch`. These functions can be used to prefetch data into the cache for a tile to read later.

`bsg_amo_prefetch` uses `amoor.w`, but with an operand of 0 so it doesn't disturb data. However, the cache doesn't know this so it pollutes the dirty bit. Therefore, `bsg_amo_prefetch` should only be used to verify prefetching behavior. In the statistics parser, correct use of `bsg_amo_prefetch` will drive the load/store miss rate to 0

After verifying behavior with `bsg_amo_prefetch` replace all instances with `bsg_lw_prefetch`

* bsg_amo_prefetch and bsg_lw_prefetch both target x0 to avoid architectural dependencies
* Use amo to verify behavioral functionality of preloads, then lw in performance code since amo marks cache lines as dirty