### PR TITLE
Build the HammerBlade RISC-V GCC toolchain on modern macOS

### DIFF
--- a/software/riscv-tools/Makefile
+++ b/software/riscv-tools/Makefile
@@ -27,6 +27,8 @@
 #
 .DEFAULT_GOAL := help
 
+.PHONY: checkout-riscv-gnu-tools install-gcc
+
 TARGET_ARCH       := rv32imaf
 TARGET_ABI        := ilp32f
 TARGET_CFLAGS     := '-fno-common'
@@ -46,13 +48,24 @@ SPIKE_URL         := https://github.com/riscv/riscv-isa-sim.git
 SPIKE_PATCH       := spike.patch
 SPIKE_GCC_PATCH   := spike-gcc.patch
 SPIKE_TAG         := v1.1.0
+BINUTILS_ZLIB_PATCH := $(abspath binutils-zlib-modern-macos.patch)
+GCC_LIBCXX_PATCH     := $(abspath gcc-modern-libcxx-safe-ctype.patch)
+GCC_ARM64_HOST_PATCH := $(abspath gcc-arm64-darwin-host-hooks.patch)
+NEWLIB_DRAMFS_PATCH  := $(abspath newlib-dramfs-modern-clang.patch)
 
 # How many thread you want to use compiling tools
 UNAME := $(shell uname)
 ifeq ($(UNAME),Linux)
-        NUMPROC := $(shell grep -c ^processor /proc/cpuinfo)
+        NUMPROC ?= $(shell grep -c ^processor /proc/cpuinfo)
 else ifeq ($(UNAME),Darwin)
-        NUMPROC := $(shell sysctl hw.ncpu | awk '{print $$2}')
+        NUMPROC ?= $(shell getconf _NPROCESSORS_ONLN)
+        export BINUTILS_TARGET_FLAGS_EXTRA ?= --disable-nls
+        HOMEBREW_PREFIX ?= $(shell command -v brew >/dev/null 2>&1 && brew --prefix)
+ifneq ($(HOMEBREW_PREFIX),)
+        export PATH := $(HOMEBREW_PREFIX)/opt/bison/bin:$(HOMEBREW_PREFIX)/opt/flex/bin:$(HOMEBREW_PREFIX)/opt/m4/bin:$(HOMEBREW_PREFIX)/opt/texinfo/bin:$(PATH)
+        export M4 := $(HOMEBREW_PREFIX)/opt/m4/bin/m4
+        export SED := $(HOMEBREW_PREFIX)/opt/gnu-sed/bin/gsed
+endif
 endif
 
 # Only take half as many processors as available
@@ -68,16 +81,17 @@ export RISCV_INSTALL_DIR ?= $(CURDIR)/riscv-install
 export RISCV_BIN_DIR ?= $(RISCV_INSTALL_DIR)/bin
 
 export RISCV:=$(RISCV_INSTALL_DIR)
-export SED=sed
+ifneq ($(UNAME),Darwin)
+export SED ?= sed
+endif
 export CC=gcc
 export CXX=g++
-export SED=sed
 export PATH
 export SHELL:=/bin/bash
 
 APPLY_PATCH  ?= git apply --ignore-whitespace --ignore-space-change
 CHECK_PATCH  ?= $(APPLY_PATCH) --check --reverse
-QUICK_CLONE  ?= git clone -j $(COMPILING_THREADS) --single-branch --recurse-submodules --shallow-submodules --shallow-since=2020-01-01
+QUICK_CLONE  ?= git clone -j $(COMPILING_THREADS) --single-branch --shallow-since=2020-01-01
 STABLE_CLONE ?= git clone
 
 # Git version
@@ -121,17 +135,24 @@ $(DEPENDS_DIR):
 		wget $$dep_url;			\
 	done
 
-checkout-riscv-gnu-tools: | $(TOOLCHAIN_REPO)
 $(TOOLCHAIN_REPO):
 	@echo "====================================="
 	@echo "Cloning riscv-toolchain repo..."
 	@echo "====================================="
 	$(GIT_CLONE) -b $(TOOLCHAIN_VERSION) $(TOOLCHAIN_URL) $(TOOLCHAIN_REPO) || \
 		echo "riscv-gnu-toolchain already cloned, reusing"
+
+checkout-riscv-gnu-tools: $(TOOLCHAIN_REPO)
 	cd $(TOOLCHAIN_REPO) && git submodule update --init --checkout riscv-binutils
 	cd $(TOOLCHAIN_REPO) && git submodule update --init --checkout riscv-glibc
 	cd $(TOOLCHAIN_REPO) && git submodule update --init --checkout riscv-gcc
 	cd $(TOOLCHAIN_REPO) && git submodule update --init --checkout riscv-newlib
