### PR TITLE
[DO NOT MERGE] Multikernel SPSC example

### DIFF
--- a/software/bsg_manycore_lib/bsg_manycore_spsc_queue.hpp
+++ b/software/bsg_manycore_lib/bsg_manycore_spsc_queue.hpp
@@ -1,0 +1,100 @@
+
+#ifndef _BSG_MANYCORE_SPSC_QUEUE_HPP
+#define _BSG_MANYCORE_SPSC_QUEUE_HPP
+
+#include <bsg_manycore_atomic.h>
+
+template <typename T, int S>
+class bsg_manycore_spsc_queue_recv {
+private:
+    volatile T *buffer;
+    volatile int *count;
+    int rptr;
+
+public:
+    bsg_manycore_spsc_queue_recv(T *buffer, int *count) 
+        : buffer(buffer), count(count), rptr(0) { };
+
+    bool is_empty(void)
+    {
+        return *count == 0;
+    }
+
+    bool try_recv(T *data)
+    {
+        if (is_empty())
+        {
+            return false;
+        }
+
+        *data = buffer[rptr];
+        // Probably faster than modulo, but should see if compiler
+        //   optimizes...
+        if (++rptr == S)
+        {
+            rptr = 0;
+        }
+        bsg_fence();
+        bsg_amoadd(count, -1);
+
+        return true;
+    }
+
+    // TODO: Add timeout?
+    T recv(void)
+    {
+        T data;
+        while (1)
+        {
+            if (try_recv(&data)) break;
+        }
+
+        return data;
+    }
+};
+
+template <typename T, int S>
+class bsg_manycore_spsc_queue_send {
+private:
+    volatile T *buffer;
+    volatile int *count;
+    int wptr;
+
+public:
+    bsg_manycore_spsc_queue_send(T *buffer, int *count) 
+        : buffer(buffer), count(count), wptr(0) { };
+
+    bool is_full(void)
+    {
+        return (*count == S);
+    }
+
+    bool try_send(T data)
+    {
+        if (is_full()) return false;
+
+        buffer[wptr] = data;
+        // Probably faster than modulo, but should see if compiler
+        //   optimizes...
+        if (++wptr == S)
+        {
+            wptr = 0;
+        }
+        bsg_fence();
+        bsg_amoadd(count, 1);
+
+        return true;
+    }
+
+    // TODO: Add timeout?
+    void send(T data)
+    {
+        while (1)
+        {
+            if (try_send(data)) break;
+        }
+    }
+};
+
+#endif
+

--- a/software/mk/Makefile.paths
+++ b/software/mk/Makefile.paths
@@ -5,7 +5,7 @@ export CAD_DIR ?= $(BSG_MANYCORE_DIR)/../bsg_cadenv
 ifeq ($(BSG_PLATFORM),verilator)
 BSG_MACHINE_PATH ?= $(BSG_MANYCORE_DIR)/machines/pod_1x1_4X2Y
 else ifeq ($(BSG_PLATFORM),vcs)
-BSG_MACHINE_PATH ?= $(BSG_MANYCORE_DIR)/machines/pod_1x1
+BSG_MACHINE_PATH ?= $(BSG_MANYCORE_DIR)/machines/pod_1x1_4X2Y
 else ifeq ($(BSG_PLATFORM),xcelium)
 BSG_MACHINE_PATH ?= $(BSG_MANYCORE_DIR)/machines/pod_1x1_4X2Y
 endif

--- a/software/spmd/spsc_queue/Makefile
+++ b/software/spmd/spsc_queue/Makefile
@@ -1,0 +1,15 @@
+bsg_tiles_X = 4
+bsg_tiles_Y = 2
+
+all: main.run
+
+OBJECT_FILES := main.o
+
+include ../Makefile.include
+
+main.riscv: $(LINK_SCRIPT) $(OBJECT_FILES) $(SPMD_COMMON_OBJECTS) $(BSG_MANYCORE_LIB)
+	$(RISCV_LINK)  $(filter %.o, $^) -L. "-l:$(BSG_MANYCORE_LIB)" -o $@ $(RISCV_LINK_OPTS)
+
+main.o: Makefile
+
+include $(BSG_MANYCORE_DIR)/software/mk/Makefile.tail_rules

