### PR TITLE
Fixes #648

### DIFF
--- a/software/mk/Makefile.llvminstall
+++ b/software/mk/Makefile.llvminstall
@@ -32,12 +32,12 @@ ifndef GENERATOR
   endif
 endif
 
-llvm-install:
+
+
+llvm-install: $(LLVM_DIR)/llvm-src
 	mkdir -p $(LLVM_DIR)/llvm-build && mkdir -p $(LLVM_DIR)/llvm-install
 	# Get LLVM sources
-	cd $(LLVM_DIR) && \
-    git clone https://github.com/bespoke-silicon-group/llvm-project.git ./llvm-src && \
-    cd ./llvm-src && git fetch && git checkout hb-dev
+	cd $(LLVM_DIR)/llvm-src && git stash && git fetch && git checkout hb-dev && git apply $(PATCH_DIR)/llvm-gcc11.patch
 	# Install only X86 and RISCV targets
 	cd $(LLVM_DIR)/llvm-build \
 	    && $(CMAKE) -G $(GENERATOR) -DCMAKE_BUILD_TYPE="Debug" \
@@ -51,3 +51,7 @@ llvm-install:
 	    -DLLVM_OPTIMIZED_TABLEGEN=True \
 	    ../llvm-src/llvm
 	cd  $(LLVM_DIR)/llvm-build && $(CMAKE) --build . --target install -- -j 12
+
+$(LLVM_DIR)/llvm-src:
+	cd $(LLVM_DIR) && \
+    git clone https://github.com/bespoke-silicon-group/llvm-project.git ./llvm-src

--- a/software/riscv-tools/Makefile
+++ b/software/riscv-tools/Makefile
@@ -155,7 +155,7 @@ build-llvm:
 	@echo "====================================="
 	@echo "Building $(LLVM_DIR)..."
 	@echo "====================================="
-	$(MAKE) -C ../mk/ -f Makefile.llvminstall LLVM_DIR=$(LLVM_DIR) RISCV_INSTALL_DIR=$(RISCV)
+	$(MAKE) -C ../mk/ -f Makefile.llvminstall PATCH_DIR=$(CURDIR) LLVM_DIR=$(LLVM_DIR) RISCV_INSTALL_DIR=$(RISCV)
 
 build-all: 
 	$(MAKE) build-deps 

--- a/software/riscv-tools/llvm-gcc11.patch
+++ b/software/riscv-tools/llvm-gcc11.patch
@@ -1,0 +1,12 @@
+diff --git a/llvm/utils/benchmark/src/benchmark_register.h b/llvm/utils/benchmark/src/benchmark_register.h
+index 0705e219f2fa..6001fb8e0e48 100644
+--- a/llvm/utils/benchmark/src/benchmark_register.h
++++ b/llvm/utils/benchmark/src/benchmark_register.h
+@@ -2,6 +2,7 @@
+ #define BENCHMARK_REGISTER_H
+ 
+ #include <vector>
++#include <limits>
+ 
+ #include "check.h"
+ 


### PR DESCRIPTION
Patches to include `<limits>` so LLVM compiles on GCC 11; minor change to avoid cloning LLVM every time.