+ifeq ($(UNAME),Darwin)
+	@$(call patch_if_new,$(TOOLCHAIN_REPO)/riscv-binutils,$(BINUTILS_ZLIB_PATCH))
+	@$(call patch_if_new,$(TOOLCHAIN_REPO)/riscv-gcc,$(GCC_LIBCXX_PATCH))
+	@$(call patch_if_new,$(TOOLCHAIN_REPO)/riscv-gcc,$(GCC_ARM64_HOST_PATCH))
+	@$(call patch_if_new,$(TOOLCHAIN_REPO)/riscv-newlib,$(NEWLIB_DRAMFS_PATCH))
+endif
 
 checkout-llvm: | $(LLVM_REPO)
 $(LLVM_REPO):
@@ -185,6 +206,9 @@ build-riscv-gnu-tools: configure-riscv-gnu-tools
 	@echo "====================================="
 	$(MAKE) -C $(TOOLCHAIN_REPO) -j $(COMPILING_THREADS) CFLAGS_FOR_TARGET_EXTRA=$(TARGET_CFLAGS)
 	$(MAKE) -C $(TOOLCHAIN_REPO) install
+
+install-gcc: checkout-riscv-gnu-tools
+	$(MAKE) build-riscv-gnu-tools
 
 build-spike:
 	@echo "====================================="
@@ -240,4 +264,3 @@ clean-all:
 installs:
 	sudo apt-get install autoconf automake libtool curl gawk bison flex texinfo gperf \
 		sed autotools-dev libmpc-dev libmpfr-dev libgmp-dev build-essential
-

--- a/software/riscv-tools/binutils-zlib-modern-macos.patch
+++ b/software/riscv-tools/binutils-zlib-modern-macos.patch
@@ -1,0 +1,13 @@
+diff --git a/zlib/zutil.h b/zlib/zutil.h
+index 9545145..90e9aa9 100644
+--- a/zlib/zutil.h
++++ b/zlib/zutil.h
+@@ -130,7 +130,7 @@ extern z_const char * const z_errmsg[10]; /* indexed by 2-zlib_error */
+ #  endif
+ #endif
+ 
+-#if defined(MACOS) || defined(TARGET_OS_MAC)
++#if defined(MACOS)
+ #  define OS_CODE  7
+ #  ifndef Z_SOLO
+ #    if defined(__MWERKS__) && __dest_os != __be_os && __dest_os != __win32_os

--- a/software/riscv-tools/gcc-arm64-darwin-host-hooks.patch
+++ b/software/riscv-tools/gcc-arm64-darwin-host-hooks.patch
@@ -1,0 +1,66 @@
+diff --git a/gcc/config.host b/gcc/config.host
+index e27eab789..034c24b51 100644
+--- a/gcc/config.host
++++ b/gcc/config.host
+@@ -250,6 +250,10 @@ case ${host} in
+     host_extra_gcc_objs="${host_extra_gcc_objs} driver-mingw32.o"
+     host_lto_plugin_soname=liblto_plugin-0.dll
+     ;;
++  arm*-*-darwin* | aarch64*-*-darwin*)
++    out_host_hook_obj="${out_host_hook_obj} host-aarch64-darwin.o"
++    host_xmake_file="${host_xmake_file} aarch64/x-darwin"
++    ;;
+   i[34567]86-*-darwin* | x86_64-*-darwin*)
+     out_host_hook_obj="${out_host_hook_obj} host-i386-darwin.o"
+     host_xmake_file="${host_xmake_file} i386/x-darwin"
+diff --git a/gcc/config/aarch64/host-aarch64-darwin.c b/gcc/config/aarch64/host-aarch64-darwin.c
+new file mode 100644
+index 000000000..7aaaf9dc6
+--- /dev/null
++++ b/gcc/config/aarch64/host-aarch64-darwin.c
+@@ -0,0 +1,16 @@
++/* arm64/aarch64 Darwin host-specific hook definitions.  */
++
++#define IN_TARGET_CODE 1
++
++#include "config.h"
++#include "system.h"
++#include "coretypes.h"
++#include "hosthooks.h"
++#include "hosthooks-def.h"
++#include "config/host-darwin.h"
++
++/* Darwin does not need additional arm64-specific hooks.  This translation
++   unit instantiates the generic Darwin hooks, matching current upstream
++   GCC's aarch64 Darwin host support.  */
++
++const struct host_hooks host_hooks = HOST_HOOKS_INITIALIZER;
+diff --git a/gcc/config/host-darwin.c b/gcc/config/host-darwin.c
+index 2643888e5..a15512073 100644
+--- a/gcc/config/host-darwin.c
++++ b/gcc/config/host-darwin.c
+@@ -23,8 +23,14 @@
+ #include "diagnostic-core.h"
+ #include "config/host-darwin.h"
+ 
++#if defined (__aarch64__)
++#define DARWIN_PCH_ALIGNMENT 16384
++#else
++#define DARWIN_PCH_ALIGNMENT 4096
++#endif
++
+ /* Yes, this is really supposed to work.  */
+-static char pch_address_space[1024*1024*1024] __attribute__((aligned (4096)));
++static char pch_address_space[1024*1024*1024] __attribute__((aligned (DARWIN_PCH_ALIGNMENT)));
+ 
+ /* Return the address of the PCH address space, if the PCH will fit in it.  */
+ 
+diff --git a/gcc/config/aarch64/x-darwin b/gcc/config/aarch64/x-darwin
+new file mode 100644
+index 000000000..02c9190a1
+--- /dev/null
++++ b/gcc/config/aarch64/x-darwin
+@@ -0,0 +1,3 @@
++host-aarch64-darwin.o : $(srcdir)/config/aarch64/host-aarch64-darwin.c
++	$(COMPILE) $<
++	$(POSTCOMPILE)