--- a/software/spmd/spsc_queue/main.cpp
+++ b/software/spmd/spsc_queue/main.cpp
@@ -1,0 +1,68 @@
+//This kernel performs a barrier among all tiles in tile group 
+
+#include "bsg_manycore.h"
+#include "bsg_set_tile_x_y.h"
+#include "bsg_manycore_spsc_queue.hpp"
+#include "bsg_tile_group_barrier.hpp"
+
+bsg_barrier<bsg_tiles_X, bsg_tiles_Y> barrier;
+
+#define BUFFER_ELS 24
+#define CHAIN_LEN   8
+#define NUM_PACKETS 1000
+
+int buffer_chain [CHAIN_LEN*BUFFER_ELS] __attribute__ ((section (".dram"))) = {0};
+int buffer_count [CHAIN_LEN] __attribute__ ((section (".dram"))) = {0};
+
+int main()
+{
+    bsg_set_tile_x_y();
+
+    int *buffer = &buffer_chain[0] + (__bsg_id * BUFFER_ELS);
+    int *count  = &buffer_count[0] + (__bsg_id);
+
+    int *next_buffer = &buffer_chain[0] + ((__bsg_id+1) * BUFFER_ELS);
+    int *next_count = &buffer_count[0] + (__bsg_id+1);
+
+    bsg_manycore_spsc_queue_recv<int, BUFFER_ELS> recv_spsc(buffer, count);
+    bsg_manycore_spsc_queue_send<int, BUFFER_ELS> send_spsc(next_buffer, next_count);
+
+    int packets = 0;
+    int recv_data;
+    int send_data;
+    do
+    {
+        if (__bsg_id == 0)
+        {
+            recv_data = packets;
+        }
+        else
+        {
+            recv_data = recv_spsc.recv();
+        }
+
+        //bsg_printf("[%d] RECV %d\n", __bsg_id, recv_data);
+
+        send_data = recv_data;
+
+        if (__bsg_id == CHAIN_LEN-1)
+        {
+            if (recv_data != packets)
+            {
+                bsg_fail();
+            }
+        }
+        else
+        {
+            send_spsc.send(send_data);
+        }
+
+        //bsg_printf("[%d] SEND %d\n", __bsg_id, send_data);
+    } while (++packets < NUM_PACKETS);
+
+    barrier.sync();
+    bsg_finish();
+    bsg_wait_while(1);
+	return 0;
+}
+

--- a/software/spmd/test_multifunction/Makefile
+++ b/software/spmd/test_multifunction/Makefile
@@ -1,0 +1,18 @@
+bsg_tiles_X = 2
+bsg_tiles_Y = 1
+
+RISCV_GXX_EXTRA_OPTS += -DNUM_KERNELS=2 -DBUFFER_SIZE=64
+
+all: main.run
+
+OBJECT_FILES=main.o bsg_barrier_amoadd.o
+
+include ../Makefile.include
+
+main.riscv: $(LINK_SCRIPT) $(OBJECT_FILES) $(SPMD_COMMON_OBJECTS) $(BSG_MANYCORE_LIB) crt.o
+	$(RISCV_LINK) $(OBJECT_FILES) $(SPMD_COMMON_OBJECTS) -L. "-l:$(BSG_MANYCORE_LIB)" -o $@ $(RISCV_LINK_OPTS)
+
+
+main.o: Makefile
+
+include ../../mk/Makefile.tail_rules

--- a/software/spmd/test_multikernel/Makefile
+++ b/software/spmd/test_multikernel/Makefile
@@ -1,18 +1,45 @@
-bsg_tiles_X = 2
-bsg_tiles_Y = 1
-
-RISCV_GXX_EXTRA_OPTS += -DNUM_KERNELS=2 -DBUFFER_SIZE=64
+bsg_tiles_X = 4
+bsg_tiles_Y = 2
 
 all: main.run
 
-OBJECT_FILES=main.o bsg_barrier_amoadd.o
+# library functions
+LIBRARY_OBJECTS += bsg_barrier_amoadd.o
+
+# kernel functions
+KERNEL_OBJECTS += kernel0.o
+KERNEL_OBJECTS += kernel1.o
+KERNEL_OBJECTS += kernel2.o
+KERNEL_OBJECTS += kernel3.o
+KERNEL_OBJECTS += kernel4.o
+KERNEL_OBJECTS += kernel5.o
+KERNEL_OBJECTS += kernel6.o
+KERNEL_OBJECTS += kernel7.o
+
+# Main function
+MAIN_OBJECTS = main.o
 
 include ../Makefile.include
 
-main.riscv: $(LINK_SCRIPT) $(OBJECT_FILES) $(SPMD_COMMON_OBJECTS) $(BSG_MANYCORE_LIB) crt.o
-	$(RISCV_LINK) $(OBJECT_FILES) $(SPMD_COMMON_OBJECTS) -L. "-l:$(BSG_MANYCORE_LIB)" -o $@ $(RISCV_LINK_OPTS)
+# Main build rule, most likely unmodified
+OBJECT_FILES = $(LIBRARY_OBJECTS) $(KERNEL_OBJECTS) $(MAIN_OBJECTS)
+main.riscv: $(LINK_SCRIPT) $(OBJECT_FILES) $(BSG_MANYCORE_LIB) crt.o
+	$(RISCV_LINK) $(OBJECT_FILES) -L. "-l:$(BSG_MANYCORE_LIB)" -o $@ $(RISCV_LINK_OPTS)
 
