### PR TITLE
Adding a flag to linker gen script to move rodata to dmem;

### DIFF
--- a/software/mk/Makefile.builddefs
+++ b/software/mk/Makefile.builddefs
@@ -161,6 +161,15 @@ else
   $(error Invalid BSG_ELF_OFF_CHIP_MEM = $(BSG_ELF_OFF_CHIP_MEM); Only 0 and 1 are valid)
 endif
 
+# Linker gen: move rodata to dmem;
+# Set this to 1 to place constants in dmem instead of in dram;
+# By default, this is set to 0;
+LINK_GEN_MOVE_RODATA_TO_DMEM?=0
+ifeq ($(LINK_GEN_MOVE_RODATA_TO_DMEM),1)
+	LINK_GEN_OPTS += --move_rodata_to_dmem
+endif
+
+
 LINK_SCRIPT ?= $(CURR_DIR)/bsg_link.ld
 
 $(CURR_DIR)/bsg_link.ld: $(LINK_GEN)

--- a/software/py/bsg_manycore_link_gen.py
+++ b/software/py/bsg_manycore_link_gen.py
@@ -55,6 +55,7 @@ class bsg_manycore_link_gen:
         + " dram memory size: 0x{0:08x}\n".format(dram_size) \
         + " imem allocated size: 0x{0:08x}\n".format(imem_size) \
         + " stack pointer init: 0x{0:08x}\n".format(sp) \
+        + " move_rodata_to_dmem: {}\n".format(move_rodata_to_dmem) \
         + "\n" \
         + " Generated at " + str(datetime.now()) + "\n" \
       + "**********************************************************/\n"
@@ -149,19 +150,14 @@ class bsg_manycore_link_gen:
         if sec == ".rodata.dram":
           ro_idx = i
           break
-      section_map.pop(ro_idx)
+      popped_rodata_dram_map = section_map.pop(ro_idx)
 
       # add to .dmem
       for i, m in enumerate(section_map):
         sec = m[0]
         if sec == ".dmem":
-          m[1].append(".rodata")
-          m[1].append(".rodata*")
-          m[1].append(".srodata.cst16")
-          m[1].append(".srodata.cst8")
-          m[1].append(".srodata.cst4")
-          m[1].append(".srodata.cst2")
-          m[1].append(".srodata*")
+          for in_sec in popped_rodata_dram_map[1]:
+            m[1].append(in_sec)
       
     return section_map
     


### PR DESCRIPTION
- Adding a flag --move_rodata_to_dmem.
- By default, this flag is turned off.