### PR TITLE
Support singleton mesh dimensions with explicit coordinate and cache mapping

### DIFF
--- a/testbenches/common/v/bsg_nonsynth_manycore_testbench.sv
+++ b/testbenches/common/v/bsg_nonsynth_manycore_testbench.sv
@@ -331,6 +331,10 @@ module bsg_nonsynth_manycore_testbench
       ,.proc_link_sif_i(io_link_sif_li[x][P])
       ,.proc_link_sif_o(io_link_sif_lo[x][P])
 
+      // The first pod starts at 2^local_X_bits; SAFE_CLOG2 reserves one bit even for X=1.
+      // Add the column index to that origin, placing the single-column I/O router at X=2.
+      // Multiple pods across X are unsupported when each pod is only one tile wide.
+      // They require I/O X coordinates 2,4,..., but this formula produces 2,3,... .
       ,.global_x_i(x_cord_width_p'((1 << `BSG_SAFE_CLOG2(num_tiles_x_p))+x))
       ,.global_y_i(y_cord_width_p'(0))
     );
@@ -405,6 +409,8 @@ module bsg_nonsynth_manycore_testbench
       
     parameter num_total_vcaches_lp = (num_pods_x_p*num_pods_y_p*2*num_tiles_x_p);
     parameter lg_num_total_vcaches_lp = `BSG_SAFE_CLOG2(num_total_vcaches_lp);
+    // Normally, divide columns between east/west and then among cache-to-DRAM lanes.
+    // With one column and one lane, division gives zero, but each used east link serves one cache.
     parameter num_vcaches_per_link_lp = `BSG_MAX(1, (num_tiles_x_p*num_pods_x_p)/wh_ruche_factor_p/2); // # of vcaches attached to each link
 
     parameter num_total_channels_lp = num_total_vcaches_lp/num_vcaches_per_channel_p;
@@ -1013,4 +1019,3 @@ end // if (enable_vanilla_core_pc_histogram_p)
 endmodule
 
 `BSG_ABSTRACT_MODULE(bsg_nonsynth_manycore_testbench)
-

--- a/testbenches/common/v/bsg_nonsynth_manycore_testbench.sv
+++ b/testbenches/common/v/bsg_nonsynth_manycore_testbench.sv
@@ -331,7 +331,7 @@ module bsg_nonsynth_manycore_testbench
       ,.proc_link_sif_i(io_link_sif_li[x][P])
       ,.proc_link_sif_o(io_link_sif_lo[x][P])
 
-      ,.global_x_i(x_cord_width_p'(num_tiles_x_p+x))
+      ,.global_x_i(x_cord_width_p'((1 << `BSG_SAFE_CLOG2(num_tiles_x_p))+x))
       ,.global_y_i(y_cord_width_p'(0))
     );
 
@@ -405,7 +405,7 @@ module bsg_nonsynth_manycore_testbench
       
     parameter num_total_vcaches_lp = (num_pods_x_p*num_pods_y_p*2*num_tiles_x_p);
     parameter lg_num_total_vcaches_lp = `BSG_SAFE_CLOG2(num_total_vcaches_lp);
-    parameter num_vcaches_per_link_lp = (num_tiles_x_p*num_pods_x_p)/wh_ruche_factor_p/2; // # of vcaches attached to each link
+    parameter num_vcaches_per_link_lp = `BSG_MAX(1, (num_tiles_x_p*num_pods_x_p)/wh_ruche_factor_p/2); // # of vcaches attached to each link
 
     parameter num_total_channels_lp = num_total_vcaches_lp/num_vcaches_per_channel_p;
     parameter num_dram_lp = `BSG_CDIV(num_total_channels_lp,hbm2_num_channels_p);

--- a/testbenches/common/v/vcache_dma_to_dram_channel_map.sv
+++ b/testbenches/common/v/vcache_dma_to_dram_channel_map.sv
@@ -20,6 +20,8 @@ module vcache_dma_to_dram_channel_map
     , parameter `BSG_INV_PARAM(vcache_dma_data_width_p)
     , parameter `BSG_INV_PARAM(vcache_block_size_in_words_p)
 
+    // Normally, divide columns between east/west and then among cache-to-DRAM lanes.
+    // With one column and one lane, division gives zero, but each used east link serves one cache.
     , parameter num_vcaches_per_link_lp = `BSG_MAX(1, (num_tiles_x_p*num_pods_x_p)/wh_ruche_factor_p/2)
     , parameter num_total_vcaches_lp = (num_pods_x_p*num_pods_y_p*2*num_tiles_x_p)
 
