### PR TITLE
Spacetime Heatmap

### DIFF
--- a/software/py/remote_prof.py
+++ b/software/py/remote_prof.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+import math
+import argparse
+import pandas as pd
+import re
+from pathlib import Path
+import seaborn as sns
+sns.set()
+import matplotlib as plt
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+# Tommy, you can change this to point to different files.
+p = "remote_load_trace.csv"
+
+df = pd.read_csv(p)
+
+df = df[df.type != "icache"]
+df = df[df.dest_y != 0] # Filter host packets
+
+
+df = df[(df.dest_y == df.dest_y.min()) | (df.dest_y == df.dest_y.max())]
+
+#df = df[df.start_cycle > 1246542]
+
+#df = df[df.start_cycle < np.Inf]
+
+# Bin the CSV entries
+stdf = df
+nbins = 1000
+bins = pd.cut(stdf.start_cycle,bins=nbins, precision = 0)
+
+stdf = stdf.groupby([bins, "dest_y", "dest_x"]).size()
+stdf = stdf.unstack(level=0)
+
+# Set up figure formatting
+# Rows per Inch
+rpi = 4
+height = len(stdf.index) / rpi
+# Columns per inch
+cpi = 18
+width = len(stdf.columns) / cpi
+
+fig = plt.figure(figsize=(width, height))
+ax = sns.heatmap(stdf, cbar_kws={'label': 'Number of Requests'})
+ax.tick_params(axis='x', labelsize=10)
+ax.tick_params(axis='y', labelsize=10)
+ax.set_xlabel(f"Cycle Range ({nbins} bins of {bins[bins.index[0]].right - bins[bins.index[0]].left} Cycles)")
+ax.set_ylabel(f"Cache Location (Y-X)")
+ax.set_title(f"HammerBlade Spacetime Request Heatmap")
+
+plt.tight_layout()
+fig.savefig("request_heatmap.pdf")
+plt.close(fig)
+
+
+
+
+ldf = df.copy()
+ldf = ldf[ldf.type != "write"]
+ldf = ldf.fillna(0)
+ldf.latency = ldf.latency.astype(int)
+
+nbins = 1000
+bins = pd.cut(ldf.start_cycle, bins=nbins, precision = 0)
+# TODO: Find out why reported latency is so high on some of these requests.
+ldf.latency = ldf.latency.apply(lambda x: 1000 if x > 1000 else x)
+ldf = ldf.groupby([bins, "dest_y", "dest_x"]).latency.max()
+ldf = ldf.unstack(level=0)
+ldf = ldf.fillna(0)
+
+# Rows per Inch
+rpi = 4
+height = len(stdf.index) / rpi
+# Columns per inch
+cpi = 18
+width = len(stdf.columns) / cpi
+
+fig = plt.figure(figsize=(width, height))
+ax = sns.heatmap(ldf, cbar_kws={'label': 'Max Latency of Requests in Bin'})
+ax.tick_params(axis='x', labelsize=10)
+ax.tick_params(axis='y', labelsize=10)
+ax.set_xlabel(f"Cycle Range ({nbins} bins of {bins[bins.index[0]].right - bins[bins.index[0]].left} Cycles)")
+ax.set_ylabel(f"Cache Location (Y,X)")
+ax.set_title(f"HammerBlade Spacetime Max Latency Heatmap")
+
+plt.tight_layout()
+fig.savefig("maxlat_heatmap.pdf")
+plt.close(fig)
+
+
+
+
+ldf = df.copy()
+ldf = ldf[ldf.type != "write"]
+ldf = ldf.fillna(0)
+ldf.latency = ldf.latency.astype(int)
+
+nbins = 1000
+bins = pd.cut(ldf.start_cycle, bins=nbins, precision = 0)
+ldf.latency = ldf.latency.apply(lambda x: 1000 if x > 1000 else x)
+ldf = ldf.groupby([bins, "dest_y", "dest_x"]).latency.mean()
+ldf = ldf.unstack(level=0)
+ldf = ldf.fillna(0)
+
+# Rows per Inch
+rpi = 4
+height = len(stdf.index) / rpi
+# Columns per inch
+cpi = 18
+width = len(stdf.columns) / cpi
+
+fig = plt.figure(figsize=(width, height))
+ax = sns.heatmap(ldf, cbar_kws={'label': 'Mean Latency of Requests in Bin'})
+ax.tick_params(axis='x', labelsize=10)
+ax.tick_params(axis='y', labelsize=10)
+ax.set_xlabel(f"Cycle Range ({nbins} bins of {bins[bins.index[0]].right - bins[bins.index[0]].left} Cycles)")
+ax.set_ylabel(f"Cache Location (Y,X)")
+ax.set_title(f"HammerBlade Spacetime Mean Latency Heatmap")
+
+plt.tight_layout()
+fig.savefig("meanlat_heatmap.pdf")
+plt.close(fig)
+
+
+
+
+

