### PR TITLE
Merge tag tracking logic from Replicant

### DIFF
--- a/machines/sim_filelist.mk
+++ b/machines/sim_filelist.mk
@@ -75,6 +75,7 @@ VSOURCES += $(BSG_MANYCORE_DIR)/testbenches/common/v/bsg_nonsynth_manycore_io_co
 VSOURCES += $(BSG_MANYCORE_DIR)/testbenches/common/v/bsg_nonsynth_manycore_spmd_loader.v
 VSOURCES += $(BSG_MANYCORE_DIR)/testbenches/common/v/bsg_nonsynth_manycore_monitor.v
 VSOURCES += $(BSG_MANYCORE_DIR)/testbenches/common/v/bsg_nonsynth_wormhole_test_mem.v
+VSOURCES += $(BSG_MANYCORE_DIR)/testbenches/common/v/bsg_print_stat_snoop.v
 VSOURCES += $(BSG_MANYCORE_DIR)/testbenches/common/v/bsg_nonsynth_manycore_testbench.v
 VSOURCES += $(BSG_MANYCORE_DIR)/testbenches/common/v/vcache_dma_to_dram_channel_map.v
 VSOURCES += $(BSG_MANYCORE_DIR)/testbenches/common/v/spmd_testbench.v

--- a/testbenches/common/v/bsg_nonsynth_manycore_io_complex.v
+++ b/testbenches/common/v/bsg_nonsynth_manycore_io_complex.v
@@ -40,8 +40,6 @@ module bsg_nonsynth_manycore_io_complex
     , input [link_sif_width_lp-1:0] io_link_sif_i
     , output [link_sif_width_lp-1:0] io_link_sif_o
 
-    , output logic print_stat_v_o
-    , output logic [data_width_p-1:0] print_stat_tag_o
   );
 
 
@@ -145,9 +143,6 @@ module bsg_nonsynth_manycore_io_complex
 
     ,.data_o(returning_data_li)
     ,.v_o(returning_v_li) 
-
-    ,.print_stat_v_o(print_stat_v_o)
-    ,.print_stat_tag_o(print_stat_tag_o)
   );
 
   // SPMD loader

--- a/testbenches/common/v/bsg_nonsynth_manycore_monitor.v
+++ b/testbenches/common/v/bsg_nonsynth_manycore_monitor.v
@@ -41,9 +41,6 @@ module bsg_nonsynth_manycore_monitor
     , output logic [data_width_p-1:0] data_o
     , output logic v_o
 
-
-    , output logic print_stat_v_o
-    , output logic [data_width_p-1:0] print_stat_tag_o
   );
 
   longint max_cycle;
@@ -269,11 +266,6 @@ module bsg_nonsynth_manycore_monitor
       end
     end
   end
-
-  // print stat trigger
-  //
-  assign print_stat_v_o = v_i & (epa_addr == bsg_print_stat_epa_gp);
-  assign print_stat_tag_o = data_i;
 
 endmodule
 

--- a/testbenches/common/v/bsg_nonsynth_manycore_testbench.v
+++ b/testbenches/common/v/bsg_nonsynth_manycore_testbench.v
@@ -564,8 +564,8 @@ module bsg_nonsynth_manycore_testbench
 
         ,.print_stat_clk_i    (clk_i)
         ,.print_stat_reset_i  (reset_r)
-        ,.print_stat_v_i      ($root.`HOST_MODULE_PATH.print_stat_v)
-        ,.print_stat_tag_i    ($root.`HOST_MODULE_PATH.print_stat_tag)
+        ,.print_stat_v_i      ($root.`HOST_MODULE_PATH.testbench.print_stat_v)
+        ,.print_stat_tag_i    ($root.`HOST_MODULE_PATH.testbench.print_stat_tag)
 
         ,.write_done_o        ()
         ,.write_done_ch_addr_o()
@@ -765,12 +765,26 @@ module bsg_nonsynth_manycore_testbench
     end
   end
   
+  logic print_stat_v;
+  logic [data_width_p-1:0] print_stat_tag;
 
