### PR TITLE
Allow router stat to print without turning on trace_en_i

### DIFF
--- a/testbenches/common/v/router_profiler.v
+++ b/testbenches/common/v/router_profiler.v
@@ -96,7 +96,7 @@ module router_profiler
 
   // when there is print_stat_v_i signal received, it dumps the stats.
   always @ (posedge clk_i) begin
-    if (~reset_i & trace_en_i & print_stat_v_i) begin
+    if (~reset_i & print_stat_v_i) begin
       fd = $fopen(tracefile_p, "a");
       for (integer i = 0; i < dirs_lp; i++) begin
         $fwrite(fd, "%0t,%0d,%0d,%0d,%0d,%0d,%0d,%0d,%0d,%0d\n", 


### PR DESCRIPTION
Router stat is not very heavy on file IO, and we still want to see it without turning on other traces that are actually heavy on file IO.