### PR TITLE
[profiler] Dram Stall stats

### DIFF
--- a/testbenches/common/v/vanilla_exe_bubble_classifier.v
+++ b/testbenches/common/v/vanilla_exe_bubble_classifier.v
@@ -56,8 +56,14 @@ module vanilla_exe_bubble_classifier
    ,input exe_signals_s exe_r
    ,input fp_exe_ctrl_signals_s fp_exe_ctrl_r
 
+   ,input instruction_s instruction
+   ,input decode_s decode
+
    ,output [pc_width_p-1:0] exe_bubble_pc_o
    ,output [31:0] exe_bubble_type_o
+
+   ,output logic is_exe_seq_lw_o
+   ,output logic is_exe_seq_flw_o
    );
 
   // icache miss PC tracker
@@ -118,6 +124,7 @@ module vanilla_exe_bubble_classifier
 
   vanilla_isb_info_s [RV32_reg_els_gp-1:0]  int_sb;
   vanilla_fsb_info_s [RV32_reg_els_gp-1:0]  float_sb;
+  logic is_id_seq_lw, is_id_seq_flw;
 
   vanilla_scoreboard_tracker
     #(.data_width_p(data_width_p))
@@ -125,7 +132,34 @@ module vanilla_exe_bubble_classifier
     (.*
      ,.int_sb_o(int_sb)
      ,.float_sb_o(float_sb)
+     ,.is_id_seq_lw_o(is_id_seq_lw)
+     ,.is_id_seq_flw_o(is_id_seq_flw)
      );
+
+  // Sequential load tracking;
+  logic is_exe_seq_lw_r, is_exe_seq_flw_r;
+  always_ff @ (posedge clk_i) begin
+    if (reset_i) begin
+      is_exe_seq_lw_r <= 1'b0;
+      is_exe_seq_flw_r <= 1'b0;
+    end
+    else begin
+      if (~stall_all) begin
+        if (stall_id | flush) begin
+          is_exe_seq_lw_r <= 1'b0;
+          is_exe_seq_flw_r <= 1'b0;
+        end
+        else begin
+          is_exe_seq_lw_r <= is_id_seq_lw;
+          is_exe_seq_flw_r <= is_id_seq_flw;
+        end
+      end
+    end
+  end
+
+  assign is_exe_seq_lw_o = is_exe_seq_lw_r;
+  assign is_exe_seq_flw_o = is_exe_seq_flw_r;
+
 
   wire stall_depend_group_load = stall_depend_long_op
        & ((id_r.decode.read_rs1 & int_sb[id_r.instruction.rs1].remote_group_load) |
@@ -150,6 +184,19 @@ module vanilla_exe_bubble_classifier
           (id_r.decode.read_frs1 & float_sb[id_r.instruction.rs1].remote_dram_load) |
           (id_r.decode.read_frs2 & float_sb[id_r.instruction.rs2].remote_dram_load) |
           (id_r.decode.write_frd & float_sb[id_r.instruction.rd].remote_dram_load));
+
+  wire stall_depend_dram_seq_load = stall_depend_long_op
+       & ((id_r.decode.read_rs1 & int_sb[id_r.instruction.rs1].remote_dram_seq_load) |
+          (id_r.decode.read_rs2 & int_sb[id_r.instruction.rs2].remote_dram_seq_load) |
+          (id_r.decode.write_rd & int_sb[id_r.instruction.rd].remote_dram_seq_load) |
+          (id_r.decode.read_frs1 & float_sb[id_r.instruction.rs1].remote_dram_seq_load) |
+          (id_r.decode.read_frs2 & float_sb[id_r.instruction.rs2].remote_dram_seq_load) |
+          (id_r.decode.write_frd & float_sb[id_r.instruction.rd].remote_dram_seq_load));
+
+  wire stall_depend_dram_amo = stall_depend_long_op
+       & ((id_r.decode.read_rs1 & int_sb[id_r.instruction.rs1].remote_dram_amo) |
+          (id_r.decode.read_rs2 & int_sb[id_r.instruction.rs2].remote_dram_amo) |
+          (id_r.decode.write_rd & int_sb[id_r.instruction.rd].remote_dram_amo));
 
   wire stall_depend_idiv = stall_depend_long_op
        & ((id_r.decode.read_rs1 & int_sb[id_r.instruction.rs1].idiv) |
@@ -190,6 +237,14 @@ module vanilla_exe_bubble_classifier
         end
         else if (stall_depend_dram_load) begin
           exe_bubble_r <= e_exe_bubble_stall_depend_dram;
+          exe_bubble_pc_r <= id_pc;
+        end
+        else if (stall_depend_dram_seq_load) begin
+          exe_bubble_r <= e_exe_bubble_stall_depend_seq_dram;
+          exe_bubble_pc_r <= id_pc;
+        end
+        else if (stall_depend_dram_amo) begin
+          exe_bubble_r <= e_exe_bubble_stall_depend_dram_amo;
           exe_bubble_pc_r <= id_pc;
         end
         else if (stall_depend_group_load) begin

--- a/testbenches/common/v/vanilla_exe_bubble_classifier_pkg.v
+++ b/testbenches/common/v/vanilla_exe_bubble_classifier_pkg.v
@@ -6,6 +6,8 @@ package vanilla_exe_bubble_classifier_pkg;
     e_exe_bubble_icache_miss,
 
     e_exe_bubble_stall_depend_dram,
+    e_exe_bubble_stall_depend_seq_dram,
+    e_exe_bubble_stall_depend_dram_amo,
     e_exe_bubble_stall_depend_global,
     e_exe_bubble_stall_depend_group,
     e_exe_bubble_stall_depend_fdiv,

--- a/testbenches/common/v/vanilla_scoreboard_tracker.v
+++ b/testbenches/common/v/vanilla_scoreboard_tracker.v
@@ -26,36 +26,53 @@ module vanilla_scoreboard_tracker
    ,input exe_signals_s exe_r
    ,input fp_exe_ctrl_signals_s fp_exe_ctrl_r
 
+   ,input instruction_s instruction
+   ,input decode_s decode
+
    ,output vanilla_isb_info_s [RV32_reg_els_gp-1:0] int_sb_o
    ,output vanilla_fsb_info_s [RV32_reg_els_gp-1:0] float_sb_o
+   // is the load in ID sequential load?
+   ,output logic is_id_seq_lw_o
+   ,output logic is_id_seq_flw_o
    );
 
