### PR TITLE
Fix host module paths in saif dumper

### DIFF
--- a/machines/xcelium_dump.tcl
+++ b/machines/xcelium_dump.tcl
@@ -1,4 +1,4 @@
 database -open dump -shm
-probe -create spmd_testbench.testbench.DUT -depth all -all -shm -database dump
+probe -create spmd_testbench.testbench.fi1.DUT -depth all -all -shm -database dump
 run
 exit

--- a/testbenches/common/v/bsg_nonsynth_manycore_testbench.v
+++ b/testbenches/common/v/bsg_nonsynth_manycore_testbench.v
@@ -165,7 +165,7 @@ module bsg_nonsynth_manycore_testbench
   bsg_manycore_ruche_x_link_sif_s [E:W][num_pods_y_p-1:0][num_tiles_y_p-1:0] ruche_link_li;
   bsg_manycore_ruche_x_link_sif_s [E:W][num_pods_y_p-1:0][num_tiles_y_p-1:0] ruche_link_lo;
 
-  if (bsg_manycore_network_cfg_p == e_network_half_ruche_x) begin: halfruche
+  if (bsg_manycore_network_cfg_p == e_network_half_ruche_x) begin: fi1
     bsg_manycore_pod_ruche_array #(
       .num_tiles_x_p(num_tiles_x_p)
       ,.num_tiles_y_p(num_tiles_y_p)
@@ -224,7 +224,7 @@ module bsg_nonsynth_manycore_testbench
       ,.pod_tags_i(pod_tags_lo) 
     );
   end
-  else if (bsg_manycore_network_cfg_p == e_network_mesh) begin: mesh
+  else if (bsg_manycore_network_cfg_p == e_network_mesh) begin: fi1
     bsg_manycore_pod_mesh_array #(
       .num_tiles_x_p(num_tiles_x_p)
       ,.num_tiles_y_p(num_tiles_y_p)
@@ -920,7 +920,7 @@ if (enable_cache_profiling_p) begin
     .data_width_p(data_width_p)
     ,.addr_width_p(addr_width_p)
     ,.block_size_in_words_p(block_size_in_words_p)
-    ,.header_print_p({`BSG_STRINGIFY(`HOST_MODULE_PATH),".testbench.DUT.py[0].podrow.px[0].pod.north_vc_x[0].north_vc_row.vc_y[0].vc_x[0].vc.cache.vcache_prof"})
+    ,.header_print_p({`BSG_STRINGIFY(`HOST_MODULE_PATH),".testbench.fi1.DUT.py[0].podrow.px[0].pod.north_vc_x[0].north_vc_row.vc_y[0].vc_x[0].vc.cache.vcache_prof"})
     ,.ways_p(ways_p)
   ) vcache_prof (
     // everything else

--- a/testbenches/common/v/spmd_testbench.v
+++ b/testbenches/common/v/spmd_testbench.v
@@ -186,7 +186,7 @@ module spmd_testbench
     ,.icache_block_size_in_words_p(icache_block_size_in_words_p)
     ,.io_x_cord_p(`BSG_MACHINE_HOST_X_CORD)
     ,.io_y_cord_p(`BSG_MACHINE_HOST_Y_CORD)
-    ,.saif_toggle_scope_p("spmd_testbench.testbench.DUT.podrow.px[0].pod.mc_y[0].mc_x[0].mc.y[0].x[0].tile")
+    ,.saif_toggle_scope_p("spmd_testbench.testbench.fi1.DUT.podrow.px[0].pod.mc_y[0].mc_x[0].mc.y[0].x[0].tile")
   ) io (
     .clk_i(core_clk)
     ,.reset_i(reset_r)

--- a/testbenches/common/v/vanilla_core_saif_dumper.v
+++ b/testbenches/common/v/vanilla_core_saif_dumper.v
@@ -65,14 +65,14 @@ module vanilla_core_saif_dumper
             if(debug_p)
               $display("TRIGGER_ON t=%t (%m)", $time);
             $set_gate_level_monitoring("rtl_on", "sv");
-            $set_toggle_region(`HOST_MODULE_PATH.testbench.DUT);
+           $set_toggle_region(`HOST_MODULE_PATH.testbench.fi1.DUT);
             $toggle_start();
          end
          if(trigger_end) begin
             if(debug_p)
               $display("TRIGGER_OFF t=%t (%m)", $time);
             $toggle_stop();
-            $toggle_report("run.saif", 1.0e-12, `HOST_MODULE_PATH.testbench.DUT);
+           $toggle_report("run.saif", 1.0e-12, `HOST_MODULE_PATH.testbench.fi1.DUT);
          end
       end // if (saif_en_i ^ saif_en_r)
    end // always @ (negedge clk_i)


### PR DESCRIPTION
https://github.com/bespoke-silicon-group/bsg_manycore/blob/8b450d997095c84dbfe5a44b83c7ea00713025b3/testbenches/common/v/bsg_nonsynth_manycore_testbench.v#L168

This path broke as a result of this change: #652 