### PR TITLE
Updating hostname detection to be bsg_cadenv detection

### DIFF
--- a/software/mk/Makefile.verilog
+++ b/software/mk/Makefile.verilog
@@ -22,7 +22,7 @@ ifneq ($(IGNORE_CADENV),)
   # select the tools
 
 # Checking the VCS settings
-else ifeq (,$(findstring cs.washington.edu,$(HOSTNAME)))
+else ifeq (,$(wildcard $(CAD_DIR)/cadenv.mk))
   ifeq ($(VCS),)
     $(error Unfamiliar machine/cadtool setup: Please define the $$VCS which points to the VCS binaries )
   endif


### PR DESCRIPTION
This allows one to use bsg_cadenv on machines hosted in other domains (or Docker images). Should have no new behavior on current setups. It also has the advantage of alerting bsg users if they forget to clone bsg_cadenv alongside of bsg_manycore