### PR TITLE
Allow llvm installation with gcc11

### DIFF
--- a/software/mk/Makefile.llvminstall
+++ b/software/mk/Makefile.llvminstall
@@ -4,7 +4,7 @@ endif
 
 # devtoolset-8
 GCCVERSION = $(shell gcc -dumpversion)
-ifeq ($(shell expr $(GCCVERSION) \> 7)$(shell expr $(GCCVERSION) \< 10), 11)
+ifeq ($(shell expr $(GCCVERSION) \> 7)$(shell expr $(GCCVERSION) \< 12), 11)
 HOST_TOOLCHAIN ?=
 $(info Using default GCCVERSION $(GCCVERSION))
 else


### PR DESCRIPTION
Allow llvm installation with gcc11. This would be useful for OS that does not support devtoolset-8 (like Rocky 9 with gcc11 as default)

Tested with gcc 9.3.1, 10.2.1, 11.2.1 and 11.5.0 (llvm installation finished)