### PR TITLE
Miniblade rc2

### DIFF
--- a/testbenches/common/v/bsg_nonsynth_wormhole_test_uncached_io.sv
+++ b/testbenches/common/v/bsg_nonsynth_wormhole_test_uncached_io.sv
@@ -32,6 +32,8 @@ module bsg_nonsynth_wormhole_test_uncached_io
 
     , parameter wh_link_sif_width_lp =
       `bsg_ready_and_link_sif_width(wh_flit_width_p)
+
+    , localparam word_offset_width_lp = `BSG_SAFE_CLOG2(vcache_data_width_p>>3)
   )
   (
     input clk_i
@@ -192,13 +194,12 @@ module bsg_nonsynth_wormhole_test_uncached_io
     assign mem_addr = {
       src_cid_r[0+:wh_cid_width_p],
       src_cord_r[0+:lg_num_vcaches_lp],
-      addr_r[mem_addr_width_lp-lg_num_vcaches_lp-wh_cid_width_p-1:0]
+      (mem_addr_width_lp-lg_num_vcaches_lp-wh_cid_width_p)'(addr_r[wh_flit_width_p-1:word_offset_width_lp])
     };
   end
   else begin
-    assign mem_addr = addr_r;
+    assign mem_addr = (mem_addr_width_lp)'(addr_r[wh_flit_width_p-1:word_offset_width_lp]);
   end
-
 
   always_ff @ (posedge clk_i) begin
     if (reset_i) begin

--- a/testbenches/common/v/mini_testbench.sv
+++ b/testbenches/common/v/mini_testbench.sv
@@ -257,7 +257,7 @@ module mini_testbench
     ,.wh_flit_width_p(wh_flit_width_p)
     ,.wh_cord_width_p(wh_cord_width_p)
     ,.wh_len_width_p(wh_len_width_p)
-    ,.mem_size_p((2**29))
+    ,.mem_size_p((2**vcache_addr_width_p))
     ,.no_concentration_p(0)
   ) test_io (
     .clk_i(core_clk)

--- a/testbenches/common/v/mini_testbench.sv
+++ b/testbenches/common/v/mini_testbench.sv
@@ -257,7 +257,7 @@ module mini_testbench
     ,.wh_flit_width_p(wh_flit_width_p)
     ,.wh_cord_width_p(wh_cord_width_p)
     ,.wh_len_width_p(wh_len_width_p)
-    ,.mem_size_p(2*mem_size_lp)
+    ,.mem_size_p((2**29))
     ,.no_concentration_p(0)
   ) test_io (
     .clk_i(core_clk)

--- a/testbenches/common/v/mini_testbench.sv
+++ b/testbenches/common/v/mini_testbench.sv
@@ -257,7 +257,7 @@ module mini_testbench
     ,.wh_flit_width_p(wh_flit_width_p)
     ,.wh_cord_width_p(wh_cord_width_p)
     ,.wh_len_width_p(wh_len_width_p)
-    ,.mem_size_p((2**vcache_addr_width_p))
+    ,.mem_size_p((2**(32-1-`BSG_SAFE_CLOG2(num_tiles_x_p))))
     ,.no_concentration_p(0)
   ) test_io (
     .clk_i(core_clk)

--- a/v/vanilla_bean/network_tx.sv
+++ b/v/vanilla_bean/network_tx.sv
@@ -122,7 +122,7 @@ module network_tx
 //    ? {(pod_y_cord_width_p)'(pod_y_i + 1'b1), {y_subcord_width_lp{1'b0}}}
 //    : {(pod_y_cord_width_p)'(pod_y_i - 1'b1), {y_subcord_width_lp{1'b1}}};
 
-  wire [x_cord_width_p-1:0] proxy_x_cord_lo = {pod_x_i, io_addr[30:29]};
+  wire [x_cord_width_p-1:0] proxy_x_cord_lo = {pod_x_i, io_addr[30-:x_subcord_width_lp]};
   wire [y_cord_width_p-1:0] proxy_y_cord_lo = proxy_is_in_the_south
     ? {(pod_y_cord_width_p)'(pod_y_i + 1'b1), {y_subcord_width_lp{1'b0}}}
     : {(pod_y_cord_width_p)'(pod_y_i - 1'b1), {y_subcord_width_lp{1'b1}}};
@@ -177,7 +177,7 @@ module network_tx
     if (is_uncached_op) begin
       out_packet.y_cord = proxy_y_cord_lo;
       out_packet.x_cord = proxy_x_cord_lo;
-      out_packet.addr = (addr_width_p)'(io_addr[28:2]);
+      out_packet.addr = (addr_width_p)'(io_addr[30-x_subcord_width_lp:2]);
     end
     else begin
       out_packet.y_cord = y_cord_lo;

--- a/v/vanilla_bean/network_tx.sv
+++ b/v/vanilla_bean/network_tx.sv
@@ -112,15 +112,21 @@ module network_tx
   wire [x_cord_width_p-1:0] src_x_cord = {pod_x_i, my_x_i};
   wire [y_cord_width_p-1:0] src_y_cord = {pod_y_i, my_y_i};
 
-  wire proxy_is_in_the_south = src_y_cord[y_subcord_width_lp-1];
+  wire [31:0] io_addr = remote_req_i.addr;
+//  wire proxy_is_in_the_south = src_y_cord[y_subcord_width_lp-1];
+  wire proxy_is_in_the_south = io_addr[31];
 
   // Uncached requests will be sent to the nearest vcache
-  wire [x_cord_width_p-1:0] proxy_x_cord_lo = (x_cord_width_p)'(src_x_cord);
+//  wire [x_cord_width_p-1:0] proxy_x_cord_lo = (x_cord_width_p)'(src_x_cord);
+//  wire [y_cord_width_p-1:0] proxy_y_cord_lo = proxy_is_in_the_south
+//    ? {(pod_y_cord_width_p)'(pod_y_i + 1'b1), {y_subcord_width_lp{1'b0}}}
+//    : {(pod_y_cord_width_p)'(pod_y_i - 1'b1), {y_subcord_width_lp{1'b1}}};
+
+  wire [x_cord_width_p-1:0] proxy_x_cord_lo = {pod_x_i, io_addr[30:29]};
   wire [y_cord_width_p-1:0] proxy_y_cord_lo = proxy_is_in_the_south
     ? {(pod_y_cord_width_p)'(pod_y_i + 1'b1), {y_subcord_width_lp{1'b0}}}
     : {(pod_y_cord_width_p)'(pod_y_i - 1'b1), {y_subcord_width_lp{1'b1}}};
 
-  wire [addr_width_p-1:0] io_addr = remote_req_i.addr[addr_width_p+1:2];
 
   wire is_uncached_op = remote_req_i.is_uncached_op;
   // Uncached op does not carry eva
@@ -171,7 +177,7 @@ module network_tx
     if (is_uncached_op) begin
       out_packet.y_cord = proxy_y_cord_lo;
       out_packet.x_cord = proxy_x_cord_lo;
-      out_packet.addr = io_addr;
+      out_packet.addr = (addr_width_p)'(io_addr[28:2]);
     end
     else begin
       out_packet.y_cord = y_cord_lo;


### PR DESCRIPTION
The major changes is in the last commit. The first two commits are unmerged fixes from RC1.

In this PR, the uncached IO address has the following format: {vcache y cord (1 bit), vcache x cord (2 bits), IO address}. With that, programmers can now use the 3 MSBs to decide which Vcache the IO request would go to.

@tommydcjung @gaozihou Thanks!