### PR TITLE
Keep scalar tile group keys with pandas 2.2

### DIFF
--- a/software/py/vanilla_parser/stats_parser.py
+++ b/software/py/vanilla_parser/stats_parser.py
@@ -1150,7 +1150,7 @@ class GroupCacheStats():
 
         # Group the dataframe by Tile Group ID and then parse that
         # group
-        for i, grp in df.groupby(["Tile Group ID"]):
+        for i, grp in df.groupby("Tile Group ID"):
             self._agg[i] = AggregateCacheStats(grp, cache_line_words)
 
     def __getitem__(self, i):


### PR DESCRIPTION
With pandas 2.2, iterating groupby(["Tile Group ID"]) yields tuple keys, while tile-group report lookup expects scalar IDs. Group by the column name directly so --tile-group completes without KeyError: 0.

Validation: the parser completed on all twelve saved 128-tile expert profiles with pandas 2.2.3; every generated report matches the previously validated task-local fix byte for byte. Counter arithmetic and RTL are unchanged.