-
+# Additional dependency to rebuild from makefile
 main.o: Makefile
+
+# Special rules to build kernels
+kernel0.o: RISCV_GXX_EXTRA_OPTS += -DTEST_VAR=0
+kernel1.o: RISCV_GXX_EXTRA_OPTS += -DTEST_VAR=1
+kernel2.o: RISCV_GXX_EXTRA_OPTS += -DTEST_VAR=2
+kernel3.o: RISCV_GXX_EXTRA_OPTS += -DTEST_VAR=3
+kernel4.o: RISCV_GXX_EXTRA_OPTS += -DTEST_VAR=4
+kernel5.o: RISCV_GXX_EXTRA_OPTS += -DTEST_VAR=5
+kernel6.o: RISCV_GXX_EXTRA_OPTS += -DTEST_VAR=6
+kernel7.o: RISCV_GXX_EXTRA_OPTS += -DTEST_VAR=7
+
+# Global rules
+RISCV_GXX_EXTRA_OPTS += -DNUM_KERNELS=8 -DBUFFER_SIZE=64
 
 include ../../mk/Makefile.tail_rules

--- a/software/spmd/test_multikernel/Makefile
+++ b/software/spmd/test_multikernel/Makefile
@@ -1,0 +1,18 @@
+bsg_tiles_X = 2
+bsg_tiles_Y = 1
+
+RISCV_GXX_EXTRA_OPTS += -DNUM_KERNELS=2 -DBUFFER_SIZE=64
+
+all: main.run
+
+OBJECT_FILES=main.o bsg_barrier_amoadd.o
+
+include ../Makefile.include
+
+main.riscv: $(LINK_SCRIPT) $(OBJECT_FILES) $(SPMD_COMMON_OBJECTS) $(BSG_MANYCORE_LIB) crt.o
+	$(RISCV_LINK) $(OBJECT_FILES) $(SPMD_COMMON_OBJECTS) -L. "-l:$(BSG_MANYCORE_LIB)" -o $@ $(RISCV_LINK_OPTS)
+
+
+main.o: Makefile
+
+include ../../mk/Makefile.tail_rules

--- a/software/spmd/test_multikernel/kernel.hpp
+++ b/software/spmd/test_multikernel/kernel.hpp
@@ -1,0 +1,33 @@
+#ifndef __KERNEL_HPP
+#define __KERNEL_HPP
+
+// This file defines N number of mostly identical kernels (up to 16 currently)
+// These kernels will
+// - print hello from a tile
+// - process an input buffer of size N by adding 100*its kernel id
+// - sync using a global AMOADD, waiting for all K kernels to reach
+
+#define MAKE_KERNEL_DEF(x) kernel##x
+#define KERNEL_DEF(x) \
+  extern "C" __attribute__ ((noinline))                                               \
+  int MAKE_KERNEL_DEF(x)(int *buffer, int n, int *sync, int k) {                      \
+  bsg_printf("Hello from kernel %d -- Tile X: %d Tile Y: %d\n", x, __bsg_x, __bsg_y); \
+                                                                                      \
+  for (int i = 0; i < n; i++) {                                                       \
+      buffer[x*n+i] += 100*(x+1);                                                     \
+      bsg_printf("kernel %d Process[%d]: %d\n", x, i, buffer[x*n+i]);                 \
+  }                                                                                   \
+                                                                                      \
+  volatile int *sync_ptr = sync;                                                      \
+  int sync_val;                                                                       \
+  bsg_printf("[kernel %d] Trying to sync to EVA: %x", x, sync);                       \
+  bsg_amoadd(sync, 1);                                                                \
+  while ((sync_val = *sync_ptr) < k) {                                                \
+     bsg_printf("[kernel %d] Waiting for sync_ptr == %d (%d)", x, k, sync_val);       \
+  }                                                                                   \
+                                                                                      \
+  return 0;                                                                           \
+}
+
+#endif
+

--- a/software/spmd/test_multikernel/kernel0.cpp
+++ b/software/spmd/test_multikernel/kernel0.cpp
@@ -1,0 +1,15 @@
+
+#include "bsg_manycore.h"
+#include "bsg_set_tile_x_y.h"
+#include "bsg_manycore_atomic.h"
+
+#include "kernel.hpp"
+
+#define KERNEL_NUM 0
+
+#if TEST_VAR == KERNEL_NUM
+KERNEL_DEF(KERNEL_NUM)
+#else
+#error TEST_VAR != KERNEL_NUM
+#endif
+

