### PR TITLE
Remove en_i from tag masters

### DIFF
--- a/testbenches/common/v/bsg_nonsynth_manycore_tag_master.sv
+++ b/testbenches/common/v/bsg_nonsynth_manycore_tag_master.sv
@@ -47,7 +47,6 @@ module bsg_nonsynth_manycore_tag_master
   ) tr (
     .clk_i(clk_i)
     ,.reset_i(reset_i)
-    ,.en_i(1'b1)
 
     ,.rom_addr_o(rom_addr)
     ,.rom_data_i(rom_data)
@@ -82,7 +81,6 @@ module bsg_nonsynth_manycore_tag_master
   ) btm (
     .clk_i(clk_i)
     ,.data_i(tr_en_r_lo & tr_valid_lo & tr_data_lo)
-    ,.en_i(1'b1)
     ,.clients_r_o({pod_tags_o})
   );
 


### PR DESCRIPTION
Needed for compatibility with: https://github.com/bespoke-silicon-group/basejump_stl/commit/7b55bbc36220206decb23850310693f0338de740