### PR TITLE
Fixes naming conventions for ready signals in bsg_manycore_link_to_ca…

### DIFF
--- a/v/bsg_manycore_link_to_cache.v
+++ b/v/bsg_manycore_link_to_cache.v
@@ -50,7 +50,7 @@ module bsg_manycore_link_to_cache
     // cache-side
     , output [bsg_cache_pkt_width_lp-1:0] cache_pkt_o
     , output logic v_o
-    , input ready_i
+    , input ready_and_i
 
     , input [data_width_p-1:0] data_i
     , input v_i
@@ -180,7 +180,7 @@ module bsg_manycore_link_to_cache
 
   always_ff @ (posedge clk_i) begin
     if (state_r == READY || state_r == IFETCH) begin
-      if (v_o & ready_i) begin
+      if (v_o & ready_and_i) begin
         tl_info_r <= '{
           pkt_type: return_pkt_type,
           reg_id : ((packet_lo.op_v2 == e_remote_store) | (packet_lo.op_v2 == e_cache_op)) 
@@ -245,7 +245,7 @@ module bsg_manycore_link_to_cache
         };
 
 
-        tagst_sent_n = (v_o & ready_i)
+        tagst_sent_n = (v_o & ready_and_i)
           ? tagst_sent_r + 1
           : tagst_sent_r;
         tagst_received_n = v_i
@@ -265,7 +265,7 @@ module bsg_manycore_link_to_cache
         v_o = packet_v_lo;
         packet_yumi_li = is_packet_ifetch
           ? 1'b0
-          : (packet_v_lo & ready_i);
+          : (packet_v_lo & ready_and_i);
     
 
         // if two MSBs are ones, then it maps to wh_dest_east_not_west.
@@ -284,7 +284,7 @@ module bsg_manycore_link_to_cache
           endcase
 
           // updated when nop packet is taken by the cache.
-          wh_dest_east_not_west_n = (packet_v_lo & ready_i)
+          wh_dest_east_not_west_n = (packet_v_lo & ready_and_i)
             ? packet_lo.payload[0]
             : wh_dest_east_not_west_r;
         end
@@ -378,15 +378,15 @@ module bsg_manycore_link_to_cache
         yumi_o = v_i & return_packet_ready_lo;
 
         
-        ifetch_count_up = (is_packet_ifetch & ready_i & packet_v_lo);
+        ifetch_count_up = (is_packet_ifetch & ready_and_i & packet_v_lo);
         state_n = is_packet_ifetch
-          ? ((ready_i & packet_v_lo) ? IFETCH : READY)
+          ? ((ready_and_i & packet_v_lo) ? IFETCH : READY)
           : READY;
       end
 
       IFETCH: begin
         v_o = packet_v_lo;
-        packet_yumi_li = packet_v_lo & ready_i & (ifetch_count_r == icache_block_size_in_words_p-1);
+        packet_yumi_li = packet_v_lo & ready_and_i & (ifetch_count_r == icache_block_size_in_words_p-1);
 
         cache_pkt.opcode = LW;
         cache_pkt.data = '0;
@@ -401,8 +401,8 @@ module bsg_manycore_link_to_cache
         return_packet_v_li = v_i;
         yumi_o = v_i & return_packet_ready_lo;
 
-        ifetch_count_up = (packet_v_lo & ready_i);
-        state_n = (packet_v_lo & ready_i)
+        ifetch_count_up = (packet_v_lo & ready_and_i);
+        state_n = (packet_v_lo & ready_and_i)
           ? ((ifetch_count_r == icache_block_size_in_words_p-1) 
             ? READY
             : IFETCH)

--- a/v/bsg_manycore_link_to_cache_non_blocking.v
+++ b/v/bsg_manycore_link_to_cache_non_blocking.v
@@ -42,7 +42,7 @@ module bsg_manycore_link_to_cache_non_blocking
     // cache side
     , output [cache_pkt_width_lp-1:0] cache_pkt_o
     , output logic v_o
-    , input ready_i
+    , input ready_and_i
   
     , input [data_width_p-1:0] data_i
     , input [id_width_lp-1:0] id_i