@@ -62,7 +64,8 @@ module vcache_dma_to_dram_channel_map
 
 
   if (num_tiles_x_p == 1 && num_pods_x_p == 1) begin: single_column
-    // Both banks drain east. The unused west endpoints remain quiescent.
+    // This wiring requires one cache-to-DRAM lane per endpoint, so its lane index is always 0.
+    // Runtime initialization sends both caches east; keep the unused west handshakes inactive.
     initial assert (wh_ruche_factor_p == 1)
       else $error("Single-column HBM wiring requires WH factor 1");
     assign dma_pkt_yumi_o[W] = '0;
@@ -71,6 +74,8 @@ module vcache_dma_to_dram_channel_map
     assign dma_data_yumi_o[W] = '0;
     for (genvar y = 0; y < num_pods_y_p; y++) begin: py
       for (genvar k = N; k <= S; k++) begin: ns
+        // Each pod row contributes two caches, ordered north then south.
+        // Thus row y occupies indices 2*y and 2*y+1, with the same mapping for data and handshakes.
         localparam idx = 2*y + (k == S);
         assign remapped_dma_pkt_o[idx] = dma_pkt_i[E][y][k][0][0];
         assign remapped_dma_pkt_v_o[idx] = dma_pkt_v_i[E][y][k][0][0];
@@ -167,4 +172,3 @@ module vcache_dma_to_dram_channel_map
 endmodule
 
 `BSG_ABSTRACT_MODULE(vcache_dma_to_dram_channel_map)
-

--- a/testbenches/common/v/vcache_dma_to_dram_channel_map.sv
+++ b/testbenches/common/v/vcache_dma_to_dram_channel_map.sv
@@ -20,7 +20,7 @@ module vcache_dma_to_dram_channel_map
     , parameter `BSG_INV_PARAM(vcache_dma_data_width_p)
     , parameter `BSG_INV_PARAM(vcache_block_size_in_words_p)
 
-    , parameter num_vcaches_per_link_lp = (num_tiles_x_p*num_pods_x_p)/wh_ruche_factor_p/2
+    , parameter num_vcaches_per_link_lp = `BSG_MAX(1, (num_tiles_x_p*num_pods_x_p)/wh_ruche_factor_p/2)
     , parameter num_total_vcaches_lp = (num_pods_x_p*num_pods_y_p*2*num_tiles_x_p)
 
     , parameter num_vcaches_per_slice_lp = (num_pods_x_p == 1)
