### PR TITLE
Restore tag trace replay enable

### DIFF
--- a/testbenches/common/v/bsg_nonsynth_manycore_tag_master.sv
+++ b/testbenches/common/v/bsg_nonsynth_manycore_tag_master.sv
@@ -47,6 +47,7 @@ module bsg_nonsynth_manycore_tag_master
   ) tr (
     .clk_i(clk_i)
     ,.reset_i(reset_i)
+    ,.en_i(1'b1)
 
     ,.rom_addr_o(rom_addr)
     ,.rom_data_i(rom_data)
@@ -89,4 +90,3 @@ module bsg_nonsynth_manycore_tag_master
 endmodule
 
 `BSG_ABSTRACT_MODULE(bsg_nonsynth_manycore_tag_master)
-


### PR DESCRIPTION
## Summary
- restore the enable input on the nonsynth tag trace replay
- keep the tag-master instantiation aligned with current BaseJump STL, where bsg_tag_master no longer has en_i

## Why
Commit 3a879f1b removed both enable connections to follow BaseJump tag-interface changes, but current BaseJump master still requires bsg_tag_trace_replay.en_i. Under two-state Verilator simulation, leaving that input unconnected holds trace replay disabled and prevents device reset from completing.

## Compatibility
This change is intended with BaseJump STL master b48037e. That revision has removed bsg_tag_master.en_i but retains bsg_tag_trace_replay.en_i.

## Validation
Verilator 5.050 on macOS arm64 with BaseJump b48037e:
- HammerBench memcpy, 4x2 tiles, MSIZE=16, VERILATOR_THREADS=1: pass
- same test with VERILATOR_THREADS=16: pass
- HammerBench memcpy, 4x2 tiles, MSIZE=4096, VERILATOR_THREADS=16: pass