### PR TITLE
Partial revert of #766

### DIFF
--- a/testbenches/common/v/bsg_nonsynth_manycore_tag_master.sv
+++ b/testbenches/common/v/bsg_nonsynth_manycore_tag_master.sv
@@ -47,6 +47,7 @@ module bsg_nonsynth_manycore_tag_master
   ) tr (
     .clk_i(clk_i)
     ,.reset_i(reset_i)
+    ,.en_i(1'b1)
 
     ,.rom_addr_o(rom_addr)
     ,.rom_data_i(rom_data)


### PR DESCRIPTION
Hotfix: Accidentally removed the en_i from bsg_tag_trace_replay when it should have just been bsg_tag_master. This PR restores the enable