--- a/software/riscv-tools/gcc-modern-libcxx-safe-ctype.patch
+++ b/software/riscv-tools/gcc-modern-libcxx-safe-ctype.patch
@@ -1,0 +1,65 @@
+diff --git a/gcc/system.h b/gcc/system.h
+index d04f8fd33..7760b460b 100644
+--- a/gcc/system.h
++++ b/gcc/system.h
+@@ -194,27 +194,9 @@ extern int fprintf_unlocked (FILE *, const char *, ...);
+ #undef fread_unlocked
+ #undef fwrite_unlocked
+ 
+-/* Include <string> before "safe-ctype.h" to avoid GCC poisoning
+-   the ctype macros through safe-ctype.h */
+-
+-#ifdef __cplusplus
+-#ifdef INCLUDE_STRING
+-# include <string>
+-#endif
+-#endif
+-
+-/* There are an extraordinary number of issues with <ctype.h>.
+-   The last straw is that it varies with the locale.  Use libiberty's
+-   replacement instead.  */
+-#include "safe-ctype.h"
+-
+-#include <sys/types.h>
+-
+-#include <errno.h>
+-
+-#if !defined (errno) && defined (HAVE_DECL_ERRNO) && !HAVE_DECL_ERRNO
+-extern int errno;
+-#endif
++/* Include C++ standard headers before "safe-ctype.h" to avoid GCC
++   poisoning the ctype macros through safe-ctype.h.  Modern libc++ headers
++   may expose locale-aware ctype overloads through any of these containers.  */
+ 
+ #ifdef __cplusplus
+ #if defined (INCLUDE_ALGORITHM) || !defined (HAVE_SWAP_IN_UTILITY)
+@@ -229,6 +211,9 @@ extern int errno;
+ #ifdef INCLUDE_SET
+ # include <set>
+ #endif
++#ifdef INCLUDE_STRING
++# include <string>
++#endif
+ #ifdef INCLUDE_VECTOR
+ # include <vector>
+ #endif
+@@ -237,6 +222,19 @@ extern int errno;
+ # include <utility>
+ #endif
+ 
++/* There are an extraordinary number of issues with <ctype.h>.
++   The last straw is that it varies with the locale.  Use libiberty's
++   replacement instead.  */
++#include "safe-ctype.h"
++
++#include <sys/types.h>
++
++#include <errno.h>
++
++#if !defined (errno) && defined (HAVE_DECL_ERRNO) && !HAVE_DECL_ERRNO
++extern int errno;
++#endif
++
+ /* Some of glibc's string inlines cause warnings.  Plus we'd rather
+    rely on (and therefore test) GCC's string builtins.  */
+ #define __NO_STRING_INLINES

--- a/software/riscv-tools/newlib-dramfs-modern-clang.patch
+++ b/software/riscv-tools/newlib-dramfs-modern-clang.patch
@@ -1,0 +1,12 @@
+diff --git a/libgloss/dramfs/dramfs/dramfs_util.c b/libgloss/dramfs/dramfs/dramfs_util.c
+index 35c9b8448..b1595c1d2 100644
+--- a/libgloss/dramfs/dramfs/dramfs_util.c
++++ b/libgloss/dramfs/dramfs/dramfs_util.c
+@@ -3,6 +3,7 @@
+ // Bandhav Veluri
+ // 08/15/2019
+ 
++#include <stdlib.h>
+ #include <stdio.h>
+ #include <sys/types.h>
+ #include <sys/stat.h>


### PR DESCRIPTION
## Summary

Add a GCC-and-newlib-only installation target for workloads that do not need Spike or LLVM, and make the pinned GCC 9.2-era toolchain build with current Apple Clang and libc++ on Apple Silicon.

The checkout rule reapplies required patches idempotently when the parent repository is updated. Darwin selects Homebrew GNU sed and M4, disables binutils native-language support, and derives parallelism with portable `getconf`.

## Notable changes

- Prevent the bundled zlib source from treating modern macOS as classic MacOS
- Include libc++ headers before GCC's identifier poisoning
- Add arm64 Darwin GCC host hooks with 16 KiB PCH alignment
- Add the missing `malloc` declaration to the HammerBlade newlib DRAM filesystem utility
- Add `install-gcc` without changing the complete `install-clean` flow

## Validation

- Built native arm64 `riscv32-unknown-elf-dramfs-gcc` and G++ 9.2.0 executables
- Repeated the GCC-only build successfully without recompilation
- Compiled the HammerBlade device runtime, memcpy workload, and vector-add workload
- Rebased cleanly onto the current `master` branch

## AI assistance

Prepared with OpenAI Codex assistance. The submitter remains responsible for review and validation.