--- a/software/spmd/test_multikernel/kernel1.cpp
+++ b/software/spmd/test_multikernel/kernel1.cpp
@@ -1,0 +1,15 @@
+
+#include "bsg_manycore.h"
+#include "bsg_set_tile_x_y.h"
+#include "bsg_manycore_atomic.h"
+
+#include "kernel.hpp"
+
+#define KERNEL_NUM 1
+
+#if TEST_VAR == KERNEL_NUM
+KERNEL_DEF(KERNEL_NUM)
+#else
+#error TEST_VAR != KERNEL_NUM
+#endif
+

--- a/software/spmd/test_multikernel/kernel2.cpp
+++ b/software/spmd/test_multikernel/kernel2.cpp
@@ -1,0 +1,15 @@
+
+#include "bsg_manycore.h"
+#include "bsg_set_tile_x_y.h"
+#include "bsg_manycore_atomic.h"
+
+#include "kernel.hpp"
+
+#define KERNEL_NUM 2
+
+#if TEST_VAR == KERNEL_NUM
+KERNEL_DEF(KERNEL_NUM)
+#else
+#error TEST_VAR != KERNEL_NUM
+#endif
+

--- a/software/spmd/test_multikernel/kernel3.cpp
+++ b/software/spmd/test_multikernel/kernel3.cpp
@@ -1,0 +1,15 @@
+
+#include "bsg_manycore.h"
+#include "bsg_set_tile_x_y.h"
+#include "bsg_manycore_atomic.h"
+
+#include "kernel.hpp"
+
+#define KERNEL_NUM 3
+
+#if TEST_VAR == KERNEL_NUM
+KERNEL_DEF(KERNEL_NUM)
+#else
+#error TEST_VAR != KERNEL_NUM
+#endif
+

--- a/software/spmd/test_multikernel/kernel4.cpp
+++ b/software/spmd/test_multikernel/kernel4.cpp
@@ -1,0 +1,15 @@
+
+#include "bsg_manycore.h"
+#include "bsg_set_tile_x_y.h"
+#include "bsg_manycore_atomic.h"
+
+#include "kernel.hpp"
+
+#define KERNEL_NUM 4
+
+#if TEST_VAR == KERNEL_NUM
+KERNEL_DEF(KERNEL_NUM)
+#else
+#error TEST_VAR != KERNEL_NUM
+#endif
+

--- a/software/spmd/test_multikernel/kernel5.cpp
+++ b/software/spmd/test_multikernel/kernel5.cpp
@@ -1,0 +1,15 @@
+
+#include "bsg_manycore.h"
+#include "bsg_set_tile_x_y.h"
+#include "bsg_manycore_atomic.h"
+
+#include "kernel.hpp"
+
+#define KERNEL_NUM 5
+
+#if TEST_VAR == KERNEL_NUM
+KERNEL_DEF(KERNEL_NUM)
+#else
+#error TEST_VAR != KERNEL_NUM
+#endif
+

--- a/software/spmd/test_multikernel/kernel6.cpp
+++ b/software/spmd/test_multikernel/kernel6.cpp
@@ -1,0 +1,15 @@
+
+#include "bsg_manycore.h"
+#include "bsg_set_tile_x_y.h"
+#include "bsg_manycore_atomic.h"
+
+#include "kernel.hpp"
+
+#define KERNEL_NUM 6
+
+#if TEST_VAR == KERNEL_NUM
+KERNEL_DEF(KERNEL_NUM)
+#else
+#error TEST_VAR != KERNEL_NUM
+#endif
+

--- a/software/spmd/test_multikernel/kernel7.cpp
+++ b/software/spmd/test_multikernel/kernel7.cpp
@@ -1,0 +1,15 @@
+
+#include "bsg_manycore.h"
+#include "bsg_set_tile_x_y.h"
+#include "bsg_manycore_atomic.h"
+
+#include "kernel.hpp"
+
+#define KERNEL_NUM 7
+
+#if TEST_VAR == KERNEL_NUM
+KERNEL_DEF(KERNEL_NUM)
+#else
+#error TEST_VAR != KERNEL_NUM
+#endif
+