--- a/software/py/remote_prof.py
+++ b/software/py/remote_prof.py
@@ -15,11 +15,27 @@ parser = argparse.ArgumentParser(description="Argument parser for the HB Spaceti
 parser.add_argument("-s", "--source", default=[], action="append", help="Source tile y,x for remote requests. Can specify multiple.")
 parser.add_argument("--first", default=0, type=int, help="First Cycle for Spacetime Graph")
 parser.add_argument("--last", default=np.Inf, type=int, help="Last Cycle for Spacetime Graph")
+parser.add_argument("--cycbin", default=None, type=int, help="Cycles per Bin in Heatmap. Cannot specify both --cycbin and --nbins simultaneously.")
+parser.add_argument("--nbins", default=None, type=int, help="Number of Bins in Heatmap. Cannot specify both --cycbin and --nbins simultaneously.")
+
 args = parser.parse_args()
 args.source = set(tuple(map(int, c.split(","))) for c in args.source)
 
+if(args.cycbin and args.nbins):
+    print("Error! Cannot specify --cycbin and --nbins simultaneously")
+    exit(1)
+if(not args.nbins):
+    args.nbins = 1000
 
-# Tommy, you can change this to point to different files.
+# Set up figure formatting
+# Rows per Inch
+rpi = 4
+# Columns per inch
+cpi = 40
+
+lsy = 10
+lsx = 8
+    
 p = "remote_load_trace.csv"
 
 df = pd.read_csv(p)
@@ -40,61 +56,59 @@ df = df[df.start_cycle < args.last]
 
 # Bin the CSV entries
 stdf = df
-nbins = 1000
-bins = pd.cut(stdf.start_cycle,bins=nbins, precision = 0)
+
+# Create bins
+if(args.cycbin):
+    f = args.cycbin
+else:
+    f = int((stdf.start_cycle.max() - stdf.start_cycle.min()) / args.nbins)
+
+r = pd.interval_range(start = stdf.start_cycle.min(), end = stdf.start_cycle.max(), freq = f)
+bins = pd.cut(stdf.start_cycle, bins=r, precision=1)
 
 stdf = stdf.groupby([bins, "dest_y", "dest_x"]).size()
 stdf = stdf.unstack(level=0)
 
-# Set up figure formatting
-# Rows per Inch
-rpi = 4
 height = len(stdf.index) / rpi
-# Columns per inch
-cpi = 18
 width = len(stdf.columns) / cpi
 
 fig = plt.figure(figsize=(width, height))
 ax = sns.heatmap(stdf, cbar_kws={'label': 'Number of Requests'})
-ax.tick_params(axis='x', labelsize=10)
-ax.tick_params(axis='y', labelsize=10)
-ax.set_xlabel(f"Cycle Range ({nbins} bins of {bins[bins.index[0]].right - bins[bins.index[0]].left} Cycles)")
+ax.tick_params(axis='x', labelsize=lsx)
+ax.tick_params(axis='y', labelsize=lsy)
+
+ax.set_xlabel(f"Cycle Range ({len(stdf.columns)} bins of {f} Cycles)")
 ax.set_ylabel(f"Cache Location (Y-X)")
-ax.set_title(f"HammerBlade Spacetime Request Heatmap")
+ax.set_title(f"HammerBlade Spacetime Read & Write Request Heatmap")
 
 plt.tight_layout()
 fig.savefig("request_heatmap.pdf")
 plt.close(fig)
 
 
-
 ldf = df.copy()
 ldf = ldf[ldf.type != "write"]
 ldf = ldf.fillna(0)
 ldf.latency = ldf.latency.astype(int)
-
-nbins = 1000
-bins = pd.cut(ldf.start_cycle, bins=nbins, precision = 0)
+r = pd.interval_range(start = ldf.start_cycle.min(), end = ldf.start_cycle.max(), freq = f)
+bins = pd.cut(ldf.start_cycle, bins = r, precision=0)
+#pd.IntervalIndex([*filter(lambda i: i.left < ldf.start_cycle.max(), bins)], retbins =True)
 # TODO: Find out why reported latency is so high on some of these requests.
 ldf.latency = ldf.latency.apply(lambda x: 1000 if x > 1000 else x)
 ldf = ldf.groupby([bins, "dest_y", "dest_x"]).latency.max()
 ldf = ldf.unstack(level=0)
 ldf = ldf.fillna(0)
 
-# Rows per Inch
-rpi = 4
-height = len(stdf.index) / rpi
-# Columns per inch
-cpi = 18
-width = len(stdf.columns) / cpi
+height = len(ldf.index) / rpi
+width = len(ldf.columns) / cpi
 
 fig = plt.figure(figsize=(width, height))
-ax = sns.heatmap(ldf, cbar_kws={'label': 'Max Latency of Requests in Bin'})
-ax.tick_params(axis='x', labelsize=10)
-ax.tick_params(axis='y', labelsize=10)
-ax.set_xlabel(f"Cycle Range ({nbins} bins of {bins[bins.index[0]].right - bins[bins.index[0]].left} Cycles)")
+ax = sns.heatmap(ldf, cbar_kws={'label': 'Max Latency of Read Requests in Bin'})
+ax.tick_params(axis='x', labelsize=lsx)
+ax.tick_params(axis='y', labelsize=lsy)
+ax.set_xlabel(f"Cycle Range ({len(ldf.columns)} bins of {f} Cycles)")
 ax.set_ylabel(f"Cache Location (Y,X)")
-ax.set_title(f"HammerBlade Spacetime Max Latency Heatmap")
+ax.set_title(f"HammerBlade Spacetime Max Read Latency Heatmap")
 
 plt.tight_layout()
 fig.savefig("maxlat_heatmap.pdf")
@@ -108,27 +122,23 @@ ldf = ldf[ldf.type != "write"]
 ldf = ldf.fillna(0)
 ldf.latency = ldf.latency.astype(int)
 
-nbins = 1000
-bins = pd.cut(ldf.start_cycle, bins=nbins, precision = 0)
+r = pd.interval_range(start = ldf.start_cycle.min(), end = ldf.start_cycle.max(), freq = f)
+bins = pd.cut(ldf.start_cycle, bins = r, precision=0)
 ldf.latency = ldf.latency.apply(lambda x: 1000 if x > 1000 else x)
 ldf = ldf.groupby([bins, "dest_y", "dest_x"]).latency.mean()
 ldf = ldf.unstack(level=0)
 ldf = ldf.fillna(0)
 
-# Rows per Inch
-rpi = 4
-height = len(stdf.index) / rpi
-# Columns per inch
-cpi = 18
-width = len(stdf.columns) / cpi
+height = len(ldf.index) / rpi
+width = len(ldf.columns) / cpi
 
 fig = plt.figure(figsize=(width, height))
-ax = sns.heatmap(ldf, cbar_kws={'label': 'Mean Latency of Requests in Bin'})
-ax.tick_params(axis='x', labelsize=10)
-ax.tick_params(axis='y', labelsize=10)
-ax.set_xlabel(f"Cycle Range ({nbins} bins of {bins[bins.index[0]].right - bins[bins.index[0]].left} Cycles)")
+ax = sns.heatmap(ldf, cbar_kws={'label': 'Mean Latency of Read Requests in Bin'})
+ax.tick_params(axis='x', labelsize=lsx)
+ax.tick_params(axis='y', labelsize=lsy)
+ax.set_xlabel(f"Cycle Range ({len(ldf.columns)} bins of {f} Cycles)")
 ax.set_ylabel(f"Cache Location (Y,X)")
-ax.set_title(f"HammerBlade Spacetime Mean Latency Heatmap")
+ax.set_title(f"HammerBlade Spacetime Mean Read Latency Heatmap")
 
 plt.tight_layout()
 fig.savefig("meanlat_heatmap.pdf")

--- a/software/py/remote_prof.py
+++ b/software/py/remote_prof.py
@@ -68,12 +68,14 @@ bins = pd.cut(stdf.start_cycle, bins=r, precision=1)
 
 stdf = stdf.groupby([bins, "dest_y", "dest_x"]).size()
 stdf = stdf.unstack(level=0)
+stdf = 100.0 *(stdf/f)
 
 height = len(stdf.index) / rpi
 width = len(stdf.columns) / cpi
 
+print()
 fig = plt.figure(figsize=(width, height))
-ax = sns.heatmap(stdf, cbar_kws={'label': 'Number of Requests'})
+ax = sns.heatmap(stdf, cbar_kws={'label': 'Percent of Cache Request Bandwidth (# Requests / # of Cycles in bin)'}, vmin =0, vmax=max(stdf.max().max(), 100.00))
 ax.tick_params(axis='x', labelsize=lsx)
 ax.tick_params(axis='y', labelsize=lsy)
 

--- a/software/py/remote_prof.py
+++ b/software/py/remote_prof.py
@@ -17,7 +17,131 @@ parser.add_argument("--first", default=0, type=int, help="First Cycle for Spacet
 parser.add_argument("--last", default=np.Inf, type=int, help="Last Cycle for Spacetime Graph")
 parser.add_argument("--cycbin", default=None, type=int, help="Cycles per Bin in Heatmap. Cannot specify both --cycbin and --nbins simultaneously.")
 parser.add_argument("--nbins", default=None, type=int, help="Number of Bins in Heatmap. Cannot specify both --cycbin and --nbins simultaneously.")
+parser.add_argument("--filename", default="./remote_load_trace.csv", type=str, help="Remote Load Trace CSV File")
 
+# Figure formatting parameters
+# Rows per Inch
+ROWS_PER_INCH = 4
+# Columns per inch
+COLS_PER_INCH = 40
+# Labelsize y/x
+LABELSIZE_Y = 10
+LABELSIZE_X = 8
+
+# It isn't useful to show huge latencies since it changes the heatmap
+# scale. Use this to cap the maximum latency in a bin when plotting.
+MAX_LATENCY = 1000
+
+# Writes (normalized) request heatmap. Assumes each cache can process
+# 1 READ OR WRITE request on each cycle.
+def write_heatmap_req(df, f):
+    # Create Bins
+    r = pd.interval_range(start = df.start_cycle.min(), end = df.start_cycle.max(), freq = f)
+    bins = pd.cut(df.start_cycle, bins=r, precision=1)
+    
+    # Bin, and count number of requests in each bin
+    df = df.groupby([bins, "dest_y", "dest_x"]).size()
+    df = df.unstack(level=0)
+
+    # Normalize by dividing by cache bandwidth
+    df = 100.0 *(df/f)
+    
+    # Generate Figure
+    height = len(df.index) / ROWS_PER_INCH
+    width = len(df.columns) / COLS_PER_INCH
+    
+    fig = plt.figure(figsize=(width, height))
+    ax = sns.heatmap(df, cbar_kws={'label': 'Percent of Cache Request Bandwidth (# Requests / # of Cycles in bin)'}, vmin =0, vmax=max(df.max().max(), 100.00))
+    ax.tick_params(axis='x', labelsize=LABELSIZE_X)
+    ax.tick_params(axis='y', labelsize=LABELSIZE_Y)
+    
+    ax.set_xlabel(f"Cycle Range ({len(df.columns)} bins of {f} Cycles)")
+    ax.set_ylabel(f"Cache Location (Y-X)")
+    ax.set_title(f"HammerBlade Spacetime Read & Write Request Heatmap")
+    
+    plt.tight_layout()
+    fig.savefig("request_heatmap.pdf")
+    plt.close(fig)
+
+
+# Writes mean read latency heatmap. Takes the maximum write latency of
+# each request in each bucket. Writes are ignored since there is no way
+# to track the latency of write responses
+def write_heatmap_maxlat(df, f):
+    # Remove write requests, since they do not have a valid latency
+    df = df[df.type != "write"]
+    df = df.fillna(0)
+    df.latency = df.latency.astype(int)
+
+    # Create Bins
+    r = pd.interval_range(start = df.start_cycle.min(), end = df.start_cycle.max(), freq = f)
+    bins = pd.cut(df.start_cycle, bins = r, precision=0)
+
+    # TODO: Find out why reported latency is so high on some of these requests.
+    df.latency = df.latency.apply(lambda x: MAX_LATENCY if x > MAX_LATENCY else x)
+
+    # Bin, and determine max in each bin
+    df = df.groupby([bins, "dest_y", "dest_x"]).latency.max()
+    df = df.unstack(level=0)
+    df = df.fillna(0)
+
+    # Generate Figure
+    height = len(df.index) / ROWS_PER_INCH
+    width = len(df.columns) / COLS_PER_INCH
+
+    fig = plt.figure(figsize=(width, height))
+    ax = sns.heatmap(df, cbar_kws={'label': 'Max Latency of Read Requests in Bin'})
+    ax.tick_params(axis='x', labelsize=LABELSIZE_X)
+    ax.tick_params(axis='y', labelsize=LABELSIZE_Y)
+    ax.set_xlabel(f"Cycle Range ({len(df.columns)} bins of {f} Cycles)")
+    ax.set_ylabel(f"Cache Location (Y,X)")
+    ax.set_title(f"HammerBlade Spacetime Max Read Latency Heatmap")
+
+    plt.tight_layout()
+    fig.savefig("maxlat_heatmap.pdf")
+    plt.close(fig)
+
+
+
+# Writes max read latency heatmap. Takes the maximum write latency of
+# each request in each bucket. Writes are ignored since there is no way
+# to track the latency of write responses
+def write_heatmap_meanlat(df, f):
+    # Remove write requests, since they do not have a valid latency
+    df = df[df.type != "write"]
+    df = df.fillna(0)
+    df.latency = df.latency.astype(int)
+
+    # Create Bins
+    r = pd.interval_range(start = df.start_cycle.min(), end = df.start_cycle.max(), freq = f)
+    bins = pd.cut(df.start_cycle, bins = r, precision=0)
+
+    # TODO: Find out why reported latency is so high on some of these requests.
+    df.latency = df.latency.apply(lambda x: MAX_LATENCY if x > MAX_LATENCY else x)
+
+    # Bin, and determine max in each bin
+    df = df.groupby([bins, "dest_y", "dest_x"]).latency.mean()
+    df = df.unstack(level=0)
+    df = df.fillna(0)
+    
+    # Generate Figure
+    height = len(df.index) / ROWS_PER_INCH
+    width = len(df.columns) / COLS_PER_INCH
+    
+    fig = plt.figure(figsize=(width, height))
+    ax = sns.heatmap(df, cbar_kws={'label': 'Mean Latency of Read Requests in Bin'})
+    ax.tick_params(axis='x', labelsize=LABELSIZE_X)
+    ax.tick_params(axis='y', labelsize=LABELSIZE_Y)
+    ax.set_xlabel(f"Cycle Range ({len(df.columns)} bins of {f} Cycles)")
+    ax.set_ylabel(f"Cache Location (Y,X)")
+    ax.set_title(f"HammerBlade Spacetime Mean Read Latency Heatmap")
+    
+    plt.tight_layout()
+    fig.savefig("meanlat_heatmap.pdf")
+    plt.close(fig)
+
+
+# Parse Arguments
 args = parser.parse_args()
 args.source = set(tuple(map(int, c.split(","))) for c in args.source)
 
@@ -27,126 +151,32 @@ if(args.cycbin and args.nbins):
 if(not args.nbins):
     args.nbins = 1000
 
-# Set up figure formatting
-# Rows per Inch
-rpi = 4
-# Columns per inch
-cpi = 40
+# Create DataFrame
+df = pd.read_csv(args.filename)
 
-lsy = 10
-lsx = 8
-    
-p = "remote_load_trace.csv"
-
-df = pd.read_csv(p)
-
+# Filter requests.
+# 1. Remove icache requests
+# 2. Remove packets to host
+# 3. Keep cache packets
 df = df[df.type != "icache"]
 df = df[df.dest_y != 0] # Filter host packets
-
 df = df[(df.dest_y == df.dest_y.min()) | (df.dest_y == df.dest_y.max())]
 
-# Filter out specified sources
+# 4. Filter outside of first/last cycle
+df = df[df.start_cycle > args.first]
+df = df[df.start_cycle < args.last]
+
+# If a source was specified, filter out all other sources
 if(args.source != set()):
     srcs = (df.src_y.combine(df.src_x, lambda y,x: (int(y),int(x))))
     df = df[srcs.apply(lambda l: l in args.source)]
 
-# Filter outside of first/last cycle
-df = df[df.start_cycle > args.first]
-df = df[df.start_cycle < args.last]
-
-# Bin the CSV entries
-stdf = df
-
-# Create bins
+# Determine bin duration (aka Frequency)
 if(args.cycbin):
     f = args.cycbin
 else:
-    f = int((stdf.start_cycle.max() - stdf.start_cycle.min()) / args.nbins)
+    f = int((df.start_cycle.max() - df.start_cycle.min()) / args.nbins)
 
-r = pd.interval_range(start = stdf.start_cycle.min(), end = stdf.start_cycle.max(), freq = f)
-bins = pd.cut(stdf.start_cycle, bins=r, precision=1)
-
-stdf = stdf.groupby([bins, "dest_y", "dest_x"]).size()
-stdf = stdf.unstack(level=0)
-stdf = 100.0 *(stdf/f)
-
-height = len(stdf.index) / rpi
-width = len(stdf.columns) / cpi
-
-print()
-fig = plt.figure(figsize=(width, height))
-ax = sns.heatmap(stdf, cbar_kws={'label': 'Percent of Cache Request Bandwidth (# Requests / # of Cycles in bin)'}, vmin =0, vmax=max(stdf.max().max(), 100.00))
-ax.tick_params(axis='x', labelsize=lsx)
-ax.tick_params(axis='y', labelsize=lsy)
-
-ax.set_xlabel(f"Cycle Range ({len(stdf.columns)} bins of {f} Cycles)")
-ax.set_ylabel(f"Cache Location (Y-X)")
-ax.set_title(f"HammerBlade Spacetime Read & Write Request Heatmap")
-
-plt.tight_layout()
-fig.savefig("request_heatmap.pdf")
-plt.close(fig)
-
-
-ldf = df.copy()
-ldf = ldf[ldf.type != "write"]
-ldf = ldf.fillna(0)
-ldf.latency = ldf.latency.astype(int)
-r = pd.interval_range(start = ldf.start_cycle.min(), end = ldf.start_cycle.max(), freq = f)
-bins = pd.cut(ldf.start_cycle, bins = r, precision=0)
-#pd.IntervalIndex([*filter(lambda i: i.left < ldf.start_cycle.max(), bins)], retbins =True)
-# TODO: Find out why reported latency is so high on some of these requests.
-ldf.latency = ldf.latency.apply(lambda x: 1000 if x > 1000 else x)
-ldf = ldf.groupby([bins, "dest_y", "dest_x"]).latency.max()
-ldf = ldf.unstack(level=0)
-ldf = ldf.fillna(0)
-
-height = len(ldf.index) / rpi
-width = len(ldf.columns) / cpi
-
-fig = plt.figure(figsize=(width, height))
-ax = sns.heatmap(ldf, cbar_kws={'label': 'Max Latency of Read Requests in Bin'})
-ax.tick_params(axis='x', labelsize=lsx)
-ax.tick_params(axis='y', labelsize=lsy)
-ax.set_xlabel(f"Cycle Range ({len(ldf.columns)} bins of {f} Cycles)")
-ax.set_ylabel(f"Cache Location (Y,X)")
-ax.set_title(f"HammerBlade Spacetime Max Read Latency Heatmap")
-
-plt.tight_layout()
-fig.savefig("maxlat_heatmap.pdf")
-plt.close(fig)
-
-
-
-
-ldf = df.copy()
-ldf = ldf[ldf.type != "write"]
-ldf = ldf.fillna(0)
-ldf.latency = ldf.latency.astype(int)
-
-r = pd.interval_range(start = ldf.start_cycle.min(), end = ldf.start_cycle.max(), freq = f)
-bins = pd.cut(ldf.start_cycle, bins = r, precision=0)
-ldf.latency = ldf.latency.apply(lambda x: 1000 if x > 1000 else x)
-ldf = ldf.groupby([bins, "dest_y", "dest_x"]).latency.mean()
-ldf = ldf.unstack(level=0)
-ldf = ldf.fillna(0)
-
-height = len(ldf.index) / rpi
-width = len(ldf.columns) / cpi
-
-fig = plt.figure(figsize=(width, height))
-ax = sns.heatmap(ldf, cbar_kws={'label': 'Mean Latency of Read Requests in Bin'})
-ax.tick_params(axis='x', labelsize=lsx)
-ax.tick_params(axis='y', labelsize=lsy)
-ax.set_xlabel(f"Cycle Range ({len(ldf.columns)} bins of {f} Cycles)")
-ax.set_ylabel(f"Cache Location (Y,X)")
-ax.set_title(f"HammerBlade Spacetime Mean Read Latency Heatmap")
-
-plt.tight_layout()
-fig.savefig("meanlat_heatmap.pdf")
-plt.close(fig)
-
-
-
-
-
+write_heatmap_req(df, f)
+write_heatmap_meanlat(df, f)
+write_heatmap_maxlat(df, f)

--- a/software/py/remote_prof.py
+++ b/software/py/remote_prof.py
@@ -18,6 +18,7 @@ parser.add_argument("--last", default=np.Inf, type=int, help="Last Cycle for Spa
 args = parser.parse_args()
 args.source = set(tuple(map(int, c.split(","))) for c in args.source)
 
+
 # Tommy, you can change this to point to different files.
 p = "remote_load_trace.csv"
 
@@ -29,7 +30,7 @@ df = df[df.dest_y != 0] # Filter host packets
 df = df[(df.dest_y == df.dest_y.min()) | (df.dest_y == df.dest_y.max())]
 
 # Filter out specified sources
-if(args.source != []):
+if(args.source != set()):
     srcs = (df.src_y.combine(df.src_x, lambda y,x: (int(y),int(x))))
     df = df[srcs.apply(lambda l: l in args.source)]
 


### PR DESCRIPTION
This python script parses remote_load_trace.csv. It produces three outputs: 

`request_heatmap.pdf`: A heatmap showing cache bandwidth utilization of LOAD and STORE requests issued to each cache within a series of time windows (bins). The bandwidth utilization is shown as a percent in the heatmap so that heatmaps can be compared.
`meanlat_heatmap.pdf`: A heatmap showing mean latency of all LOADS issued to each cache within a series of time windows (bins).
`maxnlat_heatmap.pdf`: A heatmap showing mean latency of all LOADS issued to each cache within a series of time windows (bins).

Examples are attached.

```
usage: remote_prof.py [-h] [-s SOURCE] [--first FIRST] [--last LAST]
                      [--cycbin CYCBIN] [--nbins NBINS] [--filename FILENAME]

Argument parser for the HB Spacetime Heatmap (Remote Load Profiler)

optional arguments:
  -h, --help            show this help message and exit
  -s SOURCE, --source SOURCE
                        Source tile y,x for remote requests. Can specify
                        multiple.
  --first FIRST         First Cycle for Spacetime Graph
  --last LAST           Last Cycle for Spacetime Graph
  --cycbin CYCBIN       Cycles per Bin in Heatmap. Cannot specify both
                        --cycbin and --nbins simultaneously.
  --nbins NBINS         Number of Bins in Heatmap. Cannot specify both
                        --cycbin and --nbins simultaneously.
  --filename FILENAME   Remote Load Trace CSV File
```
[maxlat_heatmap.pdf](https://github.com/bespoke-silicon-group/bsg_manycore/files/8766111/maxlat_heatmap.pdf)
[meanlat_heatmap.pdf](https://github.com/bespoke-silicon-group/bsg_manycore/files/8766112/meanlat_heatmap.pdf)
[request_heatmap.pdf](https://github.com/bespoke-silicon-group/bsg_manycore/files/8766114/request_heatmap.pdf)