### PR TITLE
Fix incorrect dmem assertion

### DIFF
--- a/v/vanilla_bean/lsu.sv
+++ b/v/vanilla_bean/lsu.sv
@@ -93,8 +93,9 @@ module lsu
 
 
   // to local DMEM
-  //
-  wire is_local_dmem_addr = (mem_addr ==? 32'b00000000_00000000_0000????_????????);
+  // (Uncached IO space is a separate space)
+  wire is_local_dmem_addr = (mem_addr ==? 32'b00000000_00000000_0000????_????????)
+    & ~exe_decode_i.is_uncached_op;
 
   assign dmem_v_o = is_local_dmem_addr &
     (exe_decode_i.is_load_op | exe_decode_i.is_store_op |


### PR DESCRIPTION
Previously, dmem region was determined solely by mem_addr, and didn't exclude the case where the corresponding operation is uncached IO. This PR fixes that.

@tommydcjung @gaozihou Thanks