### PR TITLE
Sets sense to 1 in init for amoadd barrier

### DIFF
--- a/software/bsg_manycore_lib/bsg_cuda_lite_barrier.h
+++ b/software/bsg_manycore_lib/bsg_cuda_lite_barrier.h
@@ -29,6 +29,8 @@ static inline void bsg_barrier_tile_group_init()
     asm volatile ("csrrwi x0, 0xfc2, 0");
     // sync with amoadd barrier
     bsg_barrier_amoadd(&__cuda_barrier_cfg[0], &sense0);
+    #else
+    sense = 1;
     #endif
 }
 


### PR DESCRIPTION
Before this fix: if a cuda kernel invokes the barrier an odd number of times when using the amoadd barrier, then a second kernel launch will hang since barrier is always initialized to zero by the host.

After this fix: the sense is initialized to 1 and the barrier is set to 0.