### PR TITLE
Update Makefile.builddefs

### DIFF
--- a/software/mk/Makefile.builddefs
+++ b/software/mk/Makefile.builddefs
@@ -164,7 +164,7 @@ endif
 LINK_SCRIPT ?= $(CURR_DIR)/bsg_link.ld
 
 $(CURR_DIR)/bsg_link.ld: $(LINK_GEN)
-	$(LINK_GEN) $(LINK_GEN_OPTS) --out=$@
+	python $(LINK_GEN) $(LINK_GEN_OPTS) --out=$@
 
 RISCV_LINK_OPTS ?= 
 


### PR DESCRIPTION
The current makefile uses the python file directly as executable, which is not compatible with all shells. This change explicitly invokes python to run it