### PR TITLE
optimize script for `make tools`

### DIFF
--- a/software/mk/Makefile.llvminstall
+++ b/software/mk/Makefile.llvminstall
@@ -32,8 +32,6 @@ ifndef GENERATOR
   endif
 endif
 
-COMPILING_THREADS = 6
-
 llvm-install:
 	mkdir -p $(LLVM_DIR)/llvm-build && mkdir -p $(LLVM_DIR)/llvm-install
 	# Get LLVM sources

--- a/software/mk/Makefile.llvminstall
+++ b/software/mk/Makefile.llvminstall
@@ -32,6 +32,8 @@ ifndef GENERATOR
   endif
 endif
 
+COMPILING_THREADS = 6
+
 llvm-install:
 	mkdir -p $(LLVM_DIR)/llvm-build && mkdir -p $(LLVM_DIR)/llvm-install
 	# Get LLVM sources
@@ -50,4 +52,4 @@ llvm-install:
 	    -DLLVM_USE_SPLIT_DWARF=True \
 	    -DLLVM_OPTIMIZED_TABLEGEN=True \
 	    ../llvm-src/llvm
-	cd  $(LLVM_DIR)/llvm-build && $(CMAKE) --build . --target install -- -j 12
+	cd  $(LLVM_DIR)/llvm-build && $(CMAKE) --build . --target install -- -j $(COMPILING_THREADS)

--- a/software/riscv-tools/Makefile
+++ b/software/riscv-tools/Makefile
@@ -41,7 +41,10 @@ SPIKE_REPO        := riscv-isa-sim
 SPIKE_URL         := https://github.com/riscv/riscv-isa-sim.git
 SPIKE_PATCH       := spike.patch
 SPIKE_GCC_PATCH   := spike-gcc.patch
-SPIKE_TAG         := v1.0.0
+SPIKE_TAG         := v1.1.0
+
+# How many thread you want to use compiling tools
+COMPILING_THREADS := 6
 
 LLVM_DIR          := $(CURDIR)/llvm
 export PATH:=$(DEPENDS_DIR)/bin:$(PATH)
@@ -86,7 +89,7 @@ checkout-repos:
 ifeq ($(shell [ $(call git-version,1) -gt 1 ] && \
               [ $(call git-version,1) -gt 2 -o $(call git-version,2) -gt 8 ] && \
               echo 1), 1)
-	#cd $(TOOLCHAIN_REPO) && git submodule update --init --recursive -j 16;
+	#cd $(TOOLCHAIN_REPO) && git submodule update --init --recursive -j $(COMPILING_THREADS);
 	cd $(TOOLCHAIN_REPO) && git submodule update --init --checkout riscv-binutils
 	cd $(TOOLCHAIN_REPO) && git submodule update --init --checkout riscv-glibc
 	cd $(TOOLCHAIN_REPO) && git submodule update --init --checkout riscv-gcc
@@ -113,7 +116,7 @@ checkout-spike:
 	@rm -rf $(SPIKE_REPO);
 	git clone --recursive $(SPIKE_URL);
 	cd $(SPIKE_REPO) && git checkout tags/$(SPIKE_TAG)
-	cd $(SPIKE_REPO) && git apply ../$(SPIKE_PATCH) && git apply ../$(SPIKE_GCC_PATCH)
+	#cd $(SPIKE_REPO) && git apply ../$(SPIKE_PATCH) && git apply ../$(SPIKE_GCC_PATCH)
 
 checkout-all: 
 	$(MAKE) checkout-repos 
@@ -142,7 +145,7 @@ build-riscv-gnu-tools: configure-riscv-gnu-tools
 	@echo "====================================="
 	@echo "Building toolchain..."
 	@echo "====================================="
-	cd riscv-gnu-toolchain && $(MAKE) -j 16 CFLAGS_FOR_TARGET_EXTRA=$(TARGET_CFLAGS)
+	cd riscv-gnu-toolchain && $(MAKE) -j $(COMPILING_THREADS) CFLAGS_FOR_TARGET_EXTRA=$(TARGET_CFLAGS)
 
 build-spike:
 	@echo "====================================="

--- a/software/riscv-tools/Makefile
+++ b/software/riscv-tools/Makefile
@@ -44,7 +44,19 @@ SPIKE_GCC_PATCH   := spike-gcc.patch
 SPIKE_TAG         := v1.1.0
 
 # How many thread you want to use compiling tools
-COMPILING_THREADS := 6
+
+ifeq ($(OS),Linux)
+        NUMPROC := $(shell grep -c ^processor /proc/cpuinfo)
+else ifeq ($(OS),Darwin)
+        NUMPROC := $(shell sysctl hw.ncpu | awk '{print $$2}')
+endif
+
+# Only take half as many processors as available
+COMPILING_THREADS := $(shell echo "$(NUMPROC)/2"|bc)
+
+ifeq ($(COMPILING_THREADS),0)
+        COMPILING_THREADS = 1
+endif 
 
 LLVM_DIR          := $(CURDIR)/llvm
 export PATH:=$(DEPENDS_DIR)/bin:$(PATH)


### PR DESCRIPTION
1) add paramater `COMPILING_THREADS` to specify how many thread to use

2) spike version changed from v1.0.0 to v1.1.0 (aarch64/arm64 support) current spike tag can not compile on aarch64/arm64 machines since the script in the "old" spike have no idea when checking the machine's arch with result of aarch64 or arm64. In spike v1.1.0, spike fixed this mistake