+  bsg_print_stat_snoop #(
+    .data_width_p(data_width_p)
+    ,.addr_width_p(addr_width_p)
+    ,.x_cord_width_p(x_cord_width_p)
+    ,.y_cord_width_p(y_cord_width_p)
+    ,.enable_vcore_profiling_p(enable_vcore_profiling_p)
+  ) print_stat_snoop (
+    .clk_i(clk_i)
+    ,.reset_i(reset_i)
 
+    ,.manycore_link_sif_o_i(io_link_sif_o)
+    ,.host_link_sif_i_i(io_link_sif_i)
 
-
-
-
+    ,.global_ctr_i($root.`HOST_MODULE_PATH.global_ctr)
+    ,.print_stat_v_o(print_stat_v)
+    ,.print_stat_tag_o(print_stat_tag)
+  );
 
 
 //                  //
@@ -810,8 +824,8 @@ if (enable_vcore_profiling_p) begin
     .*
     ,.clk_i(clk_i)
     ,.global_ctr_i($root.`HOST_MODULE_PATH.global_ctr)
-    ,.print_stat_v_i($root.`HOST_MODULE_PATH.print_stat_v)
-    ,.print_stat_tag_i($root.`HOST_MODULE_PATH.print_stat_tag)
+    ,.print_stat_v_i($root.`HOST_MODULE_PATH.testbench.print_stat_v)
+    ,.print_stat_tag_i($root.`HOST_MODULE_PATH.testbench.print_stat_tag)
     ,.trace_en_i($root.`HOST_MODULE_PATH.trace_en)
   );
 end
@@ -854,8 +868,8 @@ if (enable_cache_profiling_p) begin
     ,.chosen_way_n(miss.chosen_way_n)
     // from testbench
     ,.global_ctr_i($root.`HOST_MODULE_PATH.global_ctr)
-    ,.print_stat_v_i($root.`HOST_MODULE_PATH.print_stat_v)
-    ,.print_stat_tag_i($root.`HOST_MODULE_PATH.print_stat_tag)
+    ,.print_stat_v_i($root.`HOST_MODULE_PATH.testbench.print_stat_v)
+    ,.print_stat_tag_i($root.`HOST_MODULE_PATH.testbench.print_stat_tag)
     ,.trace_en_i($root.`HOST_MODULE_PATH.trace_en)
   );
 
@@ -878,7 +892,7 @@ if (enable_router_profiling_p) begin
     ,.clk_i(clk_i)
     ,.global_ctr_i($root.`HOST_MODULE_PATH.global_ctr)
     ,.trace_en_i($root.`HOST_MODULE_PATH.trace_en)
-    ,.print_stat_v_i($root.`HOST_MODULE_PATH.print_stat_v)
+    ,.print_stat_v_i($root.`HOST_MODULE_PATH.testbench.print_stat_v)
   );
 end
 `endif

--- a/testbenches/common/v/bsg_print_stat_snoop.v
+++ b/testbenches/common/v/bsg_print_stat_snoop.v
@@ -1,0 +1,70 @@
+module bsg_print_stat_snoop
+  import bsg_manycore_pkg::*;
+  import bsg_manycore_addr_pkg::*;
+  import bsg_manycore_profile_pkg::*;
+  #(parameter data_width_p="inv"
+    , parameter addr_width_p="inv"
+    , parameter x_cord_width_p="inv"
+    , parameter y_cord_width_p="inv"
+    , parameter enable_vcore_profiling_p="inv"
+
+    , parameter link_sif_width_lp=
+      `bsg_manycore_link_sif_width(addr_width_p,data_width_p,x_cord_width_p,y_cord_width_p)
+  )
+  (
+   input clk_i
+   , input reset_i
+    // manycore side
+   , input [link_sif_width_lp-1:0] manycore_link_sif_o_i
+   , input [link_sif_width_lp-1:0] host_link_sif_i_i
+   , input [31:0] global_ctr_i
+
+   // snoop signals
+   , output logic print_stat_v_o
+   , output logic [data_width_p-1:0] print_stat_tag_o
+  );
+
+  localparam logfile_lp = "simple_stats.csv";
+
+  `declare_bsg_manycore_link_sif_s(addr_width_p,data_width_p,x_cord_width_p,y_cord_width_p);
+
+  bsg_manycore_link_sif_s manycore_link_sif_o;
+  bsg_manycore_link_sif_s host_link_sif_i;
+
+  assign manycore_link_sif_o = manycore_link_sif_o_i;
+  assign host_link_sif_i = host_link_sif_i_i;
+
+
+  `declare_bsg_manycore_packet_s(addr_width_p,data_width_p,x_cord_width_p,y_cord_width_p);
+  bsg_manycore_packet_s fwd_pkt;
+  assign fwd_pkt = manycore_link_sif_o.fwd.data;
+
+
+  assign print_stat_v_o = manycore_link_sif_o.fwd.v
+    & (fwd_pkt.addr == (bsg_print_stat_epa_gp >> 2)) & host_link_sif_i.fwd.ready_and_rev;
+  assign print_stat_tag_o = fwd_pkt.payload.data;
+
+  bsg_manycore_vanilla_core_stat_tag_s print_stat_tag;
+  assign print_stat_tag = print_stat_tag_o;
+
+  // Only print simple stats if profiling is disabled, so that exec
+  // and profile runs don't stomp on eachother.
+  if(enable_vcore_profiling_p == 0) begin
+    integer fd;
+
+    always @(negedge reset_i) begin
+       fd = $fopen(logfile_lp, "w");
+       $fwrite(fd, "time, cycle, y, x, tag\n");
+       $fclose(fd);
+    end
+
+    always @(negedge clk_i)  begin
+      // stat printing
+      if (~reset_i & print_stat_v_o) begin
+        fd = $fopen(logfile_lp, "a");
+        $fwrite(fd, "%0d,%0d,%0d,%0d,%0x\n", $time, global_ctr_i, fwd_pkt.src_y_cord, fwd_pkt.src_x_cord, print_stat_tag);
+        $fclose(fd);
+      end
+    end
+  end
+endmodule

--- a/testbenches/common/v/spmd_testbench.v
+++ b/testbenches/common/v/spmd_testbench.v
@@ -170,8 +170,6 @@ module spmd_testbench
 
 
   // SPMD LOADER
-  logic print_stat_v;
-  logic [data_width_p-1:0] print_stat_tag;
   bsg_nonsynth_manycore_io_complex #(
     .addr_width_p(addr_width_p)
     ,.data_width_p(data_width_p)
@@ -186,8 +184,6 @@ module spmd_testbench
     ,.reset_i(reset_r)
     ,.io_link_sif_i(io_link_sif_lo)
     ,.io_link_sif_o(io_link_sif_li)
-    ,.print_stat_v_o(print_stat_v)
-    ,.print_stat_tag_o(print_stat_tag)
     ,.loader_done_o()
   );
 


### PR DESCRIPTION
Supersedes [793](https://github.com/bespoke-silicon-group/bsg_replicant/pull/793)

When we run in no-profiling mode, we still get stats packets. This means we're throwing valuable timing information away, for a 4-5x faster runtime. Why not keep it? Why not emit the packet arrival time to a different file (simple_stats.csv), so that we can get faster runtimes but still have timing information? This is useful when we're gathering results, and not iterating.

From BSG Replicant:

_One of the more annoying aspects of the profiler is that it runs very slowly compared to non-profiled mode, and even pc-histogram mode. This is a problem, because the profiler is also a good way to get accurate execution timing for HB kernels._

_The intent of this PR is to create a "simple stats" file that gets generated during non-profiling runs. All it does is emit the arrival times and tags of statistics packets that arrive at the host interface. This can be parsed (separate script, still in development) to provide accurate timing information of kernels, without the performance hit of the profiler._

_My rough estimate is that this is 4-5x faster for long-running kernels. This will be especially helpful for obtaining results in minimal time._


This PR merges the module from BSG Replicant, and the changes from 793 so that we provide the same functionality in both repositories. If just make the change in replicant, nobody will get this benefit in manycore.

In this PR I removed some of the wires from spmd_testbench, and moved them into the bsg_nonsynth_manycore_testbench. Corresponding changes will be made in bsg_replicant. 


Two bits of weirdness. One, is that we now refer to some of the global scope wires inside of the testbench:
```
        ,.print_stat_v_i      ($root.`HOST_MODULE_PATH.testbench.print_stat_v)
        ,.print_stat_tag_i    ($root.`HOST_MODULE_PATH.testbench.print_stat_tag)
```

Instead of:

```
        ,.print_stat_v_i      ($root.`HOST_MODULE_PATH.print_stat_v)
        ,.print_stat_tag_i    ($root.`HOST_MODULE_PATH.print_stat_tag)
```


Second, is that the IO complex no longer tracks stats packets. I figured that the benefits of unified code, and 4-5x improvements mentioned above overcame these drawbacks. But, I'm open to other solutions.

* Move bsg_print_stat_snoop to bsg_manycore
* Add no-profile mode stat packet functionality
* Remove stat packet tracking from io_complex, monitor
* Instantiate bsg_print_stat_snoop in testbench
* Change bind paths