### PR TITLE
Support optional LLVM 22 device builds while preserving GCC defaults

### DIFF
--- a/software/bsg_manycore_lib/bsg_manycore.h
+++ b/software/bsg_manycore_lib/bsg_manycore.h
@@ -134,10 +134,10 @@ static inline void bsg_print_float_scientific(float f)
 #define bsg_wait_while(cond) do {} while ((cond))
 
 // load reserved; and load reserved acquire
-#ifdef __clang__
-inline int bsg_lr(int *p)    { int tmp; __asm__ __volatile__("lr.w    %0,%1\n" : "=r" (tmp) : "m" (*p)); return tmp; }
-inline int bsg_lr_aq(int *p) { int tmp; __asm__ __volatile__("lr.w.aq %0,%1\n" : "=r" (tmp) : "m" (*p)); return tmp; }
-#elif defined(__GNUC__) || defined(__GNUG__)
+#if defined(__clang__) || defined(__GNUC__) || defined(__GNUG__)
+// RISC-V LR has no encoded offset. The A constraint forces the address into a
+// register for both GCC and Clang instead of allowing a generic offset(base)
+// memory operand that modern LLVM's integrated assembler correctly rejects.
 inline int bsg_lr(int *p)    { int tmp; __asm__ __volatile__("lr.w    %0,%1\n" : "=r" (tmp) : "A" (*p)); return tmp; }
 inline int bsg_lr_aq(int *p) { int tmp; __asm__ __volatile__("lr.w.aq %0,%1\n" : "=r" (tmp) : "A" (*p)); return tmp; }
 

--- a/software/bsg_manycore_lib/bsg_manycore_atomic.h
+++ b/software/bsg_manycore_lib/bsg_manycore_atomic.h
@@ -47,6 +47,16 @@ inline int bsg_amoor (volatile int* p, int val)
   return result;
 }
 
