### PR TITLE
Change pipe structure for bash compatibility

### DIFF
--- a/software/mk/Makefile.builddefs
+++ b/software/mk/Makefile.builddefs
@@ -261,10 +261,10 @@ endif
 
 else
 %.o: %.c
-	$(RISCV_GCC) $(RISCV_GCC_OPTS) $(OPT_LEVEL) $(spmd_defs) -c $(INCS) $< -o $@ 2>&1 tee $*.comp.log
+	$(RISCV_GCC) $(RISCV_GCC_OPTS) $(OPT_LEVEL) $(spmd_defs) -c $(INCS) $< -o $@ 2>&1 | tee $*.comp.log
 
 %.o: %.cpp
-	$(RISCV_GXX) $(RISCV_GXX_OPTS) $(OPT_LEVEL) $(spmd_defs) -c $(INCS) $< -o $@ 2>&1 tee $*.comp.log
+	$(RISCV_GXX) $(RISCV_GXX_OPTS) $(OPT_LEVEL) $(spmd_defs) -c $(INCS) $< -o $@ 2>&1 | tee $*.comp.log
 endif
 
 

--- a/software/mk/Makefile.builddefs
+++ b/software/mk/Makefile.builddefs
@@ -344,8 +344,8 @@ else
 endif
 
 %.S: %.c
-	$(RISCV_GCC) $(RISCV_GCC_OPTS) $(spmd_defs) -S -fverbose-asm $(INCS) $< -o $@ 2>&1 tee $*.comp.log
+	$(RISCV_GCC) $(RISCV_GCC_OPTS) $(spmd_defs) -S -fverbose-asm $(INCS) $< -o $@ 2>&1 | tee $*.comp.log
 
 %.S: %.cpp
-	$(RISCV_GXX) $(RISCV_GXX_OPTS) $(spmd_defs) -S -fverbose-asm $(INCS) $< -o $@ 2>&1 tee $*.comp.log
+	$(RISCV_GXX) $(RISCV_GXX_OPTS) $(spmd_defs) -S -fverbose-asm $(INCS) $< -o $@ 2>&1 | tee $*.comp.log
 

--- a/software/mk/Makefile.builddefs
+++ b/software/mk/Makefile.builddefs
@@ -261,10 +261,10 @@ endif
 
 else
 %.o: %.c
-	$(RISCV_GCC) $(RISCV_GCC_OPTS) $(OPT_LEVEL) $(spmd_defs) -c $(INCS) $< -o $@ |& tee $*.comp.log
+	$(RISCV_GCC) $(RISCV_GCC_OPTS) $(OPT_LEVEL) $(spmd_defs) -c $(INCS) $< -o $@ 2>&1 tee $*.comp.log
 
 %.o: %.cpp
-	$(RISCV_GXX) $(RISCV_GXX_OPTS) $(OPT_LEVEL) $(spmd_defs) -c $(INCS) $< -o $@ |& tee $*.comp.log
+	$(RISCV_GXX) $(RISCV_GXX_OPTS) $(OPT_LEVEL) $(spmd_defs) -c $(INCS) $< -o $@ 2>&1 tee $*.comp.log
 endif
 
 
@@ -344,8 +344,8 @@ else
 endif
 
 %.S: %.c
-	$(RISCV_GCC) $(RISCV_GCC_OPTS) $(spmd_defs) -S -fverbose-asm $(INCS) $< -o $@ |& tee $*.comp.log
+	$(RISCV_GCC) $(RISCV_GCC_OPTS) $(spmd_defs) -S -fverbose-asm $(INCS) $< -o $@ 2>&1 tee $*.comp.log
 
 %.S: %.cpp
-	$(RISCV_GXX) $(RISCV_GXX_OPTS) $(spmd_defs) -S -fverbose-asm $(INCS) $< -o $@ |& tee $*.comp.log
+	$(RISCV_GXX) $(RISCV_GXX_OPTS) $(spmd_defs) -S -fverbose-asm $(INCS) $< -o $@ 2>&1 tee $*.comp.log
 


### PR DESCRIPTION
Old versions of bash do not like |&. 2>&1 has the same functionality but greater compatibility: https://stackoverflow.com/questions/20553916/syntax-error-near-unexpected-token-using