### PR TITLE
[WIP] Add uncached IO instructions

### DIFF
--- a/software/spmd/uncached_io_test/Makefile
+++ b/software/spmd/uncached_io_test/Makefile
@@ -1,0 +1,17 @@
+bsg_tiles_X ?= 16
+bsg_tiles_Y ?= 8
+
+
+all: main.run
+
+OBJECT_FILES=main.o
+
+include ../Makefile.include
+
+main.riscv: $(LINK_SCRIPT) $(OBJECT_FILES) $(SPMD_COMMON_OBJECTS) $(BSG_MANYCORE_LIB) crt.o
+	$(RISCV_LINK) $(OBJECT_FILES) $(SPMD_COMMON_OBJECTS) -L. "-l:$(BSG_MANYCORE_LIB)" -o $@ $(RISCV_LINK_OPTS)
+
+
+main.o: Makefile
+
+include ../../mk/Makefile.tail_rules

--- a/software/spmd/uncached_io_test/main.c
+++ b/software/spmd/uncached_io_test/main.c
@@ -1,0 +1,52 @@
+#include "bsg_manycore.h"
+#include "bsg_set_tile_x_y.h"
+
+#define N 536870912
+//#define N 32768
+#define VCACHE_LINE_WORDS 8
+
+
+#define cbo_inval_block(addr) ({ \
+  __asm__ __volatile__ (".insn i 0x0f, 0b010, x0, %0, 0x0" : : "r" (addr)); \
+  })
+
+#define cbo_clean_block(addr) ({ \
+  __asm__ __volatile__ (".insn i 0x0f, 0b010, x0, %0, 0x1" : : "r" (addr)); \
+  })
+
+#define cbo_flush_block(addr) ({ \
+  __asm__ __volatile__ (".insn i 0x0f, 0b010, x0, %0, 0x2" : : "r" (addr)); \
+  })
+
+#define cbo_taglv(ret, addr) ({ \
+  __asm__ __volatile__ (".insn i 0x0f, 0b010, %0, %1, 0x3" : "=r" (ret) : "r" (addr)); \
+  })
+
+// 0(rs1) <- rs2
+#define uncached_write(rs1, rs2) ({ \
+  __asm__ __volatile__ (".insn r 0b0100011, 0b111, 0x0, x0, %0, %1" : : "r" (rs1), "r" (rs2)); \
+  })
+
+// rd <- 0(rs1)
+#define uncached_read(rd, rs1) ({ \
+  __asm__ __volatile__ (".insn i 0b0000011, 0b111, %0, %1, 0x0" : "=r" (rd) : "r" (rs1)); \
+  })
+
+
+int main()
+{
+  unsigned ret = -1;
+  unsigned rs1 = 0;
+  unsigned rs2 = 123;
+  bsg_set_tile_x_y();
+  uncached_write(rs1, rs2);
+  uncached_read(ret, rs1);
+
+  if(ret == rs2)
+    bsg_finish();
+  else
+    bsg_fail();
+
+  bsg_wait_while(1);
+}
+

--- a/v/bsg_manycore_pkg.sv
+++ b/v/bsg_manycore_pkg.sv
@@ -33,6 +33,8 @@ package bsg_manycore_pkg;
     , e_remote_amomax
     , e_remote_amominu
     , e_remote_amomaxu
+    , e_remote_uncached_load // load word
+    , e_remote_uncached_store // store word
   } bsg_manycore_packet_op_e;
 
 

--- a/v/vanilla_bean/bsg_vanilla_pkg.sv
+++ b/v/vanilla_bean/bsg_vanilla_pkg.sv
@@ -57,6 +57,7 @@ typedef struct packed
 {
   logic write_not_read;
   logic is_amo_op;
+  logic is_uncached_op;
   bsg_vanilla_amo_type_e amo_type;
   logic [3:0] mask;
   bsg_manycore_load_info_s load_info;
@@ -125,6 +126,9 @@ typedef struct packed {
   logic is_amo_aq;
   logic is_amo_rl;
   bsg_vanilla_amo_type_e amo_type;
+
+  // Uncached IO
+  logic is_uncached_op;
 
   // FPU
   logic is_fp_op;           // goes into FP_EXE

--- a/v/vanilla_bean/cl_decode.sv
+++ b/v/vanilla_bean/cl_decode.sv
@@ -116,7 +116,11 @@ assign decode_o.is_hex_op =
   (is_rv32_load & (instruction_i.funct3 ==? 3'b?01)) |
   (is_rv32_store & (instruction_i.funct3 == 3'b001));
 assign decode_o.is_load_unsigned =
-  is_rv32_load & (instruction_i.funct3 ==? 3'b10?);
+  is_rv32_load & (instruction_i.funct3 ==? 3'b10? | instruction_i.funct3 == 3'b111);
+
+// UNCACHED IO
+assign decode_o.is_uncached_op = (is_rv32_load | is_rv32_store) &
+  (instruction_i.funct3 == 3'b111);
 
 // Branch & Jump
 assign decode_o.is_branch_op = instruction_i.op ==? `RV32_BRANCH;
@@ -237,7 +241,6 @@ end
 
 assign decode_o.is_amo_aq = instruction_i[26];
 assign decode_o.is_amo_rl = instruction_i[25];
-
 
 //+----------------------------------------------
 //|

--- a/v/vanilla_bean/lsu.sv
+++ b/v/vanilla_bean/lsu.sv
@@ -132,13 +132,14 @@ module lsu
         is_unsigned_op: exe_decode_i.is_load_unsigned,
         is_byte_op: exe_decode_i.is_byte_op,
         is_hex_op: exe_decode_i.is_hex_op,
-        part_sel: mem_addr[1:0]
+        part_sel: exe_decode_i.is_uncached_op ? 2'b00 : mem_addr[1:0]
       };
     end
 
     remote_req_o = '{
       write_not_read : (exe_decode_i.is_store_op),
       is_amo_op : exe_decode_i.is_amo_op, 
+      is_uncached_op : exe_decode_i.is_uncached_op,
       amo_type : exe_decode_i.amo_type,
       mask: store_mask,
       load_info : load_info,


### PR DESCRIPTION
This PR aims to provide two new custom RISC-V instructions - uncached read and uncached write.

* The proxy vcaches for the uncached IO requests are currently the whatever the Vcache a tile is nearest to. This is reflected in network_tx.sv.

* This work has been tested with a simple newly added spmd test that does an uncached write and then uncached read. Since it hasn't been interfaced with the Vcache side of work, module bsg_manycore_link_to_cache hasn't been changed and the current behavior is mapping the uncached read/write back to regular read and write cache op in bsg_manycore_link_to_cache. This module will be changed once we start interfacing with the Vcache work.