@@ -166,7 +166,7 @@ module bsg_manycore_link_to_cache_non_blocking
           {block_offset_width_lp{1'b0}}
         };
 
-        tagst_sent_n = (v_o & ready_i)
+        tagst_sent_n = (v_o & ready_and_i)
           ? tagst_sent_r + 1
           : tagst_sent_r;
 
@@ -186,7 +186,7 @@ module bsg_manycore_link_to_cache_non_blocking
 
         // cache pkt
         v_o = packet_v_lo;
-        packet_yumi_li = packet_v_lo & ready_i;
+        packet_yumi_li = packet_v_lo & ready_and_i;
         
         if (packet_lo.addr[addr_width_p-1]) begin
           case (packet_lo.op_v2)

--- a/v/bsg_manycore_tile_vcache.v
+++ b/v/bsg_manycore_tile_vcache.v
@@ -186,7 +186,7 @@ module bsg_manycore_tile_vcache
 
     ,.cache_pkt_o(cache_pkt)
     ,.v_o(cache_v_li)
-    ,.ready_i(cache_ready_lo)
+    ,.ready_and_i(cache_ready_lo)
 
     ,.data_i(cache_data_lo)
     ,.v_i(cache_v_lo)

--- a/v/bsg_manycore_vcache_blocking.v
+++ b/v/bsg_manycore_vcache_blocking.v
@@ -84,7 +84,7 @@ module bsg_manycore_vcache_blocking
 
     ,.cache_pkt_o(cache_pkt)
     ,.v_o(cache_v_li)
-    ,.ready_i(cache_ready_lo)
+    ,.ready_and_i(cache_ready_lo)
 
     ,.data_i(cache_data_lo)
     ,.v_i(cache_v_lo)

--- a/v/bsg_manycore_vcache_non_blocking.v
+++ b/v/bsg_manycore_vcache_non_blocking.v
@@ -109,7 +109,7 @@ module bsg_manycore_vcache_non_blocking
 
     ,.cache_pkt_o(cache_pkt)
     ,.v_o(cache_v_li)
-    ,.ready_i(cache_ready_lo)
+    ,.ready_and_i(cache_ready_lo)
 
     ,.v_i(fifo_v_lo)
     ,.id_i(fifo_id_lo)

--- a/v/vanilla_bean/fpu_fdiv_fsqrt.v
+++ b/v/vanilla_bean/fpu_fdiv_fsqrt.v
@@ -26,7 +26,7 @@ module fpu_fdiv_fsqrt
     , input [recoded_data_width_lp-1:0] fp_rs1_i
     , input [recoded_data_width_lp-1:0] fp_rs2_i
     , input fsqrt_i   // 0=fdiv, 1=fsqrt
-    , output logic ready_o
+    , output logic ready_and_o
 
     , output logic v_o
     , output logic [recoded_data_width_lp-1:0] result_o
@@ -71,7 +71,7 @@ module fpu_fdiv_fsqrt
  
   always_comb begin
     v_li = 1'b0;
-    ready_o = 1'b0;
+    ready_and_o = 1'b0;
     v_o = 1'b0;
     rd_n = rd_r;
     ds_state_n = ds_state_r;
@@ -80,12 +80,12 @@ module fpu_fdiv_fsqrt
 
       // wait for new input
       eIDLE: begin
-        ready_o = ready_lo;
+        ready_and_o = ready_lo;
         v_li = v_i;
-        rd_n = (ready_o & v_i)
+        rd_n = (ready_and_o & v_i)
           ? rd_i 
           : rd_r;
-        ds_state_n = (ready_o & v_i)
+        ds_state_n = (ready_and_o & v_i)
           ? eBUSY
           : eIDLE;
       end

--- a/v/vanilla_bean/idiv.v
+++ b/v/vanilla_bean/idiv.v
@@ -22,7 +22,7 @@ module idiv
     , input [reg_addr_width_p-1:0] rd_i
     // corresponds to instruction[13:12] or funct3[1:0]
     , input idiv_op_e op_i    
-    , output logic ready_o
+    , output logic ready_and_o
 
     , output logic v_o
     , output logic [reg_addr_width_p-1:0] rd_o
@@ -40,7 +40,7 @@ module idiv
     ,.reset_i(reset_i)
 
     ,.v_i(v_i)
-    ,.ready_and_o(ready_o)
+    ,.ready_and_o(ready_and_o)
 
     ,.dividend_i(rs1_i)
     ,.divisor_i(rs2_i)
@@ -62,7 +62,7 @@ module idiv
       rem_r <= 1'b0;
     end
     else begin
-      if (v_i & ready_o) begin
+      if (v_i & ready_and_o) begin
         rd_r <= rd_i;
         rem_r <= ((op_i == eREM) | (op_i == eREMU));
       end

--- a/v/vanilla_bean/vanilla_core.v
+++ b/v/vanilla_bean/vanilla_core.v
@@ -905,7 +905,7 @@ module vanilla_core
     ,.fp_rs1_i(fp_exe_data_r.rs1_val)
     ,.fp_rs2_i(fp_exe_data_r.rs2_val)
     ,.fsqrt_i(fp_exe_ctrl_r.fp_decode.is_fsqrt_op)
-    ,.ready_o(fdiv_fsqrt_ready_lo)
+    ,.ready_and_o(fdiv_fsqrt_ready_lo)
 
     ,.v_o(fdiv_fsqrt_v_lo)
     ,.result_o(fdiv_fsqrt_result_lo)


### PR DESCRIPTION
The ready_i signals in the bsg_manycore_link_to_cache modules are used as would be implied by a rv->& interface, assuming that bsg_cache's output signal represents a ready signal, which is currently under review as per this issue post: https://github.com/bespoke-silicon-group/basejump_stl/issues/605

In the meantime, I propose that these signals are being properly used with a ready_and interface and should therefore be named as such for clarity.