### PR TITLE
fix: type error and missing field error in nbf.py

### DIFF
--- a/software/py/nbf.py
+++ b/software/py/nbf.py
@@ -129,7 +129,7 @@ class NBF:
       stripped = line.strip()
       if stripped:
         if stripped.startswith("@"):
-          curr_addr = int(stripped.strip("@"), 16) / 4
+          curr_addr = int(stripped.strip("@"), 16) // 4
         else:
           words = stripped.split()
           #for i in range(len(words)/4):
@@ -176,8 +176,9 @@ class NBF:
     for line in lines:
       stripped = line.strip()
       words = stripped.split()
-      if words[2] == "_bsg_data_end_addr":
+      if words[2] == "_bsg_data_end_addr" or words[2] == b"_bsg_data_end_addr":
         self.bsg_data_end_addr = (int(words[0]) >> 2) # make it word address
+    assert hasattr(self, "bsg_data_end_addr"), "missing _bsg_data_end_addr from nm's stdout"
 
   # get the size of the spmd binary (text section) in unit of words.
   def get_spmd_binary_size(self):


### PR DESCRIPTION
# Background
I've been following the [Initial setup for running programs](https://github.com/Easyoakland/bsg_manycore#initial-setup-for-running-programs) part of the README and got stuck at "go into software/spmd/bsg_barrier and type make to run a test!". I believe the issue is fixed in this PR.

Am I doing something wrong trying to get into this project by following the [Initial setup for running programs](https://github.com/Easyoakland/bsg_manycore#initial-setup-for-running-programs) section of the README? How am I the first to encounter these errors?

I don't _think_ this is caused by a breaking change in Python, but in case it is, my Python version is `Python 3.10.12`

# Bug

When running `bsg_manycore/software/spmd/bsg_barrier$ IGNORE_CADENV=1 BSG_PLATFORM=verilator make` previously float division was used, but `float` can't be ANDed with an `int` so this causes an error.

Secondly, `stdout.readlines()` is `list[bytes]` not `list[str]` so the comparison check for "_bsg_data_end_addr" always failed, causing another error.

This PR adds fixes for both.

# Extra
The README says
> If you're developing on a branch called mybranch, please pull a branch called ci_mybranch based on mybranch to run CI and mybranch. It's advised to keep working on mybranch for incremental updates and rebase ci_mybranch on mybranch when it's ready for another CI run.

I'm not sure what this means. Should I change the branch name to have a `ci` prefix?