--- a/software/spmd/test_multikernel/main.cpp
+++ b/software/spmd/test_multikernel/main.cpp
@@ -1,0 +1,114 @@
+// This file defines N number of mostly identical kernels (up to 16 currently)
+// These kernels will
+// - print hello from a tile
+// - process an input buffer of size N by adding 100*its kernel id
+// - sync using a global AMOADD, waiting for all K kernels to reach
+
+#include "bsg_manycore.h"
+#include "bsg_set_tile_x_y.h"
+#include "bsg_manycore_atomic.h"
+
+#define K NUM_KERNELS
+#define N BUFFER_SIZE
+
+#define MAKE_KERNEL_DEF(x) kernel##x
+#define KERNEL_DEF(x) \
+  extern "C" __attribute__ ((noinline))                                               \
+  int MAKE_KERNEL_DEF(x)(int *buffer, int n, int *sync, int k) {                      \
+  bsg_printf("Hello from kernel %d -- Tile X: %d Tile Y: %d\n", x, __bsg_x, __bsg_y); \
+                                                                                      \
+  for (int i = 0; i < n; i++) {                                                       \
+      buffer[x*n+i] += 100*(x+1);                                                     \
+      bsg_printf("kernel %d Process[%d]: %d\n", x, i, buffer[x*n+i]);                 \
+  }                                                                                   \
+                                                                                      \
+  volatile int *sync_ptr = sync;                                                      \
+  int sync_val;                                                                       \
+  bsg_printf("[kernel %d] Trying to sync to EVA: %x", x, sync);                       \
+  bsg_amoadd(sync, 1);                                                                \
+  while ((sync_val = *sync_ptr) < k) {                                                \
+     bsg_printf("[kernel %d] Waiting for sync_ptr == %d (%d)", x, k, sync_val);       \
+  }                                                                                   \
+                                                                                      \
+  return 0;                                                                           \
+}
+
+extern "C" void bsg_barrier_amoadd(int*, int*);
+int amoadd_lock __attribute__ ((section (".dram"))) = 0;
+int amoadd_alarm = 1;
+
+int buffer[K*N] __attribute__ ((section (".dram")));
+int sync __attribute__ ((section (".dram"))) = 0;
+
+KERNEL_DEF(0)
+KERNEL_DEF(1)
+KERNEL_DEF(2)
+KERNEL_DEF(3)
+KERNEL_DEF(4)
+KERNEL_DEF(5)
+KERNEL_DEF(6)
+KERNEL_DEF(7)
+
+void preamble() {
+    for (int j = 0; j < K; j++) {
+        for (int i = 0; i < N; i++) { /* fill A with increasing data */
+            buffer[j*N+i] = i;
+            bsg_printf("Host Buffer Initial[%d]: %d\n", j*N+i, i);
+        }
+    }
+}
+
+void postamble() {
+    for (int j = 0; j < K; j++) {
+        for (int i = 0; i < N; i++) {
+            bsg_printf("Host Buffer Final[%d]: %d\n", j*N+i, buffer[j*N+i]);
+            if (buffer[j*N+i] != (j+1)*100+i) {
+                bsg_printf("MISMATCH: %d != %d\n", buffer[j*N+i], (j+1)*100+i);
+                bsg_fail();
+            }
+        }
+    }
+    bsg_finish();
+}
+
+int main()
+{
+  /************************************************************************
+   This will setup the  X/Y coordination. Current pre-defined corrdinations
+   includes:
+        __bsg_x         : The X cord inside the group
+        __bsg_y         : The Y cord inside the group
+        __bsg_org_x     : The origin X cord of the group
+        __bsg_org_y     : The origin Y cord of the group
+  *************************************************************************/
+  bsg_set_tile_x_y();
+  bsg_fence();
+
+  // Do some setup
+  if (__bsg_id == 0) {
+    preamble();
+  }
+
+  // Jump to the actual kernels
+  bsg_barrier_amoadd(&amoadd_lock, &amoadd_alarm); 
+  switch (__bsg_id) {
+    case 0: kernel0(buffer, N, &sync, K); break;
+    case 1: kernel1(buffer, N, &sync, K); break;
+    case 2: kernel2(buffer, N, &sync, K); break;
+    case 3: kernel3(buffer, N, &sync, K); break;
+    case 4: kernel4(buffer, N, &sync, K); break;
+    case 5: kernel5(buffer, N, &sync, K); break;
+    case 6: kernel6(buffer, N, &sync, K); break;
+    case 7: kernel7(buffer, N, &sync, K); break;
+  }
+  bsg_barrier_amoadd(&amoadd_lock, &amoadd_alarm); 
+
+  // Do some cleanup  
+  if (__bsg_id == 0) {
+    postamble();
+  }
+
+  // Spin
+  bsg_wait_while(1);
+}
+