@@ -61,6 +61,29 @@ module vcache_dma_to_dram_channel_map
   `declare_bsg_cache_dma_pkt_s(vcache_addr_width_p, vcache_block_size_in_words_p);
 
 
+  if (num_tiles_x_p == 1 && num_pods_x_p == 1) begin: single_column
+    // Both banks drain east. The unused west endpoints remain quiescent.
+    initial assert (wh_ruche_factor_p == 1)
+      else $error("Single-column HBM wiring requires WH factor 1");
+    assign dma_pkt_yumi_o[W] = '0;
+    assign dma_data_o[W] = '0;
+    assign dma_data_v_o[W] = '0;
+    assign dma_data_yumi_o[W] = '0;
+    for (genvar y = 0; y < num_pods_y_p; y++) begin: py
+      for (genvar k = N; k <= S; k++) begin: ns
+        localparam idx = 2*y + (k == S);
+        assign remapped_dma_pkt_o[idx] = dma_pkt_i[E][y][k][0][0];
+        assign remapped_dma_pkt_v_o[idx] = dma_pkt_v_i[E][y][k][0][0];
+        assign dma_pkt_yumi_o[E][y][k][0][0] = remapped_dma_pkt_yumi_i[idx];
+        assign dma_data_o[E][y][k][0][0] = remapped_dma_data_i[idx];
+        assign dma_data_v_o[E][y][k][0][0] = remapped_dma_data_v_i[idx];
+        assign remapped_dma_data_ready_o[idx] = dma_data_ready_i[E][y][k][0][0];
+        assign remapped_dma_data_o[idx] = dma_data_i[E][y][k][0][0];
+        assign remapped_dma_data_v_o[idx] = dma_data_v_i[E][y][k][0][0];
+        assign dma_data_yumi_o[E][y][k][0][0] = remapped_dma_data_yumi_i[idx];
+      end
+    end
+  end else begin: multiple_columns
   // cache dma unruched mapping
   bsg_cache_dma_pkt_s [E:W][num_pods_y_p-1:0][S:N][(num_tiles_x_p*num_pods_x_p/2)-1:0] unruched_dma_pkt_lo;
   logic [E:W][num_pods_y_p-1:0][S:N][(num_tiles_x_p*num_pods_x_p/2)-1:0][vcache_dma_data_width_p-1:0] unruched_dma_data_li, unruched_dma_data_lo;
@@ -138,6 +161,7 @@ module vcache_dma_to_dram_channel_map
   assign remapped_dma_data_v_o = flattened_dma_data_v_lo;
   assign flattened_dma_data_yumi_li = remapped_dma_data_yumi_i;
 
+  end
 
 
 endmodule

--- a/v/bsg_manycore_eva_to_npa.sv
+++ b/v/bsg_manycore_eva_to_npa.sv
@@ -83,6 +83,19 @@ module bsg_manycore_eva_to_npa
   logic [y_cord_width_p-1:0] dram_y_cord_lo;
   logic [addr_width_p-1:0] dram_epa_lo;
 
+  if (num_tiles_x_p == 1) begin: single_column_dram
+    // Alternate cache lines north/south; no address bit selects an X bank.
+    wire south = eva_i[2+vcache_word_offset_width_lp];
+    assign dram_x_cord_lo = {pod_x_i, {x_subcord_width_lp{1'b0}}};
+    assign dram_y_cord_lo = south
+      ? {pod_y_cord_width_p'(pod_y_i+1), {y_subcord_width_lp{1'b0}}}
+      : {pod_y_cord_width_p'(pod_y_i-1), {y_subcord_width_lp{1'b1}}};
+    assign dram_epa_lo = addr_width_p'({1'b0,
+      eva_i[30:3+vcache_word_offset_width_lp],
+      eva_i[2+:vcache_word_offset_width_lp]});
+    initial assert (!ipoly_hashing_p)
+      else $error("Single-column pods require iPoly disabled");
+  end else begin: multi_column_dram
   bsg_manycore_dram_hash_function #(
     .data_width_p(data_width_p)
     ,.addr_width_p(addr_width_p)
@@ -105,6 +118,8 @@ module bsg_manycore_eva_to_npa
   );
 
 
+
+  end
 
   // EVA->NPA table
   always_comb begin

--- a/v/bsg_manycore_eva_to_npa.sv
+++ b/v/bsg_manycore_eva_to_npa.sv
@@ -84,15 +84,22 @@ module bsg_manycore_eva_to_npa
   logic [addr_width_p-1:0] dram_epa_lo;
 
   if (num_tiles_x_p == 1) begin: single_column_dram
-    // Alternate cache lines north/south; no address bit selects an X bank.
+    // One column needs no X-bank selector, so its local X coordinate is always zero.
+    // The first EVA bit above the cache-line offset instead selects north versus south.
     wire south = eva_i[2+vcache_word_offset_width_lp];
     assign dram_x_cord_lo = {pod_x_i, {x_subcord_width_lp{1'b0}}};
+    // Cache rows border the pod's reserved Y range: north just before it, south just after.
+    // All-ones/all-zeros local fields select those boundaries: Y=1/Y=4 in our one-row profiles.
     assign dram_y_cord_lo = south
       ? {pod_y_cord_width_p'(pod_y_i+1), {y_subcord_width_lp{1'b0}}}
       : {pod_y_cord_width_p'(pod_y_i-1), {y_subcord_width_lp{1'b1}}};
+    // Remove the DRAM flag, two byte-offset bits, and the north/south bank-selection bit.
+    // Pack the remaining bits into a word address, keeping its MSB zero for normal cache data.
     assign dram_epa_lo = addr_width_p'({1'b0,
       eva_i[30:3+vcache_word_offset_width_lp],
       eva_i[2+:vcache_word_offset_width_lp]});
+    // This branch implements plain two-bank striping and does not apply an iPoly hash.
+    // Reject iPoly-enabled profiles so the RTL cannot silently disagree with the runtime.
     initial assert (!ipoly_hashing_p)
       else $error("Single-column pods require iPoly disabled");
   end else begin: multi_column_dram

--- a/v/bsg_manycore_tile_compute_mesh.sv
+++ b/v/bsg_manycore_tile_compute_mesh.sv
@@ -112,7 +112,7 @@ module bsg_manycore_tile_compute_mesh
   );
 
   assign global_x_o = {pod_x_r, my_x_r};
-  assign global_y_o = (y_cord_width_p)'(({pod_y_r, my_y_r}) + 1);
+  assign global_y_o = (y_cord_width_p)'(({pod_y_r, my_y_r}) + ((num_tiles_y_p == 1) ? 2 : 1));
 
 
 

--- a/v/bsg_manycore_tile_compute_mesh.sv
+++ b/v/bsg_manycore_tile_compute_mesh.sv
@@ -112,6 +112,8 @@ module bsg_manycore_tile_compute_mesh
   );
 
   assign global_x_o = {pod_x_r, my_x_r};
+  // A one-row pod still reserves two local Y coordinates; the second is unused.
+  // Step by two to reach the south cache (Y=2 to Y=4 here); ordinary rows advance by one.
   assign global_y_o = (y_cord_width_p)'(({pod_y_r, my_y_r}) + ((num_tiles_y_p == 1) ? 2 : 1));
 
 


### PR DESCRIPTION
One-row and one-column mesh simulations previously used coordinate and cache-bank expressions that assumed at least two tiles per dimension. This enables the tested single-pod 1×1 and 2×1 models while retaining the existing expressions for ordinary dimensions.

- Derive the I/O X origin from the reserved coordinate width and skip the unused Y coordinate after a singleton compute row.
- Map single-column DRAM lines across the north/south caches without consuming a nonexistent X-bank selector bit.
- Keep one DMA slot per used link and explicitly wire the single-column caches to their east endpoints.
- Explain each expression in short comments, including the one cache-to-DRAM lane requirement and the unsupported multiple-pod-column case.

Validation used Verilator 5.050 on macOS with the matching Replicant runtime changes: twelve vector-add execution/profile passes across 1×1 and 2×1 (4096 cold; 65,536 cold/warm), plus a freshly built 16×8 execution regression. The subsequent 2×1 suite produced 24 passes and four retained benchmark-input/reference failures across fourteen cases; unit-weight SpGEMM and a separately corrected Barnes–Hut host reference pass. All fourteen suite profiler reports match independent cycle calculations. The final comment commit was checked to leave every non-comment RTL token unchanged; no simulator rebuild was needed for comments.

Scope: singleton profiles use blocking caches, iPoly disabled, software tile-group barriers, and one cache-to-DRAM lane per endpoint. Multiple pod columns with one tile column per pod remain unsupported (required I/O X coordinates 2,4,… versus this formula's 2,3,…). This does not establish arbitrary geometry, multipod, hardware-barrier, or silicon support.

Requires [Replicant #873](https://github.com/bespoke-silicon-group/bsg_replicant/pull/873), with [HammerBench #103](https://github.com/bespoke-silicon-group/hb_hammerbench/pull/103) for the benchmark startup changes. The Bladerunner integration PR selects the compatible revisions.
