### PR TITLE
Some fixes

### DIFF
--- a/software/spmd/uncached_io_test/Makefile
+++ b/software/spmd/uncached_io_test/Makefile
@@ -1,6 +1,6 @@
-bsg_tiles_X ?= 1
-bsg_tiles_Y ?= 1
-
+bsg_tiles_X ?= 4
+bsg_tiles_Y ?= 4
+NUM_FINISH = $(call bsg-times-fn,$(bsg_tiles_X),$(bsg_tiles_Y))
 
 all: main.run
 

--- a/software/spmd/uncached_io_test/main.c
+++ b/software/spmd/uncached_io_test/main.c
@@ -1,27 +1,6 @@
 #include "bsg_manycore.h"
 #include "bsg_set_tile_x_y.h"
 
-#define N 536870912
-//#define N 32768
-#define VCACHE_LINE_WORDS 8
-
-
-#define cbo_inval_block(addr) ({ \
-  __asm__ __volatile__ (".insn i 0x0f, 0b010, x0, %0, 0x0" : : "r" (addr)); \
-  })
-
-#define cbo_clean_block(addr) ({ \
-  __asm__ __volatile__ (".insn i 0x0f, 0b010, x0, %0, 0x1" : : "r" (addr)); \
-  })
-
-#define cbo_flush_block(addr) ({ \
-  __asm__ __volatile__ (".insn i 0x0f, 0b010, x0, %0, 0x2" : : "r" (addr)); \
-  })
-
-#define cbo_taglv(ret, addr) ({ \
-  __asm__ __volatile__ (".insn i 0x0f, 0b010, %0, %1, 0x3" : "=r" (ret) : "r" (addr)); \
-  })
-
 // 0(rs1) <- rs2
 #define uncached_write(rs1, rs2) ({ \
   __asm__ __volatile__ (".insn r 0b0100011, 0b111, 0x0, x0, %0, %1" : : "r" (rs1), "r" (rs2)); \

--- a/testbenches/common/v/bsg_nonsynth_wormhole_test_uncached_io.sv
+++ b/testbenches/common/v/bsg_nonsynth_wormhole_test_uncached_io.sv
@@ -107,7 +107,7 @@ module bsg_nonsynth_wormhole_test_uncached_io
   assign header_flit_out.src_cord = '0;   // dont care
   assign header_flit_out.src_cid = '0;   // dont care
   assign header_flit_out.cid = src_cid_r;
-  assign header_flit_out.len = wh_len_width_p'(data_len_lp);
+  assign header_flit_out.len = wh_len_width_p'(1);
   assign header_flit_out.cord = src_cord_r;
 
   always_comb begin


### PR DESCRIPTION
Fix incorrect flit count in nonsynth mem for uncached IO operations. This PR only changes nonsynth part of RTL.
This change allows passing the uncached IO test with 16 tiles enabled.
@tommydcjung  @gaozihou  Thanks.