-  // remote/local scoreboard tracking
-  //
-  // int_sb[3]: idiv
-  // int_sb[2]: remote dram load
-  // int_sb[1]: remote global load
-  // int_sb[0]: remote group load
-  //
-  // float_sb[3]: fdiv / fsqrt
-  // float_sb[2]: remote dram load
-  // float_sb[1]: remote global load
-  // float_sb[0]: remote group load
+  wire [reg_addr_width_lp-1:0] if_rs1 = instruction.rs1;
+  wire [reg_addr_width_lp-1:0] id_rs1 = id_r.instruction.rs1;
+  wire [reg_addr_width_lp-1:0] id_rd = id_r.instruction.rd;
+  wire [9:0] id_imm_plus4 = 1'b1 + mem_addr_op2[11:2];
+  wire [11:0] if_load_imm = `RV32_Iimm_12extract(instruction);
+  
+  wire is_seq_lw  = id_r.decode.is_load_op & decode.is_load_op
+                  & id_r.decode.write_rd & decode.write_rd
+                  & (if_rs1 == id_rs1)
+                  & (id_rd != id_rs1)
+                  & ~(id_r.decode.is_byte_op | id_r.decode.is_hex_op | decode.is_byte_op | decode.is_hex_op)
+                  & ((id_imm_plus4 == if_load_imm[11:2]) && (mem_addr_op2[11] | ~id_imm_plus4[9]));
 
-  vanilla_isb_info_s [RV32_reg_els_gp-1:0] int_sb_r;
-  vanilla_fsb_info_s [RV32_reg_els_gp-1:0] float_sb_r;
+  wire is_seq_flw = id_r.decode.is_load_op & decode.is_load_op
+                  & id_r.decode.write_frd & decode.write_frd
+                  & ((id_imm_plus4 == if_load_imm[11:2]) && (mem_addr_op2[11] | ~id_imm_plus4[9]));
+
+  assign is_id_seq_lw_o = is_seq_lw;
+  assign is_id_seq_flw_o = is_seq_flw;
 
   wire [data_width_p-1:0] id_mem_addr = rs1_val_to_exe + `BSG_SIGN_EXTEND(mem_addr_op2,data_width_p);