--- a/software/spmd/test_multispsc/Makefile
+++ b/software/spmd/test_multispsc/Makefile
@@ -1,0 +1,45 @@
+bsg_tiles_X = 4
+bsg_tiles_Y = 2
+
+all: main.run
+
+# library functions
+LIBRARY_OBJECTS += bsg_barrier_amoadd.o
+
+# kernel functions
+KERNEL_OBJECTS += kernel0.o
+KERNEL_OBJECTS += kernel1.o
+KERNEL_OBJECTS += kernel2.o
+KERNEL_OBJECTS += kernel3.o
+KERNEL_OBJECTS += kernel4.o
+KERNEL_OBJECTS += kernel5.o
+KERNEL_OBJECTS += kernel6.o
+KERNEL_OBJECTS += kernel7.o
+
+# Main function
+MAIN_OBJECTS = main.o
+
+include ../Makefile.include
+
+# Main build rule, most likely unmodified
+OBJECT_FILES = $(LIBRARY_OBJECTS) $(KERNEL_OBJECTS) $(MAIN_OBJECTS)
+main.riscv: $(LINK_SCRIPT) $(OBJECT_FILES) $(BSG_MANYCORE_LIB) crt.o
+	$(RISCV_LINK) $(OBJECT_FILES) -L. "-l:$(BSG_MANYCORE_LIB)" -o $@ $(RISCV_LINK_OPTS)
+
+# Additional dependency to rebuild from makefile
+main.o: Makefile
+
+# Special rules to build kernels
+kernel0.o: RISCV_GXX_EXTRA_OPTS += ""
+kernel1.o: RISCV_GXX_EXTRA_OPTS += ""
+kernel2.o: RISCV_GXX_EXTRA_OPTS += ""
+kernel3.o: RISCV_GXX_EXTRA_OPTS += ""
+kernel4.o: RISCV_GXX_EXTRA_OPTS += ""
+kernel5.o: RISCV_GXX_EXTRA_OPTS += ""
+kernel6.o: RISCV_GXX_EXTRA_OPTS += ""
+kernel7.o: RISCV_GXX_EXTRA_OPTS += ""
+
+# Global rules
+RISCV_GXX_EXTRA_OPTS += -DBUFFER_ELS=24 -DCHAIN_LEN=8 -DNUM_PACKETS=10
+
+include ../../mk/Makefile.tail_rules

--- a/software/spmd/test_multispsc/kernel0.cpp
+++ b/software/spmd/test_multispsc/kernel0.cpp
@@ -1,0 +1,18 @@
+
+#include "bsg_manycore.h"
+#include "bsg_set_tile_x_y.h"
+#include "bsg_manycore_spsc_queue.hpp"
+
+extern "C" __attribute__ ((noinline))
+void kernel0(int *send_buffer, int *send_count) {
+    bsg_manycore_spsc_queue_send<int, BUFFER_ELS> send_spsc(send_buffer, send_count);
+
+    for (int p = 0; p < NUM_PACKETS; p++) {
+        int recv_data = (p << 8);
+        int send_data = recv_data | (1 << 0);
+
+        //bsg_printf("[0] RECV: %x SEND: %x\n", recv_data, send_data);
+        send_spsc.send(send_data);
+    }
+}
+

--- a/software/spmd/test_multispsc/kernel1.cpp
+++ b/software/spmd/test_multispsc/kernel1.cpp
@@ -1,0 +1,19 @@
+
+#include "bsg_manycore.h"
+#include "bsg_set_tile_x_y.h"
+#include "bsg_manycore_spsc_queue.hpp"
+
+extern "C" __attribute__ ((noinline))
+void kernel1(int *recv_buffer, int *recv_count, int *send_buffer, int *send_count) {
+    bsg_manycore_spsc_queue_recv<int, BUFFER_ELS> recv_spsc(recv_buffer, recv_count);
+    bsg_manycore_spsc_queue_send<int, BUFFER_ELS> send_spsc(send_buffer, send_count);
+
+    while (1) {
+        int recv_data = recv_spsc.recv();
+        int send_data = recv_data | (1 << 1);
+        //bsg_printf("[1] RECV: %x SEND: %x\n", recv_data, send_data);
+
+        send_spsc.send(send_data);
+    }
+}
+

--- a/software/spmd/test_multispsc/kernel2.cpp
+++ b/software/spmd/test_multispsc/kernel2.cpp
@@ -1,0 +1,19 @@
+
+#include "bsg_manycore.h"
+#include "bsg_set_tile_x_y.h"
+#include "bsg_manycore_spsc_queue.hpp"
+
+extern "C" __attribute__ ((noinline))
+void kernel2(int *recv_buffer, int *recv_count, int *send_buffer, int *send_count) {
+    bsg_manycore_spsc_queue_recv<int, BUFFER_ELS> recv_spsc(recv_buffer, recv_count);
+    bsg_manycore_spsc_queue_send<int, BUFFER_ELS> send_spsc(send_buffer, send_count);
+
+    while (1) {
+        int recv_data = recv_spsc.recv();
+        int send_data = recv_data | (1 << 2);
+        //bsg_printf("[2] RECV: %x SEND: %x\n", recv_data, send_data);
+
+        send_spsc.send(send_data);
+    }
+}
+

--- a/software/spmd/test_multispsc/kernel3.cpp
+++ b/software/spmd/test_multispsc/kernel3.cpp
@@ -1,0 +1,19 @@
+
+#include "bsg_manycore.h"
+#include "bsg_set_tile_x_y.h"
+#include "bsg_manycore_spsc_queue.hpp"
+
+extern "C" __attribute__ ((noinline))
+void kernel3(int *recv_buffer, int *recv_count, int *send_buffer, int *send_count) {
+    bsg_manycore_spsc_queue_recv<int, BUFFER_ELS> recv_spsc(recv_buffer, recv_count);
+    bsg_manycore_spsc_queue_send<int, BUFFER_ELS> send_spsc(send_buffer, send_count);
+
+    while (1) {
+        int recv_data = recv_spsc.recv();
+        int send_data = recv_data | (1 << 3);
+        //bsg_printf("[3] RECV: %x SEND: %x\n", recv_data, send_data);
+
+        send_spsc.send(send_data);
+    }
+}
+

