### PR TITLE
Update bsg_nonsynth_manycore_testbench.v

### DIFF
--- a/testbenches/common/v/bsg_nonsynth_manycore_testbench.v
+++ b/testbenches/common/v/bsg_nonsynth_manycore_testbench.v
@@ -935,8 +935,9 @@ if (enable_vanilla_core_pc_histogram_p) begin
       )
   vcore_pc_hist
     (.*);
-`endif
 end // if (enable_vanilla_core_pc_histogram_p)
+`endif
+
 
 endmodule
 


### PR DESCRIPTION
This if is in the wrong order, breaking the verilator build