-  wire remote_ld_dram_in_id = ((id_r.decode.is_load_op & id_r.decode.write_rd) | id_r.decode.is_amo_op) & id_mem_addr[data_width_p-1];
-  wire remote_ld_global_in_id = ((id_r.decode.is_load_op & id_r.decode.write_rd) | id_r.decode.is_amo_op) & (id_mem_addr[data_width_p-1-:2] == 2'b01);
-  wire remote_ld_group_in_id = ((id_r.decode.is_load_op & id_r.decode.write_rd) | id_r.decode.is_amo_op) & (id_mem_addr[data_width_p-1-:3] == 3'b001);
+  wire remote_ld_dram_in_id = ((id_r.decode.is_load_op & id_r.decode.write_rd & ~is_seq_lw)) & id_mem_addr[data_width_p-1];
+  wire remote_seq_ld_dram_in_id = ((id_r.decode.is_load_op & id_r.decode.write_rd & is_seq_lw)) & id_mem_addr[data_width_p-1];
+  wire remote_amo_dram_in_id = (id_r.decode.write_rd & id_r.decode.is_amo_op) & id_mem_addr[data_width_p-1];
+  wire remote_ld_global_in_id = ((id_r.decode.is_load_op & id_r.decode.write_rd)) & (id_mem_addr[data_width_p-1-:2] == 2'b01);
+  wire remote_ld_group_in_id = ((id_r.decode.is_load_op & id_r.decode.write_rd)) & (id_mem_addr[data_width_p-1-:3] == 3'b001);
 
-  wire remote_flw_dram_in_id = (id_r.decode.is_load_op & id_r.decode.write_frd) & id_mem_addr[data_width_p-1];
+  wire remote_flw_dram_in_id = (id_r.decode.is_load_op & id_r.decode.write_frd & ~is_seq_flw) & id_mem_addr[data_width_p-1];
+  wire remote_seq_flw_dram_in_id = (id_r.decode.is_load_op & id_r.decode.write_frd & is_seq_flw) & id_mem_addr[data_width_p-1];
   wire remote_flw_global_in_id = (id_r.decode.is_load_op & id_r.decode.write_frd) & (id_mem_addr[data_width_p-1-:2] == 2'b01);
   wire remote_flw_group_in_id = (id_r.decode.is_load_op & id_r.decode.write_frd) & (id_mem_addr[data_width_p-1-:3] == 3'b001);
 
-  wire [reg_addr_width_lp-1:0] id_rd = id_r.instruction.rd;
 
+
+  // remote/local scoreboard tracking
+  vanilla_isb_info_s [RV32_reg_els_gp-1:0] int_sb_r;
+  vanilla_fsb_info_s [RV32_reg_els_gp-1:0] float_sb_r;
 
   always_ff @ (posedge clk_i) begin
     if (reset_i) begin
@@ -94,7 +111,21 @@ module vanilla_scoreboard_tracker
         else if (int_sb_clear & (int_sb_clear_id == i)) begin
           int_sb_r[i].remote_group_load <= 1'b0;
         end
-      end // for (integer i = 0; i < RV32_reg_els_gp; i++)
+        // remote amo dram
+        if (~stall_id & ~stall_all & ~flush & remote_amo_dram_in_id & (id_rd == i)) begin
+          int_sb_r[i].remote_dram_amo <= 1'b1;
+        end
+        else if (int_sb_clear & (int_sb_clear_id == i)) begin
+          int_sb_r[i].remote_dram_amo <= 1'b0;
+        end
+        // remote seq ld dram
+        if (~stall_id & ~stall_all & ~flush & remote_seq_ld_dram_in_id & (id_rd == i)) begin
+          int_sb_r[i].remote_dram_seq_load <= 1'b1;
+        end
+        else if (int_sb_clear & (int_sb_clear_id == i)) begin
+          int_sb_r[i].remote_dram_seq_load <= 1'b0;
+        end
+      end
 
       // float sb
       for (integer i = 0; i < RV32_reg_els_gp; i++) begin
@@ -126,9 +157,17 @@ module vanilla_scoreboard_tracker
         else if (float_sb_clear & (float_sb_clear_id == i)) begin
           float_sb_r[i].remote_group_load <= 1'b0;
         end
-      end // for (integer i = 0; i < RV32_reg_els_gp; i++)
-    end // else: !if(reset_i)
-  end // always_ff @ (posedge clk_i)
+        // remote seq flw dram
+        if (~stall_id & ~stall_all & ~flush & remote_seq_flw_dram_in_id & (id_rd == i)) begin
+          float_sb_r[i].remote_dram_seq_load <= 1'b1;
+        end
+        else if (float_sb_clear & (float_sb_clear_id == i)) begin
+          float_sb_r[i].remote_dram_seq_load <= 1'b0;
+        end
+      end
+
+    end
+  end
 
   assign int_sb_o = int_sb_r;
   assign float_sb_o = float_sb_r;

--- a/testbenches/common/v/vanilla_scoreboard_tracker_pkg.v
+++ b/testbenches/common/v/vanilla_scoreboard_tracker_pkg.v
@@ -2,9 +2,11 @@ package vanilla_scoreboard_tracker_pkg;
 
   // integer scoreboard
   typedef struct packed {
+    logic remote_dram_amo;
     logic remote_group_load;
     logic remote_global_load;
     logic remote_dram_load;
+    logic remote_dram_seq_load;
     logic idiv;
   } vanilla_isb_info_s;
 
@@ -13,6 +15,7 @@ package vanilla_scoreboard_tracker_pkg;
     logic remote_group_load;
     logic remote_global_load;
     logic remote_dram_load;
+    logic remote_dram_seq_load;
     logic fdiv_fsqrt;
   } vanilla_fsb_info_s;
 


### PR DESCRIPTION
- Adding the counter whether the dram access was sequential (consecutive access based on the same rs1) vs non-sequential.
- Splitting stall_depend_dram_load into atomics, sequential loads, non-sequential loads.