--- a/software/spmd/test_multispsc/kernel4.cpp
+++ b/software/spmd/test_multispsc/kernel4.cpp
@@ -1,0 +1,19 @@
+
+#include "bsg_manycore.h"
+#include "bsg_set_tile_x_y.h"
+#include "bsg_manycore_spsc_queue.hpp"
+
+extern "C" __attribute__ ((noinline))
+void kernel4(int *recv_buffer, int *recv_count, int *send_buffer, int *send_count) {
+    bsg_manycore_spsc_queue_recv<int, BUFFER_ELS> recv_spsc(recv_buffer, recv_count);
+    bsg_manycore_spsc_queue_send<int, BUFFER_ELS> send_spsc(send_buffer, send_count);
+
+    while (1) {
+        int recv_data = recv_spsc.recv();
+        int send_data = recv_data | (1 << 4);
+        //bsg_printf("[4] RECV: %x SEND: %x\n", recv_data, send_data);
+
+        send_spsc.send(send_data);
+    }
+}
+

--- a/software/spmd/test_multispsc/kernel5.cpp
+++ b/software/spmd/test_multispsc/kernel5.cpp
@@ -1,0 +1,18 @@
+
+#include "bsg_manycore.h"
+#include "bsg_set_tile_x_y.h"
+#include "bsg_manycore_spsc_queue.hpp"
+
+extern "C" __attribute__ ((noinline))
+void kernel5(int *recv_buffer, int *recv_count, int *send_buffer, int *send_count) {
+    bsg_manycore_spsc_queue_recv<int, BUFFER_ELS> recv_spsc(recv_buffer, recv_count);
+    bsg_manycore_spsc_queue_send<int, BUFFER_ELS> send_spsc(send_buffer, send_count);
+
+    while (1) {
+        int recv_data = recv_spsc.recv();
+        int send_data = recv_data | (1 << 5);
+        //bsg_printf("[5] RECV: %x SEND: %x\n", recv_data, send_data);
+
+        send_spsc.send(send_data);
+    }
+}

--- a/software/spmd/test_multispsc/kernel6.cpp
+++ b/software/spmd/test_multispsc/kernel6.cpp
@@ -1,0 +1,18 @@
+
+#include "bsg_manycore.h"
+#include "bsg_set_tile_x_y.h"
+#include "bsg_manycore_spsc_queue.hpp"
+
+extern "C" __attribute__ ((noinline))
+void kernel6(int *recv_buffer, int *recv_count, int *send_buffer, int *send_count) {
+    bsg_manycore_spsc_queue_recv<int, BUFFER_ELS> recv_spsc(recv_buffer, recv_count);
+    bsg_manycore_spsc_queue_send<int, BUFFER_ELS> send_spsc(send_buffer, send_count);
+
+    while (1) {
+        int recv_data = recv_spsc.recv();
+        int send_data = recv_data | (1 << 6);
+        //bsg_printf("[6] RECV: %x SEND: %x\n", recv_data, send_data);
+
+        send_spsc.send(send_data);
+    }
+}

--- a/software/spmd/test_multispsc/kernel7.cpp
+++ b/software/spmd/test_multispsc/kernel7.cpp
@@ -1,0 +1,25 @@
+
+#include "bsg_manycore.h"
+#include "bsg_set_tile_x_y.h"
+#include "bsg_manycore_spsc_queue.hpp"
+
+extern "C" __attribute__ ((noinline))
+void kernel7(int *recv_buffer, int *recv_count) {
+  bsg_manycore_spsc_queue_recv<int, BUFFER_ELS> recv_spsc(recv_buffer, recv_count);
+
+  for (int p = 0; p < NUM_PACKETS; p++) {
+    int recv_data = recv_spsc.recv();
+    int send_data = recv_data | (1 << 7);
+    //bsg_printf("[7] RECV: %x SEND: %x\n", recv_data, send_data);
+
+    int actual = send_data;
+    int expected = (p << 8) | 0xff;
+    if (actual != expected) {
+      bsg_printf("[mismatch] actual: %x expected: %x\n", actual, expected);
+      bsg_fail();
+    } else {
+      bsg_printf("[match] actual: %x expected: %x\n", actual, expected);
+    }
+  }
+}
+

