### PR TITLE
Linker move read-only data from DRAM to DMEM

### DIFF
--- a/software/py/bsg_manycore_link_gen.py
+++ b/software/py/bsg_manycore_link_gen.py
@@ -155,7 +155,9 @@ class bsg_manycore_link_gen:
       # <output section>: [<input sections>]
       ['.text.dram'        , ['.text.interrupt', '.crtbegin','.text','.text.startup','.text.*']],
       # bsg-tommy: 8 bytes are allocated in.dmem.interrupt for interrupt handler to spill registers.
-      ['.dmem'             , ['.dmem.interrupt', '.dmem','.dmem.*']],
+      ['.dmem'             , ['.dmem.interrupt', '.dmem','.dmem.*',
+                              '.rodata','.rodata*','.srodata.cst16','.srodata.cst8',
+                              '.srodata.cst4', '.srodata.cst2','.srodata*']],
       ['.data'             , ['.data','.data*']],
       ['.sdata'            , ['.sdata','.sdata.*','.sdata*','.sdata*.*'
                               '.gnu.linkonce.s.*']],
@@ -165,8 +167,6 @@ class bsg_manycore_link_gen:
       ['.tbss'             , ['.tbss','.tbss*']],
       ['.striped.data.dmem', ['.striped.data']],
       ['.eh_frame.dram'    , ['.eh_frame','.eh_frame*']],
-      ['.rodata.dram'      , ['.rodata','.rodata*','.srodata.cst16','.srodata.cst8',
-                              '.srodata.cst4', '.srodata.cst2','.srodata*']],
       ['.dram'             , ['.dram','.dram.*']],
       ]
 


### PR DESCRIPTION
This PR moves `.rodata','.rodata*','.srodata.cst16','.srodata.cst8', '.srodata.cst4', '.srodata.cst2','.srodata*'` from DRAM to DMEM. The `hb_hammerhead/blackscholes` test used to use this linker.

- Pros: Useful when we want read-only data stored locally, or when DRAM is unavailable
- Cons: Will take up more space in DMEM, especially when rodata is large

@tommydcjung Do you think it is okay to move all rodata to DMEM on the master branch?