### PR TITLE
Keep the Vanilla parser compatible with current pandas and Python

### DIFF
--- a/software/py/vanilla_parser/stats_parser.py
+++ b/software/py/vanilla_parser/stats_parser.py
@@ -478,7 +478,8 @@ class CacheStats:
         # missing a row/index then it will insert a row of
         # NaNs at the cooresponding index in the output that
         # we can use to print an error.
-        diff = e.sort_index() - s.sort_index()
+        diff = e.sort_index().select_dtypes(include="number") - \
+            s.sort_index().select_dtypes(include="number")
         
         # Find rows with NaNs
         mismatches = diff[diff.isnull().any(axis="columns")].index
@@ -550,7 +551,7 @@ class CacheTagStats(CacheStats):
         # Then, for per-tag statistics we take the sum of the lowest
         # group, to get aggregate the counters across all banks.
         hierarchy = ["Action", "Tag", "Tile Coordinate (Y,X)", "Tile-Tag Iteration"]
-        banksums = df.groupby(hierarchy).sum()
+        banksums = df.groupby(hierarchy).sum(numeric_only=True)
 
         # Split into Start/End 
         starts = banksums.loc["Start"]
@@ -908,12 +909,12 @@ class CacheTagStats(CacheStats):
     # Get a pretty formatted table representation for a tag
     def __tag_tostr(self, df):
         # Get load and store totals for miss statistics
-        ld_total = df.loc[("Cycle", ["Load"], "Total")][0]
-        ldb_total = df.loc[("Bytes", ["Load"], "bytes_ld")][0]
-        st_total = df.loc[("Cycle", ["Store"], "Total")][0]
-        stb_total = df.loc[("Bytes", ["Store"], "bytes_st")][0]
-        at_total = df.loc[("Cycle", ["Atomic"], "Total")][0]
-        atb_total = df.loc[("Bytes", ["Atomic"], "bytes_amo")][0]
+        ld_total = df.loc[("Cycle", ["Load"], "Total")].iloc[0]
+        ldb_total = df.loc[("Bytes", ["Load"], "bytes_ld")].iloc[0]
+        st_total = df.loc[("Cycle", ["Store"], "Total")].iloc[0]
+        stb_total = df.loc[("Bytes", ["Store"], "bytes_st")].iloc[0]
+        at_total = df.loc[("Cycle", ["Atomic"], "Total")].iloc[0]
+        atb_total = df.loc[("Bytes", ["Atomic"], "bytes_amo")].iloc[0]
 
         s = self.__cycle_tostr(df.loc["Cycle"]) + "\n"
 
@@ -2364,7 +2365,7 @@ def add_args(parser):
 
 def main(args): 
     if (args.vcache_stats and args.cache_line_words is None):
-        parser.error('The -cache_line_words_argument is required to parse the cache stats')
+        raise ValueError("--cache-line-words is required to parse cache statistics")
 
     st = VanillaStatsParser(args.tile, args.tile_group, args.stats, args.vcache_stats, args.cache_line_words)
     st.print_manycore_stats_all()

--- a/software/py/vanilla_parser/trace_parser.py
+++ b/software/py/vanilla_parser/trace_parser.py
@@ -45,56 +45,56 @@ class VanillaTraceParser:
 
     # second column
     # int_pc, int_instr, rd, rd_write_val, stall_reason
-    match = re.search("([0-9a-f]{8}) ([0-9a-f]{8})", columns[1])
+    match = re.search(r"([0-9a-f]{8}) ([0-9a-f]{8})", columns[1])
     if match:
       trace["int_pc"] = match.group(1)
       trace["int_instr"] = match.group(2)
 
-    match = re.search("x([0-9]{2})=([0-9a-f]{8})", columns[1])
+    match = re.search(r"x([0-9]{2})=([0-9a-f]{8})", columns[1])
     if match:
       trace["int_rd"] = int(match.group(1))
       trace["int_rd_val"] = match.group(2)
 
-    match = re.search("STALL=(\w+)", columns[1])
+    match = re.search(r"STALL=(\w+)", columns[1])
     if match:
       trace["stall_reason"] = match.group(1)
 
     # third column
     # fp_pc, fp_instr, fp_rd, fp_rd_val
-    match = re.search("([0-9a-f]{8}) ([0-9a-f]{8})", columns[2])
+    match = re.search(r"([0-9a-f]{8}) ([0-9a-f]{8})", columns[2])
     if match:
       trace["fp_pc"] = match.group(1)
       trace["fp_instr"] = match.group(2)
 
-    match = re.search("f([0-9]{2})=([0-9a-f]{8})", columns[2])
+    match = re.search(r"f([0-9]{2})=([0-9a-f]{8})", columns[2])
     if match:
       trace["fp_rd"] = int(match.group(1))
       trace["fp_rd_val"] = match.group(2)
 
     # fourth column
     # branch_target, local load/store
-    match = re.search("bt=([0-9a-f]{8})", columns[3])
+    match = re.search(r"bt=([0-9a-f]{8})", columns[3])
     if match:
       trace["bt"] = match.group(1)
 
-    match = re.search("LL=\[([0-9a-f]{3})\]=([0-9a-f]{8})", columns[3])
+    match = re.search(r"LL=\[([0-9a-f]{3})\]=([0-9a-f]{8})", columns[3])
     if match:
       trace["ll_addr"] = match.group(1)
       trace["ll_val"] = match.group(2)
   
-    match = re.search("LS=\[([0-9a-f]{3})\]=([0-9a-f]{8})", columns[3])
+    match = re.search(r"LS=\[([0-9a-f]{3})\]=([0-9a-f]{8})", columns[3])
     if match:
       trace["ls_addr"] = match.group(1)
       trace["ls_val"] = match.group(2)
 
     # fifth column
     # remote load/store
-    match = re.search("RS=\[([0-9a-f]{8})\]=([0-9a-f]{8})", columns[4])
+    match = re.search(r"RS=\[([0-9a-f]{8})\]=([0-9a-f]{8})", columns[4])
     if match:
       trace["rs_addr"] = match.group(1)
       trace["rs_val"] = match.group(2)
 
-    match = re.search("RL=\[([0-9a-f]{8})\]=", columns[4])
+    match = re.search(r"RL=\[([0-9a-f]{8})\]=", columns[4])
     if match:
       trace["rl_addr"] = match.group(1)
 


### PR DESCRIPTION
## Summary

Update the Vanilla profiler parser for current Python and pandas behavior without changing its report format.

The change restricts cache aggregation and start-to-end subtraction to numeric columns, uses explicit positional Series access, reports a missing cache-line size without referencing an out-of-scope parser object, and makes trace regular expressions raw strings.

## Validation

- Ran with Python 3.14, pandas 3.0.5, NumPy 2.5.2, and Pillow 12.3.0
- Parsed 4-by-2 memcpy `vanilla_stats.csv` and `vcache_stats.csv`
- Parsed cold and warm 16,384-element vector-add profiles
- Generated a nonempty `stats/manycore_stats.log` without Python syntax warnings
- Rebased cleanly onto the current `master` branch

## AI assistance

Prepared with OpenAI Codex assistance. The submitter remains responsible for review and validation.
