### PR TITLE
Use bash shell in riscv-tools Makefile

### DIFF
--- a/software/riscv-tools/Makefile
+++ b/software/riscv-tools/Makefile
@@ -73,7 +73,7 @@ export CC=gcc
 export CXX=g++
 export SED=sed
 export PATH
-export SHELL:=$(SHELL)
+export SHELL:=/bin/bash
 
 APPLY_PATCH  ?= git apply --ignore-whitespace --ignore-space-change
 CHECK_PATCH  ?= $(APPLY_PATCH) --check --reverse


### PR DESCRIPTION
The Makefile currently uses &> which works in bash, but not other shells. On Ubuntu 20.04.6 LTS, `make` uses /bin/sh, which is a symlink to dash. dash does not support this syntax.
    
This PR explicitly sets the shell to bash in the Makefile.

Issue reported in https://github.com/black-parrot-hdk/zynq-parrot/issues/106.