### PR TITLE
Update bsg_manycore_arch.h

### DIFF
--- a/software/bsg_manycore_lib/bsg_manycore_arch.h
+++ b/software/bsg_manycore_lib/bsg_manycore_arch.h
@@ -58,38 +58,38 @@
 
 // tile-group address pointer 
 #define bsg_remote_ptr(x,y,local_addr) \
-  ((bsg_remote_int_ptr) ( (1 << REMOTE_PREFIX_SHIFT) \
-                        | (y << REMOTE_Y_CORD_SHIFT) \
-                        | (x << REMOTE_X_CORD_SHIFT) \
+  ((bsg_remote_int_ptr) ( (1 << REMOTE_PREFIX_SHIFT)   \
+                        | ((y) << REMOTE_Y_CORD_SHIFT) \
+                        | ((x) << REMOTE_X_CORD_SHIFT) \
                         | ((int) local_addr)))
 
 #define bsg_remote_flt_ptr(x,y,local_addr) \
-  ((bsg_remote_float_ptr) ( (1 << REMOTE_PREFIX_SHIFT) \
-                          | (y << REMOTE_Y_CORD_SHIFT) \
-                          | (x << REMOTE_X_CORD_SHIFT) \
+  ((bsg_remote_float_ptr) ( (1 << REMOTE_PREFIX_SHIFT)   \
+                          | ((y) << REMOTE_Y_CORD_SHIFT) \
+                          | ((x) << REMOTE_X_CORD_SHIFT) \
                           | ((int) local_addr)))
 
 #define CREATE_POINTER_BY_TYPE(type) bsg_remote_ ## type ## _ptr
 
 #define bsg_tile_group_remote_ptr(type,x,y,local_addr) \
-  ((CREATE_POINTER_BY_TYPE(type)) ( (1 << REMOTE_PREFIX_SHIFT) \
-                                  | (y << REMOTE_Y_CORD_SHIFT) \
-                                  | (x << REMOTE_X_CORD_SHIFT) \
+  ((CREATE_POINTER_BY_TYPE(type)) ( (1 << REMOTE_PREFIX_SHIFT)   \
+                                  | ((y) << REMOTE_Y_CORD_SHIFT) \
+                                  | ((x) << REMOTE_X_CORD_SHIFT) \
                                   | ((int) local_addr)))
 
 
 // global address pointer
 #define bsg_global_ptr(x,y,local_addr) \
   ((bsg_remote_int_ptr) ( (1 << GLOBAL_PREFIX_SHIFT)    \
-                        | (y << GLOBAL_Y_CORD_SHIFT)  \
-                        | (x << GLOBAL_X_CORD_SHIFT)  \
+                        | ((y) << GLOBAL_Y_CORD_SHIFT)  \
+                        | ((x) << GLOBAL_X_CORD_SHIFT)  \
                         | ((int) local_addr)))
 
 
 #define bsg_global_float_ptr(x,y,local_addr) \
   ((bsg_remote_float_ptr) ( (1 << GLOBAL_PREFIX_SHIFT)    \
-                          | (y << GLOBAL_Y_CORD_SHIFT)  \
-                          | (x << GLOBAL_X_CORD_SHIFT)  \
+                          | ((y) << GLOBAL_Y_CORD_SHIFT)  \
+                          | ((x) << GLOBAL_X_CORD_SHIFT)  \
                           | ((int) local_addr)))
 
 
@@ -100,8 +100,8 @@
 // y = subcord y
 #define bsg_global_pod_ptr(px,py,x,y,local_addr) \
   ((bsg_remote_int_ptr) ( (1 << GLOBAL_PREFIX_SHIFT)    \
-                        | ((((1+(py*2))*bsg_global_Y)+y) << GLOBAL_Y_CORD_SHIFT)  \
-                        | ((((px+1)*bsg_global_X)+x) << GLOBAL_X_CORD_SHIFT)  \
+                        | ((((1+((py)*2))*bsg_global_Y)+(y)) << GLOBAL_Y_CORD_SHIFT)  \
+                        | (((((px)+1)*bsg_global_X)+(x)) << GLOBAL_X_CORD_SHIFT)  \
                         | ((int) local_addr)))
 
 // physical pod remote pointer, corresponds to all pods for px, py
@@ -111,8 +111,8 @@
 // y = subcord y
 #define bsg_global_physical_pod_ptr(px,py,x,y,local_addr) \
   ((bsg_remote_int_ptr) ( (1 << GLOBAL_PREFIX_SHIFT)    \
-                        | ((((py)*bsg_global_Y)+y) << GLOBAL_Y_CORD_SHIFT)  \
-                        | (((px*bsg_global_X)+x) << GLOBAL_X_CORD_SHIFT)  \
+                        | ((((py)*bsg_global_Y)+(y)) << GLOBAL_Y_CORD_SHIFT)  \
+                        | ((((px)*bsg_global_X)+(x)) << GLOBAL_X_CORD_SHIFT)  \
                         | ((int) local_addr)))
 
 // DRAM address pointer

--- a/software/bsg_manycore_lib/bsg_manycore_arch.h
+++ b/software/bsg_manycore_lib/bsg_manycore_arch.h
@@ -93,7 +93,7 @@
                           | ((int) local_addr)))
 
 
-// pod remote pointer
+// compute pod remote pointer, corresponds to MC compute arrays for px, py
 // px = pod id x
 // py = pod id y
 // x = subcord x
@@ -104,6 +104,16 @@
                         | ((((px+1)*bsg_global_X)+x) << GLOBAL_X_CORD_SHIFT)  \
                         | ((int) local_addr)))
 
+// physical pod remote pointer, corresponds to all pods for px, py
+// px = pod id x
+// py = pod id y
+// x = subcord x
+// y = subcord y
+#define bsg_global_physical_pod_ptr(px,py,x,y,local_addr) \
+  ((bsg_remote_int_ptr) ( (1 << GLOBAL_PREFIX_SHIFT)    \
+                        | ((((py)*bsg_global_Y)+y) << GLOBAL_Y_CORD_SHIFT)  \
+                        | (((px*bsg_global_X)+x) << GLOBAL_X_CORD_SHIFT)  \
+                        | ((int) local_addr)))
 
 // DRAM address pointer
 #define bsg_dram_ptr(local_addr) ((bsg_remote_int_ptr) ((1<<DRAM_PREFIX_SHIFT) | ((int) local_addr)))


### PR DESCRIPTION
This PR clarifies MC compute "logical" pods vs actual "physical" pods for coordinates. I kept the name the same for bsg_global_pod_ptr to be less controversial, but maybe makes sense to rename/alias to bsg_global_compute_pod_ptr. But I'll leave that up to the team.

Fixes #661 