### PR TITLE
Volatile atomic

### DIFF
--- a/software/bsg_manycore_lib/bsg_manycore_atomic.h
+++ b/software/bsg_manycore_lib/bsg_manycore_atomic.h
@@ -1,7 +1,7 @@
 #ifndef _BSG_MANYCORE_ATOMIC_H
 #define _BSG_MANYCORE_ATOMIC_H
 
-inline int bsg_amoswap (int* p, int val)
+inline int bsg_amoswap (volatile int* p, int val)
 {
   int result;
   asm volatile ("amoswap.w %[result], %[val], 0(%[p])" \
@@ -10,7 +10,7 @@ inline int bsg_amoswap (int* p, int val)
   return result;
 }
 
-inline int bsg_amoswap_aq (int* p, int val)
+inline int bsg_amoswap_aq (volatile int* p, int val)
 {
   int result;
   asm volatile ("amoswap.w.aq %[result], %[val], 0(%[p])" \
@@ -19,7 +19,7 @@ inline int bsg_amoswap_aq (int* p, int val)
   return result;
 }
 
-inline int bsg_amoswap_rl(int* p, int val)
+inline int bsg_amoswap_rl(volatile int* p, int val)
 {
   int result;
   asm volatile ("amoswap.w.rl %[result], %[val], 0(%[p])" \
@@ -28,7 +28,7 @@ inline int bsg_amoswap_rl(int* p, int val)
   return result;
 }
 
-inline int bsg_amoswap_aqrl(int* p, int val)
+inline int bsg_amoswap_aqrl(volatile int* p, int val)
 {
   int result;
   asm volatile ("amoswap.w.aqrl %[result], %[val], 0(%[p])" \
@@ -38,7 +38,7 @@ inline int bsg_amoswap_aqrl(int* p, int val)
 }
 
 
-inline int bsg_amoor (int* p, int val)
+inline int bsg_amoor (volatile int* p, int val)
 {
   int result;
   asm volatile ("amoor.w %[result], %[val], 0(%[p])" \
@@ -47,7 +47,7 @@ inline int bsg_amoor (int* p, int val)
   return result;
 }
 
-inline int bsg_amoor_aq (int* p, int val)
+inline int bsg_amoor_aq (volatile int* p, int val)
 {
   int result;
   asm volatile ("amoor.w.aq %[result], %[val], 0(%[p])" \
@@ -56,7 +56,7 @@ inline int bsg_amoor_aq (int* p, int val)
   return result;
 }
 
-inline int bsg_amoor_rl (int* p, int val)
+inline int bsg_amoor_rl (volatile int* p, int val)
 {
   int result;
   asm volatile ("amoor.w.rl %[result], %[val], 0(%[p])" \
@@ -65,7 +65,7 @@ inline int bsg_amoor_rl (int* p, int val)
   return result;
 }
 
-inline int bsg_amoor_aqrl (int* p, int val)
+inline int bsg_amoor_aqrl (volatile int* p, int val)
 {
   int result;
   asm volatile ("amoor.w.aqrl %[result], %[val], 0(%[p])" \
@@ -74,7 +74,7 @@ inline int bsg_amoor_aqrl (int* p, int val)
   return result;
 }
 
-inline int bsg_amoadd (int* p, int val)
+inline int bsg_amoadd (volatile int* p, int val)
 {
   int result;
   asm volatile ("amoadd.w %[result], %[val], 0(%[p])" \
@@ -83,7 +83,7 @@ inline int bsg_amoadd (int* p, int val)
   return result;
 }
 
-inline int bsg_amoadd_aq (int* p, int val)
+inline int bsg_amoadd_aq (volatile int* p, int val)
 {
   int result;
   asm volatile ("amoadd.w.aq %[result], %[val], 0(%[p])" \
@@ -92,7 +92,7 @@ inline int bsg_amoadd_aq (int* p, int val)
   return result;
 }
 
-inline int bsg_amoadd_rl (int* p, int val)
+inline int bsg_amoadd_rl (volatile int* p, int val)
 {
   int result;
   asm volatile ("amoadd.w.rl %[result], %[val], 0(%[p])" \
@@ -101,7 +101,7 @@ inline int bsg_amoadd_rl (int* p, int val)
   return result;
 }
 
-inline int bsg_amoadd_aqrl (int* p, int val)
+inline int bsg_amoadd_aqrl (volatile int* p, int val)
 {
   int result;
   asm volatile ("amoadd.w.aqrl %[result], %[val], 0(%[p])" \

--- a/software/spmd/vcache_atomic_mixed/Makefile
+++ b/software/spmd/vcache_atomic_mixed/Makefile
@@ -1,0 +1,17 @@
+bsg_tiles_X = 1
+bsg_tiles_Y = 1
+
+
+all: main.run
+
+OBJECT_FILES=main.o
+
+include ../Makefile.include
+
+main.riscv: $(LINK_SCRIPT) $(OBJECT_FILES) $(SPMD_COMMON_OBJECTS) $(BSG_MANYCORE_LIB) crt.o
+	$(RISCV_LINK) $(OBJECT_FILES) $(SPMD_COMMON_OBJECTS) -L. "-l:$(BSG_MANYCORE_LIB)" -o $@ $(RISCV_LINK_OPTS)
+
+
+main.o: Makefile
+
+include ../../mk/Makefile.tail_rules

--- a/software/spmd/vcache_atomic_mixed/main.c
+++ b/software/spmd/vcache_atomic_mixed/main.c
@@ -1,0 +1,31 @@
+#include "bsg_manycore.h"
+#include "bsg_set_tile_x_y.h"
+#include "bsg_manycore_atomic.h"
+
+int lock __attribute__ ((section (".dram"))) = {0};
+
+int main()
+{
+
+  bsg_set_tile_x_y();
+
+  if (__bsg_id == 0)
+  {
+    // Using a regular int* here cause an illegal ordering resulting in:
+    //   x = 1, y = 0, z = 1
+    //int* lock_ptr = &lock;
+    volatile int* lock_ptr  = &lock;
+    int x = *lock_ptr;
+    int y = bsg_amoadd(lock_ptr, 1);
+    int z = *lock_ptr;
+
+    bsg_print_hexadecimal(x);
+    bsg_print_hexadecimal(y);
+    bsg_print_hexadecimal(z);
+    if (x != 0 || y != 0 || z != 1) bsg_fail();
+
+    bsg_finish();
+  }
+
+  bsg_wait_while(1);
+}

--- a/software/spmd/vcache_atomic_mixed/main.c
+++ b/software/spmd/vcache_atomic_mixed/main.c
@@ -19,9 +19,6 @@ int main()
     int y = bsg_amoadd(lock_ptr, 1);
     int z = *lock_ptr;
 
-    bsg_print_hexadecimal(x);
-    bsg_print_hexadecimal(y);
-    bsg_print_hexadecimal(z);
     if (x != 0 || y != 0 || z != 1) bsg_fail();
 
     bsg_finish();


### PR DESCRIPTION
I've been encountering an issue mixing loads and amos to the same address. I've convinced myself it's a coding issue rather than a hardware issue, with the compiler not tracking the inline assembly dependencies correctly. Making the pointer volatile seems to make the accesses sane. But then compiling with C++ -fno-permissive, causes the following:

```
main.c:27:24: error: invalid conversion from 'volatile int*' to 'int*' [-fpermissive]
   27 |     int y = bsg_amoadd(vol_lock_ptr, 1);
      |                        ^~~~~~~~~~~~
      |                        |
      |                        volatile int*
```

This PR makes the pointer parameter for the bsg_amo_add volatile so that we can compile this code correctly. It also adds a test demonstrating the issue