--- a/software/spmd/test_multispsc/main.cpp
+++ b/software/spmd/test_multispsc/main.cpp
@@ -1,0 +1,90 @@
+// This file defines N number of mostly identical kernels (up to 16 currently)
+// These kernels will
+// - print hello from a tile
+// - process an input buffer of size N by adding 100*its kernel id
+// - sync using a global AMOADD, waiting for all K kernels to reach
+
+#include "bsg_manycore.h"
+#include "bsg_set_tile_x_y.h"
+#include "bsg_manycore_atomic.h"
+
+// Declaring kernels as extern
+extern "C" int kernel0(int *send_buffer, int *send_count);
+extern "C" int kernel1(int *send_buffer, int *send_count, int *recv_buffer, int *recv_count);
+extern "C" int kernel2(int *send_buffer, int *send_count, int *recv_buffer, int *recv_count);
+extern "C" int kernel3(int *send_buffer, int *send_count, int *recv_buffer, int *recv_count);
+extern "C" int kernel4(int *send_buffer, int *send_count, int *recv_buffer, int *recv_count);
+extern "C" int kernel5(int *send_buffer, int *send_count, int *recv_buffer, int *recv_count);
+extern "C" int kernel6(int *send_buffer, int *send_count, int *recv_buffer, int *recv_count);
+extern "C" int kernel7(int *recv_buffer, int *recv_count);
+
+// Some global variables needed for the kernels
+int buffer_chain [CHAIN_LEN*BUFFER_ELS] __attribute__ ((section (".dram"))) = {0};
+int buffer_count [CHAIN_LEN] __attribute__ ((section (".dram"))) = {0};
+
+// Some global variables needed for amoadd barrier
+extern "C" void bsg_barrier_amoadd(int*, int*);
+int amoadd_lock __attribute__ ((section (".dram"))) = 0;
+int amoadd_alarm = 1;
+
+// Preamble, setup only done by core 0
+void preamble() {
+   bsg_printf("Core%d preamble...\n", __bsg_id);
+}
+
+// Postamble, cleanup only done by core 7
+void postamble() {
+  bsg_printf("Core%d postamble...\n", __bsg_id);
+  bsg_finish();
+}
+
+int main()
+{
+  /************************************************************************
+   This will setup the  X/Y coordination. Current pre-defined corrdinations
+   includes:
+        __bsg_x         : The X cord inside the group
+        __bsg_y         : The Y cord inside the group
+        __bsg_org_x     : The origin X cord of the group
+        __bsg_org_y     : The origin Y cord of the group
+  *************************************************************************/
+  bsg_set_tile_x_y();
+  bsg_fence();
+
+  // Do some setup from your "host" tile
+  if (__bsg_id == 0) {
+    preamble();
+  }
+
+  // Launch to individual kernels
+  // (must synchronize before)
+  bsg_barrier_amoadd(&amoadd_lock, &amoadd_alarm); 
+  switch (__bsg_id) {
+    case 0: kernel0(
+                    &buffer_chain[1*BUFFER_ELS], &buffer_count[1]); break;
+    case 1: kernel1(&buffer_chain[1*BUFFER_ELS], &buffer_count[1],
+                    &buffer_chain[2*BUFFER_ELS], &buffer_count[2]); break;
+    case 2: kernel2(&buffer_chain[2*BUFFER_ELS], &buffer_count[2],
+                    &buffer_chain[3*BUFFER_ELS], &buffer_count[3]); break;
+    case 3: kernel3(&buffer_chain[3*BUFFER_ELS], &buffer_count[3],
+                    &buffer_chain[4*BUFFER_ELS], &buffer_count[4]); break;
+    case 4: kernel4(&buffer_chain[4*BUFFER_ELS], &buffer_count[4],
+                    &buffer_chain[5*BUFFER_ELS], &buffer_count[5]); break;
+    case 5: kernel5(&buffer_chain[5*BUFFER_ELS], &buffer_count[5],
+                    &buffer_chain[6*BUFFER_ELS], &buffer_count[6]); break;
+    case 6: kernel6(&buffer_chain[6*BUFFER_ELS], &buffer_count[6],
+                    &buffer_chain[7*BUFFER_ELS], &buffer_count[7]); break;
+    case 7: kernel7(&buffer_chain[7*BUFFER_ELS], &buffer_count[7]
+                                                                 ); break;
+                    
+  }
+
+  // Do some cleanup if necessary 
+  if (__bsg_id == 7) {
+    postamble();
+  }
+
+  // Spin
+  bsg_wait_while(1);
+}
+


### PR DESCRIPTION
This PR adds a multi-kernel SPSC example, which demonstrates how to combine several kernels together and run them in a single binary, using a single tile as a "host" core.

- test_multifunction demonstrates each tile having its own kernel function
- test_multikernel demonstrates each tile having its own kernel object
- test_multispsc demonstrates communicating between these kernels using SPSC, initialized by the "host" core.

Further documentation to come

Depends on #682 #687 