+// Use this form when the caller does not consume the old memory value.  The
+// architectural zero register prevents a long-latency remote AMO response
+// from making a general-purpose register unavailable to following work.
+inline void bsg_amoor_no_return (volatile int* p, int val)
+{
+  asm volatile ("amoor.w x0, %[val], 0(%[p])" \
+                : \
+                : [p] "r" (p), [val] "r" (val));
+}
+
 inline int bsg_amoor_aq (volatile int* p, int val)
 {
   int result;

--- a/software/mk/Makefile.builddefs
+++ b/software/mk/Makefile.builddefs
@@ -225,7 +225,8 @@ LLVM_CLANG        ?= $(LLVM_DIR)/bin/clang
 LLVM_CLANGPP      ?= $(LLVM_DIR)/bin/clang++
 LLVM_OPT          ?= $(LLVM_DIR)/bin/opt
 LLVM_LLC          ?= $(LLVM_DIR)/bin/llc
-CLANG_TARGET_OPTS ?= --target=riscv32 -march=$(ARCH_OP) -mabi=$(ABI)
+LLVM_OPT_OPTS     ?=
+CLANG_TARGET_OPTS ?= --target=riscv32 -march=$(ARCH_OP) -mabi=$(ABI) -mcpu=hb-rv32
 # Preserve optimization-sensitive frontend behavior while leaving the single
 # LLVM optimization pipeline to the explicit opt step below.
 CLANG_IR_OPTS     ?= -Xclang -disable-llvm-passes
@@ -233,8 +234,17 @@ CLANG_IR_OPTS     ?= -Xclang -disable-llvm-passes
 # Ideally LLC should infer targets option provided to Clang. But LLC 11.0.0 fails
 # to infer the architecture extensions correctly. Hence the information is repeated
 # in LLC target options below.
-LLC_TARGET_OPTS   ?= -march=riscv32 -mcpu=hb-rv32 -mattr=+m,+a,+f
+LLC_TARGET_OPTS   ?= -march=riscv32 -mcpu=hb-rv32 -mattr=+m,+a,+f -target-abi=$(ABI)
 LLC_CODEGEN_OPTS  ?= $(OPT_LEVEL)
+# Emit ELF objects with LLVM's integrated assembler. Recent LLVM versions emit
+# current RISC-V ISA-attribute spellings that the SDK's older GNU assembler
+# cannot parse; the resulting objects remain compatible with the GNU linker.
+LLVM_LLC_FILETYPE ?= asm
+# The bundled binutils 2.32 linker rejects the versioned extension names in
+# modern LLVM's .riscv.attributes section. The link already receives the
+# explicit rv32imaf architecture, so remove only this metadata section from
+# LLVM-generated objects before passing them to the legacy linker.
+LLVM_STRIP_RISCV_ATTRIBUTES ?= 1
 
 ifdef ENABLE_LLVM_PASSES
 PASS_DIR          ?= $(BSG_MANYCORE_DIR)/software/manycore-llvm-pass
@@ -270,13 +280,21 @@ ifdef ENABLE_LLVM_PASSES
 PASS_OPTS = -load $(PASS_LIB) -manycore
 endif
 %.ll.pass: %.ll $(PASS_LIB)
-	$(LLVM_OPT) $(PASS_OPTS) $(OPT_LEVEL) -S $< -o $@
+	$(LLVM_OPT) $(PASS_OPTS) $(OPT_LEVEL) $(LLVM_OPT_OPTS) -S $< -o $@
 
+ifeq ($(LLVM_LLC_FILETYPE),obj)
+%.o: %.ll.pass
+	$(LLVM_LLC) $(LLC_TARGET_OPTS) $(LLC_CODEGEN_OPTS) -filetype=obj $< -o $@
+ifeq ($(LLVM_STRIP_RISCV_ATTRIBUTES),1)
+	$(RISCV_OBJCOPY) --remove-section=.riscv.attributes $@
+endif
+else
 %.ll.s: %.ll.pass
 	$(LLVM_LLC) $(LLC_TARGET_OPTS) $(LLC_CODEGEN_OPTS) $< -o $@
 
 %.o: %.ll.s
 	$(RISCV_GCC) $(RISCV_GCC_OPTS) $(OPT_LEVEL) -c $< -o $@
+endif
 
 ifdef ENABLE_LLVM_PASSES
 $(PASS_LIB): $(PASS_DIR)/manycore/Manycore.cpp $(LLVM_DIR)

--- a/software/mk/Makefile.builddefs
+++ b/software/mk/Makefile.builddefs
@@ -226,6 +226,9 @@ LLVM_CLANGPP      ?= $(LLVM_DIR)/bin/clang++
 LLVM_OPT          ?= $(LLVM_DIR)/bin/opt
 LLVM_LLC          ?= $(LLVM_DIR)/bin/llc
 CLANG_TARGET_OPTS ?= --target=riscv32 -march=$(ARCH_OP) -mabi=$(ABI)
+# Preserve optimization-sensitive frontend behavior while leaving the single
+# LLVM optimization pipeline to the explicit opt step below.
+CLANG_IR_OPTS     ?= -Xclang -disable-llvm-passes
 
 # Ideally LLC should infer targets option provided to Clang. But LLC 11.0.0 fails
 # to infer the architecture extensions correctly. Hence the information is repeated
@@ -253,7 +256,7 @@ $(LLVM_DIR):
 %.ll: %.c $(LLVM_DIR) $(RUNTIME_FNS)
 	$(LLVM_CLANG) $(CLANG_TARGET_OPTS) $(RISCV_GCC_OPTS) \
 		--sysroot=$(RISCV_BIN_DIR)/../riscv32-unknown-elf-dramfs \
-		$(OPT_LEVEL) $(spmd_defs) -c -emit-llvm -S $(INCS) $< -o $@
+		$(OPT_LEVEL) $(CLANG_IR_OPTS) $(spmd_defs) -c -emit-llvm -S $(INCS) $< -o $@
 
 # do the same for C++ sources
 %.ll: %.cpp $(LLVM_DIR) $(RUNTIME_FNS)
@@ -261,7 +264,7 @@ $(LLVM_DIR):
 		--sysroot=$(RISCV_BIN_DIR)/../riscv32-unknown-elf-dramfs \
 		-I$(RISCV_BIN_DIR)/../riscv32-unknown-elf-dramfs/include/c++/9.2.0 \
 		-I$(RISCV_BIN_DIR)/../riscv32-unknown-elf-dramfs/include/c++/9.2.0/riscv32-unknown-elf-dramfs \
-		$(OPT_LEVEL) $(spmd_defs) -c -emit-llvm -S $(INCS) $< -o $@
+		$(OPT_LEVEL) $(CLANG_IR_OPTS) $(spmd_defs) -c -emit-llvm -S $(INCS) $< -o $@
 
 ifdef ENABLE_LLVM_PASSES
 PASS_OPTS = -load $(PASS_LIB) -manycore

--- a/software/mk/Makefile.builddefs
+++ b/software/mk/Makefile.builddefs
@@ -82,6 +82,18 @@ vpath %.S $(COMMON_SRC_DIRS)
 
 # flags
 OPT_LEVEL ?= -O2
+PYTHON ?= python3
+
+# Select the SPMD C/C++ compiler explicitly. Keep CLANG as a compatibility
+# alias for existing invocations, but prefer SPMD_COMPILER in new scripts.
+ifdef CLANG
+SPMD_COMPILER ?= llvm
+endif
+SPMD_COMPILER ?= gcc
+ifeq ($(filter $(SPMD_COMPILER),gcc llvm),)
+$(error Unsupported SPMD_COMPILER '$(SPMD_COMPILER)'; expected gcc or llvm)
+endif
+
 RISCV_GCC_EXTRA_OPTS ?=
 RISCV_GCC_OPTS  =-march=$(ARCH_OP) -static -std=gnu99 -ffast-math -fno-common -mtune=bsg_vanilla_2020
 
@@ -173,7 +185,7 @@ endif
 LINK_SCRIPT ?= $(CURR_DIR)/bsg_link.ld
 
 $(CURR_DIR)/bsg_link.ld: $(LINK_GEN)
-	python $(LINK_GEN) $(LINK_GEN_OPTS) --out=$@
+	$(PYTHON) $(LINK_GEN) $(LINK_GEN_OPTS) --out=$@
 
 RISCV_LINK_OPTS ?= 
 
@@ -194,7 +206,7 @@ https://stackoverflow.com/questions/56518056/risc-v-linker-throwing-sections-lma
 RISCV_LINK = $(RISCV_GCC) -t -T $(LINK_SCRIPT) $(RISCV_LINK_SYMS)
 
 
-ifndef CLANG
+ifeq ($(SPMD_COMPILER),gcc)
   RISCV_GCC_OPTS += -fweb -frename-registers -frerun-cse-after-loop
 endif
 
@@ -207,7 +219,7 @@ RISCV_GXX_OPTS += $(RISCV_GXX_EXTRA_OPTS)
 
 spmd_defs = -DPREALLOCATE=0 -DHOST_DEBUG=0
 
-ifdef CLANG
+ifeq ($(SPMD_COMPILER),llvm)
 LLVM_DIR          ?= $(RISCV_INSTALL_DIR)
 LLVM_CLANG        ?= $(LLVM_DIR)/bin/clang
 LLVM_CLANGPP      ?= $(LLVM_DIR)/bin/clang++
@@ -219,6 +231,7 @@ CLANG_TARGET_OPTS ?= --target=riscv32 -march=$(ARCH_OP) -mabi=$(ABI)
 # to infer the architecture extensions correctly. Hence the information is repeated
 # in LLC target options below.
 LLC_TARGET_OPTS   ?= -march=riscv32 -mcpu=hb-rv32 -mattr=+m,+a,+f
+LLC_CODEGEN_OPTS  ?= $(OPT_LEVEL)
 
 ifdef ENABLE_LLVM_PASSES
 PASS_DIR          ?= $(BSG_MANYCORE_DIR)/software/manycore-llvm-pass
@@ -257,7 +270,7 @@ endif
 	$(LLVM_OPT) $(PASS_OPTS) $(OPT_LEVEL) -S $< -o $@
 
 %.ll.s: %.ll.pass
-	$(LLVM_LLC) $(LLC_TARGET_OPTS) $< -o $@
+	$(LLVM_LLC) $(LLC_TARGET_OPTS) $(LLC_CODEGEN_OPTS) $< -o $@
 
 %.o: %.ll.s
 	$(RISCV_GCC) $(RISCV_GCC_OPTS) $(OPT_LEVEL) -c $< -o $@
@@ -309,7 +322,7 @@ SKIP_DRAM_INSTRUCTION_LOAD ?= 0
 SKIP_ZEROS ?= 0
 
 %.nbf: %.riscv
-	python $(NBF_PY) \
+	$(PYTHON) $(NBF_PY) \
 	  $*.riscv \
 		$(BSG_MACHINE_GLOBAL_X) $(BSG_MACHINE_GLOBAL_Y) \
 		$(BSG_MACHINE_VCACHE_WAY) $(BSG_MACHINE_VCACHE_SET) \
@@ -325,7 +338,7 @@ SKIP_ZEROS ?= 0
 		$(BSG_MACHINE_IPOLY_HASHING) > $*.nbf
 
 %.bin:  %.hex
-	python $(HEX2BIN) $< 32 > $@
+	$(PYTHON) $(HEX2BIN) $< 32 > $@
 
 %.dis: %.riscv
 	$(RISCV_BIN_DIR)/riscv32-unknown-elf-dramfs-objdump -M numeric --disassemble-all -S $<
@@ -346,4 +359,3 @@ endif
 
 %.S: %.cpp
 	$(RISCV_GXX) $(RISCV_GXX_OPTS) $(spmd_defs) -S -fverbose-asm $(INCS) $< -o $@ 2>&1 | tee $*.comp.log
-

--- a/software/spmd/Makefile
+++ b/software/spmd/Makefile
@@ -23,8 +23,9 @@ NO-RECURSE = \
 	energy_loop_test \
 	energy_ubenchmark
 
-# Skip hb_mc test series
-SPMD_HB_MC_TESTS := $(shell find $(BSG_MANYCORE_DIR)/software/spmd -maxdepth 1 -type d -name 'hb_mc_*' -printf '%P\n')
+# Skip hb_mc test series. Use make's wildcard functions so this also works
+# with BSD find on macOS.
+SPMD_HB_MC_TESTS := $(notdir $(patsubst %/,%,$(wildcard $(BSG_MANYCORE_DIR)/software/spmd/hb_mc_*/)))
 NO-RECURSE += $(SPMD_HB_MC_TESTS)
 
 # Define this variable on cmd line to run coverage analysis. Currently

--- a/software/spmd/README.md
+++ b/software/spmd/README.md
@@ -13,6 +13,10 @@ Running single spmd program
 
 In any of the sub-directories:
 - `make`: Run VCS simulation.
+- `make SPMD_COMPILER=gcc`: Build device C/C++ with GCC (the default).
+- `make SPMD_COMPILER=llvm LLVM_DIR=/path/to/llvm-build`: Build device C/C++
+  with the HammerBlade LLVM toolchain. The linker and assembler remain from
+  the compatible RISC-V GNU installation.
 - `make WAVE=1` Run VCS simulation with waveform dump.
 - `make main.riscv`: Generate ELF binary of that SPMD program.
 - `make COVERAGE=1` Run VCS simulation with coverage analysis.
@@ -65,6 +69,9 @@ Some useful flags:
     above dimension variables are explicitly set.
 - `ENABLE_VCACHE={0|1}`:
     include vcache or instead include block SRAM.
+- `SPMD_COMPILER={gcc|llvm}`:
+    Select the device C/C++ compiler. `CLANG=1` remains a compatibility alias
+    for `SPMD_COMPILER=llvm`; new automation should use the explicit selector.
 
 Note: 
     Current design is only tested for x<=4, y<=4 and dimensions mentioned in

--- a/software/spmd/README.md
+++ b/software/spmd/README.md
@@ -16,7 +16,9 @@ In any of the sub-directories:
 - `make SPMD_COMPILER=gcc`: Build device C/C++ with GCC (the default).
 - `make SPMD_COMPILER=llvm LLVM_DIR=/path/to/llvm-build`: Build device C/C++
   with the HammerBlade LLVM toolchain. The linker and assembler remain from
-  the compatible RISC-V GNU installation.
+  the compatible RISC-V GNU installation. Clang emits IR without running its
+  internal LLVM optimization pipeline; the explicit `opt` step runs the chosen
+  optimization level exactly once.
 - `make WAVE=1` Run VCS simulation with waveform dump.
 - `make main.riscv`: Generate ELF binary of that SPMD program.
 - `make COVERAGE=1` Run VCS simulation with coverage analysis.

--- a/software/spmd/float_math/Makefile
+++ b/software/spmd/float_math/Makefile
@@ -1,6 +1,10 @@
 bsg_tiles_X = 1
 bsg_tiles_Y = 1
 
+# This test checks the exact bits produced by source-order FP32 reductions.
+# Keep the surrounding SDK fast-math policy, but do not permit reassociation or
+# reciprocal replacement to change the numerical contract being tested.
+RISCV_GCC_EXTRA_OPTS += -fno-associative-math -fno-reciprocal-math
 
 all: main.run
 

--- a/software/spmd/float_vector/Makefile
+++ b/software/spmd/float_vector/Makefile
@@ -1,6 +1,9 @@
 bsg_tiles_X = 1
 bsg_tiles_Y = 1
 
+# The precomputed checks below are exact FP32 bit patterns, so preserve the
+# source reduction order and division rounding under both supported compilers.
+RISCV_GCC_EXTRA_OPTS += -fno-associative-math -fno-reciprocal-math
 
 all: main.run
 

--- a/software/spmd/harmonic_mean/Makefile
+++ b/software/spmd/harmonic_mean/Makefile
@@ -2,6 +2,10 @@ bsg_tiles_X = 1
 bsg_tiles_Y = 1
 
 
+# The expected harmonic mean is an exact FP32 bit pattern. Preserve the source
+# reduction order while retaining the surrounding SDK fast-math policy.
+RISCV_GCC_EXTRA_OPTS += -fno-associative-math
+
 all: main.run
 
 OBJECT_FILES=main.o

--- a/software/spmd/kmean/Makefile
+++ b/software/spmd/kmean/Makefile
@@ -1,6 +1,10 @@
 bsg_tiles_X = 1
 bsg_tiles_Y = 1
 
+# Expected centroids are exact FP32 bit patterns. Fast reciprocal replacement
+# changes their final rounding, so preserve source division for both compilers.
+RISCV_GCC_EXTRA_OPTS += -fno-reciprocal-math
+
 all: main.run
 
 OBJECT_FILES=main.o


### PR DESCRIPTION
## Summary

Prepare the shared device-software dependency for optional HammerBlade LLVM 22 builds; GCC remains the default.

- Add `bsg_amoor_no_return` for callers that discard the old AMO value.
- Use the RISC-V `A` address constraint for LR/LR.AQ under both compilers.
- Add explicit `SPMD_COMPILER=gcc|llvm`, preserving the legacy CLANG alias.
- Run the LLVM IR optimization pipeline once, propagate the selected optimization level to llc, and support integrated-assembler ELF output with old-GNU-linker attribute compatibility.
- Use portable SPMD discovery and configurable Python 3 invocation.
- Preserve exact FP reduction/division semantics in four affected SPMD test Makefiles under both compilers. Checkers are not weakened.

Head: `2725e68c7ee887ddd1e5de447913f1c92ef0fafd` (six commits; nine software files). This PR contains **no RTL changes**.

## Dependencies and integration order

Merge this software dependency before the HammerBench BFS helper caller and Replicant compiler-selector wrapper. The matching published branches are:

- [HammerBench hammerblade-llvm22-support](https://github.com/bespoke-silicon-group/hb_hammerbench/tree/hammerblade-llvm22-support) at `7d0b7e4`.
- [Replicant hammerblade-llvm22-support](https://github.com/bespoke-silicon-group/bsg_replicant/tree/hammerblade-llvm22-support) at `d941e339`.
- [LLVM 22 compiler](https://github.com/bespoke-silicon-group/llvm-project/tree/hammerblade-llvm22) at `d2ebb0fda484`.

The tested software revision is **not** the simulator RTL revision. Validation reused the pinned physical-2x1 model built from RTL `660cd3be`; do not replace working RTL/model inputs with this older-base software checkout.

## Existing validation

- GCC 9.2.0: 12/12 reduced HammerBench + 15/15 selected SPMD PASS; 3 explicit-GCC controls match default selection in full ELF hashes and cycles (30/30 total).
- Current LLVM 22.1.8: 12/12 reduced HammerBench + 15/15 selected SPMD PASS.
- Physical 2x1, four blocking 32-KiB banks, iPoly off, one worker per simulator; native active SPMD groups.
- GCC checks cover both the new BFS atomic helper and `energy_lr_aq_test`; default wrapper builds unset LLVM/CLANG controls.
- [Complete GCC/LLVM target-cycle table and provenance](https://github.com/bespoke-silicon-group/hb_handbook/blob/c8ced01/evidence/gcc-llvm22-comparison-2026-09-12.md). Raw logs/binaries are retained locally, not released by this PR.
- No new simulation or compiler test was launched while preparing the PR; `git diff --check` is clean.

This is bounded compatibility evidence, not every SPMD test, a clean full SDK installation, or larger-input/geometry validation.

## Coordinated review links

- [Manycore software prerequisite #774](https://github.com/bespoke-silicon-group/bsg_manycore/pull/774).
- [HammerBench integration #110](https://github.com/bespoke-silicon-group/hb_hammerbench/pull/110).
- [Replicant SPMD wrapper #875](https://github.com/bespoke-silicon-group/bsg_replicant/pull/875).
- [Handbook and execution comparison #11](https://github.com/bespoke-silicon-group/hb_handbook/pull/11).

Compiler review: [llvm-project #9](https://github.com/bespoke-silicon-group/llvm-project/pull/9), from `hammerblade-llvm22` into `hammerblade-llvm22-integration` (base pinned at upstream `ca7933e47d3a` when opened). The review isolates 11 HammerBlade commits. The legacy LLVM 10 branch and repository default remain unchanged; no PR has been merged by this task.
